### PR TITLE
spectrum updates

### DIFF
--- a/src/ezmsg/sigproc/spectrum.py
+++ b/src/ezmsg/sigproc/spectrum.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 import enum
-from typing import Optional, Generator, AsyncGenerator
+import typing
 
 import numpy as np
 import ezmsg.core as ez
@@ -61,12 +61,14 @@ class SpectralOutput(OptionsEnum):
 
 @consumer
 def spectrum(
-    axis: Optional[str] = None,
-    out_axis: Optional[str] = "freq",
+    axis: typing.Optional[str] = None,
+    out_axis: typing.Optional[str] = "freq",
     window: WindowFunction = WindowFunction.HANNING,
     transform: SpectralTransform = SpectralTransform.REL_DB,
-    output: SpectralOutput = SpectralOutput.POSITIVE
-) -> Generator[AxisArray, AxisArray, None]:
+    output: SpectralOutput = SpectralOutput.POSITIVE,
+    # norm: typing.Optional[str] = "forward",
+    # do_fftshift: bool = True,
+) -> typing.Generator[AxisArray, AxisArray, None]:
     """
     Calculate a spectrum on a data slice.
 
@@ -156,9 +158,9 @@ class SpectrumSettings(ez.Settings):
     Settings for :obj:`Spectrum.
     See :obj:`spectrum` for a description of the parameters.
     """
-    axis: Optional[str] = None
-    # n: Optional[int] = None # n parameter for fft
-    out_axis: Optional[str] = "freq"  # If none; don't change dim name
+    axis: typing.Optional[str] = None
+    # n: typing.Optional[int] = None # n parameter for fft
+    out_axis: typing.Optional[str] = "freq"  # If none; don't change dim name
     window: WindowFunction = WindowFunction.HAMMING
     transform: SpectralTransform = SpectralTransform.REL_DB
     output: SpectralOutput = SpectralOutput.POSITIVE

--- a/src/ezmsg/sigproc/spectrum.py
+++ b/src/ezmsg/sigproc/spectrum.py
@@ -116,7 +116,7 @@ def spectrum(
             nfft = nfft or n_time
             freqs = np.fft.fftfreq(nfft, d=_axis.gain * n_time / nfft)
             if b_shift:
-                freqs = np.fft.fftshift(freqs, axis=-1)
+                freqs = np.fft.fftshift(freqs, axes=-1)
             window = WINDOWS[window](n_time)
             window = window.reshape([1] * axis_idx + [len(window),] + [1] * (axis_arr_in.data.ndim - 1 - axis_idx))
             if (transform != SpectralTransform.RAW_COMPLEX and

--- a/src/ezmsg/sigproc/spectrum.py
+++ b/src/ezmsg/sigproc/spectrum.py
@@ -89,6 +89,7 @@ def spectrum(
     axis_name = axis
     axis_idx = None
     n_time = None
+    apply_window = window != WindowFunction.NONE
 
     while True:
         axis_arr_in = yield axis_arr_out
@@ -133,7 +134,11 @@ def spectrum(
         new_axes = {k: v for k, v in axis_arr_in.axes.items() if k not in [out_axis, axis_name]}
         new_axes[out_axis] = freq_axis
 
-        spec = np.fft.fft(axis_arr_in.data * window, axis=axis_idx) / n_time
+        if apply_window:
+            win_dat = axis_arr_in.data * window
+        else:
+            win_dat = axis_arr_in.data
+        spec = np.fft.fft(win_dat, axis=axis_idx) / n_time
         spec = np.fft.fftshift(spec, axes=axis_idx)
         spec = f_transform(spec)
 

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -138,7 +138,7 @@ def test_spectrum_gen(
     # _debug_plot_welch(messages[0], results[0], welch_db=True)
 
 
-def test_spectrum_cmplx_vs_sps_fftn():
+def test_spectrum_cmplx_vs_sps_fft():
     # spectrum uses np.fft. Here we compare the output of spectrum against scipy.fft.fftn
     win_dur = 1.0
     win_step_dur = 0.5
@@ -158,17 +158,13 @@ def test_spectrum_cmplx_vs_sps_fftn():
         axis="time",
         window=WindowFunction.NONE,
         transform=SpectralTransform.RAW_COMPLEX,
-        output=SpectralOutput.FULL
+        output=SpectralOutput.FULL,
+        norm="backward",
+        do_fftshift=False,
     )
     results = [gen.send(msg) for msg in messages]
-    # Unshift the freq axis to match sp_fft.fftn
-    # fvec = results[0].axes["freq"].offset + np.arange(results[0].data.shape[0]) * results[0].axes["freq"].gain
-    # fvec = np.fft.ifftshift(fvec)
-    test_spec = np.fft.ifftshift(results[0].data, axes=0)
-    # Unscale.
-    s = messages[0].data.shape[0]
-    test_spec *= s
-    sp_res = sp_fft.fftn(messages[0].data, s=s, axes=(0,))
+    test_spec = results[0].data
+    sp_res = sp_fft.fft(messages[0].data, axis=0)
     assert np.allclose(test_spec, sp_res)
 
 

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -154,6 +154,7 @@ def test_spectrum_cmplx_vs_sps_fft():
         msg_dur=win_dur,
         win_step_dur=win_step_dur
     )
+    nfft = 1 << (messages[0].data.shape[0] - 1).bit_length()  # nextpow2
     gen = spectrum(
         axis="time",
         window=WindowFunction.NONE,
@@ -161,10 +162,11 @@ def test_spectrum_cmplx_vs_sps_fft():
         output=SpectralOutput.FULL,
         norm="backward",
         do_fftshift=False,
+        nfft=nfft
     )
     results = [gen.send(msg) for msg in messages]
     test_spec = results[0].data
-    sp_res = sp_fft.fft(messages[0].data, axis=0)
+    sp_res = sp_fft.fft(messages[0].data, n=nfft, axis=0)
     assert np.allclose(test_spec, sp_res)
 
 


### PR DESCRIPTION
- Add `nfft` argument, similar to numpy / scipy's fft
- Add `norm` argument, similar to numpy / scipy's fft
- Add `do_fftshift` argument, only used when requested output is FULL
- Use faster `rfft` over `fft` when input is not complex and requested output is POSITIVE.
- Fix frequency slicing when using POSITIVE or NEGATIVE. Previously we were missing the last frequency when nfft / win_len was even (nyquist for POSITIVE, and `f = 0 Hz` for NEGATIVE).

The last change listed above has the potential to affect outputs because in some scenarios the spectrum is longer by 1 frequency bin than previously. I had to update some unit tests to accommodate this.