### PR TITLE
Assert generators do not mutate inputs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -94,15 +94,17 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "ezmsg"
-version = "3.3.4"
+version = "3.4.0"
 description = "A simple DAG-based computation model"
 optional = false
-python-versions = "^3.8"
-files = []
-develop = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "ezmsg-3.4.0-py3-none-any.whl", hash = "sha256:656cf7fb9d51db843bf713c7c5a35a1af5e0b66af799f2557e09e5377d82ead0"},
+    {file = "ezmsg-3.4.0.tar.gz", hash = "sha256:3b18402615c88f978cde92c8c4c14f2b60e2cffcdb6834b795520785bf483cc5"},
+]
 
 [package.dependencies]
-typing-extensions = "^4.9.0"
+typing-extensions = ">=4.9.0,<5.0.0"
 
 [package.extras]
 all-ext = ["ezmsg-sigproc", "ezmsg-vispy", "ezmsg-websocket", "ezmsg-zmq"]
@@ -110,12 +112,6 @@ sigproc = ["ezmsg-sigproc"]
 vispy = ["ezmsg-vispy"]
 websocket = ["ezmsg-websocket"]
 zmq = ["ezmsg-zmq"]
-
-[package.source]
-type = "git"
-url = "https://github.com/iscoe/ezmsg.git"
-reference = "dev"
-resolved_reference = "326e1b19e12d8e3b7ed0d4dd0c2191901c1b8c90"
 
 [[package]]
 name = "flake8"
@@ -263,6 +259,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.7"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_asyncio-0.23.7-py3-none-any.whl", hash = "sha256:009b48127fbe44518a547bddd25611551b0e43ccdbf1e67d12479f569832c20b"},
+    {file = "pytest_asyncio-0.23.7.tar.gz", hash = "sha256:5f5c72948f4c49e7db4f29f2521d4031f1c27f86e57b046126654083d4770268"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
@@ -343,4 +357,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a783a8fa15b17575423d1ceed998e04a22040bc8c2a079b35719df82c6986b6b"
+content-hash = "c1ee6f2541785c352f22cd2309d9e6895d6ca252ee1aec2e88051ec178cd3ba6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,14 @@ packages = [{ include = "ezmsg", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ezmsg = { git = "https://github.com/iscoe/ezmsg.git", branch = "dev" }
+ezmsg = "^3.4.0"
 numpy = "^1.19.5"
 scipy = "^1.6.3"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.0.0"
 pytest-cov = "*"
+pytest-asyncio = "*"
 flake8 = "*"
 
 [tool.pytest.ini_options]

--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -71,29 +71,26 @@ def slicer(
                 indices = np.hstack([indices[_] for _ in _slices])
                 _slice = np.s_[indices]
             # Create the output axis.
-            if axis in axis_arr_in.axes and hasattr(axis_arr_in.axes[axis], "labels"):
+            if (axis in axis_arr_in.axes
+                    and hasattr(axis_arr_in.axes[axis], "labels")
+                    and len(axis_arr_in.axes[axis].labels) > 0):
                 new_labels = axis_arr_in.axes[axis].labels[_slice]
                 new_axis = replace(
                     axis_arr_in.axes[axis],
                     labels=new_labels
                 )
 
+        replace_kwargs = {}
         if b_change_dims:
-            out_dims = [_ for dim_ix, _ in enumerate(axis_arr_in.dims) if dim_ix != axis_idx]
-            out_axes = axis_arr_in.axes.copy()
-            out_axes.pop(axis, None)
-        else:
-            out_dims = axis_arr_in.dims
-            if new_axis is not None:
-                out_axes = {k: (v if k != axis else new_axis) for k, v in axis_arr_in.axes.items()}
-            else:
-                out_axes = axis_arr_in.axes
-
+            # Dropping the target axis
+            replace_kwargs["dims"] = [_ for dim_ix, _ in enumerate(axis_arr_in.dims) if dim_ix != axis_idx]
+            replace_kwargs["axes"] = {k: v for k, v in axis_arr_in.axes.items() if k != axis}
+        elif new_axis is not None:
+            replace_kwargs["axes"] = {k: (v if k != axis else new_axis) for k, v in axis_arr_in.axes.items()}
         axis_arr_out = replace(
             axis_arr_in,
-            dims=out_dims,
-            axes=out_axes,
             data=slice_along_axis(axis_arr_in.data, _slice, axis_idx),
+            **replace_kwargs
         )
 
 

--- a/src/ezmsg/sigproc/spectrum.py
+++ b/src/ezmsg/sigproc/spectrum.py
@@ -128,9 +128,8 @@ def spectrum(
                     else:
                         f_transform = f1
 
-        new_axes = {**axis_arr_in.axes, **{out_axis: freq_axis}}
-        if out_axis != axis_name:
-            new_axes.pop(axis_name, None)
+        new_axes = {k: v for k, v in axis_arr_in.axes.items() if k not in [out_axis, axis_name]}
+        new_axes[out_axis] = freq_axis
 
         spec = np.fft.fft(axis_arr_in.data * window, axis=axis_idx) / n_time
         spec = np.fft.fftshift(spec, axes=axis_idx)

--- a/src/ezmsg/sigproc/window.py
+++ b/src/ezmsg/sigproc/window.py
@@ -68,7 +68,7 @@ def windowing(
     shift_deficit: int = 0  # Number of incoming samples to ignore. Only relevant when shift > window.
     b_1to1 = window_shift is None
     newaxis_warned: bool = b_1to1
-    out_template: Optional[AxisArray] = None  # Template for building return values.
+    out_newaxis: Optional[AxisArray.Axis] = None
 
     while True:
         axis_arr_in = yield axis_arr_out
@@ -102,8 +102,7 @@ def windowing(
             else:  # i.e. zero_pad_until == "input"
                 req_samples = axis_arr_in.data.shape[axis_idx]
             n_zero = max(0, window_samples - req_samples)
-            buffer_shape = axis_arr_in.data.shape[:axis_idx] + (n_zero,) + axis_arr_in.data.shape[axis_idx + 1:]
-            buffer = np.zeros(buffer_shape)
+            buffer = np.zeros(axis_arr_in.data.shape[:axis_idx] + (n_zero,) + axis_arr_in.data.shape[axis_idx + 1:])
             prev_samp_shape = samp_shape
             prev_fs = fs
 
@@ -132,63 +131,59 @@ def windowing(
                 shift_deficit -= n_skip
 
         # Prepare reusable parts of output
-        if out_template is None:
-            template_data_shape = (axis_arr_in.data.shape[:axis_idx]
-                                   + (0, window_samples)
-                                   + axis_arr_in.data.shape[axis_idx + 1:])
+        if out_newaxis is None:
             out_dims = axis_arr_in.dims[:axis_idx] + [newaxis] + axis_arr_in.dims[axis_idx:]
-            out_axes = {
-                **axis_arr_in.axes,
-                axis: replace(axis_info, offset=0.0),  # Sliced axis is relative to newaxis offset
-                newaxis: AxisArray.Axis(
-                    unit=axis_info.unit,
-                    gain=0.0 if b_1to1 else axis_info.gain * window_shift_samples,
-                    offset=0.0  # offset modified below
-                )
-            }
-            out_template = replace(
-                axis_arr_in,
-                data=np.zeros(template_data_shape, dtype=axis_arr_in.data.dtype),
-                dims=out_dims,
-                axes=out_axes
+            out_newaxis = replace(
+                axis_info,
+                gain=0.0 if b_1to1 else axis_info.gain * window_shift_samples,
+                offset=0.0  # offset modified per-msg below
             )
 
         # Generate outputs.
+        # Preliminary copy of axes without the axes that we are modifying.
+        out_axes = {k: v for k, v in axis_arr_in.axes.items() if k not in [newaxis, axis]}
+
+        # Update targeted (windowed) axis so that its offset is relative to the new axis
+        # TODO: If we have `anchor_newest=True` then offset should be -win_dur
+        out_axes[axis] = replace(axis_info, offset=0.0)
+
+        # How we update .data and .axes[newaxis] depends on the windowing mode.
         if b_1to1:
             # one-to-one mode -- Each send yields exactly one window containing only the most recent samples.
             buffer = slice_along_axis(buffer, np.s_[-window_samples:], axis_idx)
-            axis_arr_out = replace(
-                    out_template,
-                    data=np.expand_dims(buffer, axis=axis_idx),
-                    axes={
-                        **out_axes,
-                        newaxis: replace(
-                            out_axes[newaxis],
-                            offset=buffer_offset[-window_samples]
-                        )
-                    }
-            )
+            out_dat = np.expand_dims(buffer, axis=axis_idx)
+            out_newaxis = replace(out_newaxis, offset=buffer_offset[-window_samples])
         elif buffer.shape[axis_idx] >= window_samples:
             # Deterministic window shifts.
-            win_view = sliding_win_oneaxis(buffer, window_samples, axis_idx)
-            win_view = slice_along_axis(win_view, np.s_[::window_shift_samples], axis_idx)
+            out_dat = sliding_win_oneaxis(buffer, window_samples, axis_idx)
+            out_dat = slice_along_axis(out_dat, np.s_[::window_shift_samples], axis_idx)
             offset_view = sliding_win_oneaxis(buffer_offset, window_samples, 0)[::window_shift_samples]
-            axis_arr_out = replace(
-                out_template,
-                data=win_view,
-                axes={
-                    **out_axes,
-                    newaxis: replace(out_axes[newaxis], offset=offset_view[0, 0])
-                }
-            )
+            out_newaxis = replace(out_newaxis, offset=offset_view[0, 0])
 
             # Drop expired beginning of buffer and update shift_deficit
-            multi_shift = window_shift_samples * win_view.shape[axis_idx]
+            multi_shift = window_shift_samples * out_dat.shape[axis_idx]
             shift_deficit = max(0, multi_shift - buffer.shape[axis_idx])
             buffer = slice_along_axis(buffer, np.s_[multi_shift:], axis_idx)
         else:
             # Not enough data to make a new window. Return empty data.
-            axis_arr_out = out_template
+            empty_data_shape = (
+                    axis_arr_in.data.shape[:axis_idx]
+                    + (0, window_samples)
+                    + axis_arr_in.data.shape[axis_idx + 1:]
+            )
+            out_dat = np.zeros(empty_data_shape, dtype=axis_arr_in.data.dtype)
+            # out_newaxis will have first timestamp in input... but mostly meaningless because output is size-zero.
+            out_newaxis = replace(out_newaxis, offset=axis_info.offset)
+
+        axis_arr_out = replace(
+            axis_arr_in,
+            data=out_dat,
+            dims=out_dims,
+            axes={
+                **out_axes,
+                newaxis: out_newaxis
+            }
+        )
 
 
 class WindowSettings(ez.Settings):
@@ -235,26 +230,29 @@ class Window(ez.Unit):
     async def on_signal(self, msg: AxisArray) -> AsyncGenerator:
         try:
             out_msg = self.STATE.gen.send(msg)
-            if self.STATE.cur_settings.newaxis is not None or self.STATE.cur_settings.window_dur is None:
-                # Multi-win mode or pass-through mode.
-                yield self.OUTPUT_SIGNAL, out_msg
-            else:
-                # We need to split out_msg into multiple yields, dropping newaxis.
-                axis_idx = out_msg.get_axis_idx("win")
-                win_axis = out_msg.axes["win"]
-                offsets = np.arange(out_msg.data.shape[axis_idx]) * win_axis.gain + win_axis.offset
-                for msg_ix in range(out_msg.data.shape[axis_idx]):
-                    yield self.OUTPUT_SIGNAL, replace(
-                        msg,
-                        data=slice_along_axis(out_msg.data, msg_ix, axis_idx),
-                        axes={
-                            **msg.axes,
-                            self.STATE.cur_settings.axis: replace(
-                                msg.axes[self.STATE.cur_settings.axis],
-                                offset=offsets[msg_ix]
-                            ),
-                        }
-                    )
+            if out_msg.data.size > 0:
+                if self.STATE.cur_settings.newaxis is not None or self.STATE.cur_settings.window_dur is None:
+                    # Multi-win mode or pass-through mode.
+                    yield self.OUTPUT_SIGNAL, out_msg
+                else:
+                    # We need to split out_msg into multiple yields, dropping newaxis.
+                    axis_idx = out_msg.get_axis_idx("win")
+                    win_axis = out_msg.axes["win"]
+                    offsets = np.arange(out_msg.data.shape[axis_idx]) * win_axis.gain + win_axis.offset
+                    for msg_ix in range(out_msg.data.shape[axis_idx]):
+                        _out_msg = replace(
+                            out_msg,
+                            data=slice_along_axis(out_msg.data, msg_ix, axis_idx),
+                            dims=out_msg.dims[:axis_idx] + out_msg.dims[axis_idx + 1:],
+                            axes={
+                                **out_msg.axes,
+                                self.STATE.cur_settings.axis: replace(
+                                    out_msg.axes[self.STATE.cur_settings.axis],
+                                    offset=offsets[msg_ix]
+                                )
+                            }
+                        )
+                        yield self.OUTPUT_SIGNAL, _out_msg
         except (StopIteration, GeneratorExit):
             ez.logger.debug(f"Window closed in {self.address}")
         except Exception:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -6,50 +6,67 @@ from ezmsg.util.messages.axisarray import AxisArray
 
 from ezmsg.sigproc.aggregate import ranged_aggregate, AggregationFunction
 
+from util import assert_messages_equal
 
-@pytest.mark.parametrize("agg_func", [AggregationFunction.MEAN, AggregationFunction.MEDIAN, AggregationFunction.STD])
-def test_aggregate(agg_func: AggregationFunction):
+
+def get_msg_gen():
     n_chans = 20
     n_freqs = 100
     data_dur = 30.0
     fs = 1024.0
-    bands = [(5.0, 20.0), (30.0, 50.0)]
-    targ_ax = "freq"
 
     n_samples = int(data_dur * fs)
     data = np.arange(n_samples * n_chans * n_freqs).reshape(n_samples, n_chans, n_freqs)
     n_msgs = int(data_dur / 2)
 
-    offset = 0
-    messages = []
-    for arr in np.array_split(data, n_samples // n_msgs):
-        messages.append(
-            AxisArray(
-                arr,
+    def msg_generator():
+        offset = 0
+        for arr in np.array_split(data, n_samples // n_msgs):
+            msg = AxisArray(
+                data=arr,
                 dims=["time", "ch", "freq"],
                 axes={
                     "time": AxisArray.Axis.TimeAxis(fs=fs, offset=offset),
                     "freq": AxisArray.Axis(gain=1.0, offset=0.0, unit="Hz")
                 }
             )
-        )
-        offset += arr.shape[0] / fs
+            offset += arr.shape[0] / fs
+            yield msg
+    return msg_generator()
+
+
+@pytest.mark.parametrize(
+    "agg_func", [AggregationFunction.MEAN, AggregationFunction.MEDIAN, AggregationFunction.STD]
+)
+def test_aggregate(agg_func: AggregationFunction):
+    bands = [(5.0, 20.0), (30.0, 50.0)]
+    targ_ax = "freq"
+
+    in_msgs = [_ for _ in get_msg_gen()]
+
+    # Grab a deepcopy backup of the inputs so we can check the inputs didn't change
+    #  while being processed.
+    import copy
+    backup = [copy.deepcopy(_) for _ in in_msgs]
 
     gen = ranged_aggregate(axis=targ_ax, bands=bands, operation=agg_func)
-    results = [gen.send(_) for _ in messages]
+    out_msgs = [gen.send(_) for _ in in_msgs]
 
-    assert all([type(_) is AxisArray for _ in results])
+    assert_messages_equal(in_msgs, backup)
+
+    assert all([type(_) is AxisArray for _ in out_msgs])
 
     # Check output axis
-    for res in results:
-        ax = res.axes[targ_ax]
+    for out_msg in out_msgs:
+        ax = out_msg.axes[targ_ax]
         assert ax.offset == np.mean(bands[0])
         if len(bands) > 1:
             assert ax.gain == np.mean(bands[1]) - np.mean(bands[0])
-        assert ax.unit == messages[0].axes[targ_ax].unit
+        assert ax.unit == in_msgs[0].axes[targ_ax].unit
 
     # Check data
-    targ_ax = messages[0].axes[targ_ax]
+    data = AxisArray.concatenate(*in_msgs, dim="time").data
+    targ_ax = in_msgs[0].axes[targ_ax]
     targ_ax_vec = targ_ax.offset + np.arange(data.shape[-1]) * targ_ax.gain
     agg_func = {
         AggregationFunction.MEAN: partial(np.mean, axis=-1, keepdims=True),
@@ -60,5 +77,5 @@ def test_aggregate(agg_func: AggregationFunction):
         agg_func(data[..., np.logical_and(targ_ax_vec >= start, targ_ax_vec <= stop)])
         for (start, stop) in bands
     ], axis=-1)
-    received_data = AxisArray.concatenate(*results, dim="time").data
+    received_data = AxisArray.concatenate(*out_msgs, dim="time").data
     assert np.allclose(received_data, expected_data)

--- a/tests/test_bandpower.py
+++ b/tests/test_bandpower.py
@@ -1,8 +1,10 @@
+import copy
+
 import numpy as np
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.sigproc.bandpower import bandpower, SpectrogramSettings
 
-from util import create_messages_with_periodic_signal
+from util import create_messages_with_periodic_signal, assert_messages_equal
 
 
 def _debug_plot(result):
@@ -30,6 +32,10 @@ def test_bandpower():
         win_step_dur=None  # The spectrogram will do the windowing
     )
 
+    # Grab a deepcopy backup of the inputs, so we can check the inputs didn't change
+    #  while being processed.
+    backup = [copy.deepcopy(_) for _ in messages]
+
     gen = bandpower(
         spectrogram_settings=SpectrogramSettings(
             window_dur=win_dur,
@@ -37,7 +43,9 @@ def test_bandpower():
         ),
         bands=bands
     )
-    results = [gen.send(msg) for msg in messages]
+    results = [gen.send(_) for _ in messages]
+
+    assert_messages_equal(messages, backup)
 
     result = AxisArray.concatenate(*results, dim="time")
     # _debug_plot(result)

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -1,3 +1,4 @@
+import copy
 import typing
 
 import numpy as np
@@ -6,7 +7,7 @@ from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.sigproc.spectrum import WindowFunction, SpectralTransform, SpectralOutput
 from ezmsg.sigproc.spectrogram import spectrogram
 
-from util import create_messages_with_periodic_signal
+from util import create_messages_with_periodic_signal, assert_messages_equal
 
 
 def _debug_plot(
@@ -56,6 +57,7 @@ def test_spectrogram():
         msg_dur=0.4,
         win_step_dur=None  # The spectrogram will do the windowing
     )
+    backup = [copy.deepcopy(_) for _ in messages]
 
     gen = spectrogram(
         window_dur=win_dur,
@@ -67,6 +69,8 @@ def test_spectrogram():
 
     results = [gen.send(msg) for msg in messages]
     results = [_ for _ in results if _.data.size]  # Drop empty messages
+
+    assert_messages_equal(messages, backup)
 
     # Check that the windows span the expected times.
     expected_t_span = 2 * seg_dur

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,9 +1,10 @@
+import copy
 import pytest
 import numpy as np
 
 from ezmsg.util.messages.axisarray import AxisArray, slice_along_axis
 from ezmsg.sigproc.spectrum import spectrum, SpectralTransform, SpectralOutput, WindowFunction
-from util import get_test_fn, create_messages_with_periodic_signal
+from util import get_test_fn, create_messages_with_periodic_signal, assert_messages_equal
 
 
 def _debug_plot_welch(raw: AxisArray, result: AxisArray, welch_db: bool = True):
@@ -112,8 +113,12 @@ def test_spectrum_gen(
         msg_dur=win_dur,
         win_step_dur=win_step_dur
     )
+    backup = [copy.deepcopy(_) for _ in messages]
+
     gen = spectrum(axis="time", window=window, transform=transform, output=output)
     results = [gen.send(msg) for msg in messages]
+
+    assert_messages_equal(messages, backup)
 
     assert "freq" in results[0].dims
     assert "ch" in results[0].dims

--- a/tests/util.py
+++ b/tests/util.py
@@ -76,3 +76,20 @@ def create_messages_with_periodic_signal(
         )
         offset += split_dat.shape[0] / fs
     return messages
+
+
+def assert_messages_equal(messages1, messages2):
+    # Verify the inputs have not changed as a result of processing.
+    for msg_ix in range(len(messages1)):
+        msg1 = messages1[msg_ix]
+        msg2 = messages2[msg_ix]
+        assert type(msg1) is type(msg2)
+        if isinstance(msg1, AxisArray):
+            assert np.array_equal(msg1.data, msg2.data)
+            assert msg1.dims == msg2.dims
+            assert list(msg1.axes.keys()) == list(msg2.axes.keys())
+            for k, v in msg1.axes.items():
+                assert k in msg2.axes
+                assert v == msg2.axes[k]
+        else:
+            assert msg1.__dict__ == msg2.__dict__


### PR DESCRIPTION
I added some checks to the unit tests that the inputs are not mutated (relative to a preliminary copy.deepcopy() backup) after being processed.

Then I cleaned up some of the generators to make sure these all passed, and a little for legibility.

Note that this PR is using #1 as a base. If #1 is merged first then this should be rebased on dev.