### PR TITLE
Filterbank

### DIFF
--- a/src/ezmsg/sigproc/filterbank.py
+++ b/src/ezmsg/sigproc/filterbank.py
@@ -30,6 +30,7 @@ def filterbank(
     kernels: typing.Union[list[npt.NDArray], tuple[npt.NDArray, ...]],
     mode: FilterbankMode = FilterbankMode.CONV,
     axis: str = "time",
+    new_axis: str = "kernel",
 ) -> typing.Generator[AxisArray, AxisArray, None]:
     """
     Returns a generator that perform multiple (direct or fft) convolutions on a signal using a bank of kernels.
@@ -43,6 +44,7 @@ def filterbank(
           conv mode is less efficient but will return data for every incoming chunk regardless of how small it is
           and thus can provide shorter latency updates.
         axis: The name of the axis to operate on. This should usually be "time".
+        new_axis: The name of the new axis corresponding to the kernel index.
 
     Returns:
 
@@ -57,6 +59,29 @@ def filterbank(
         if template is None or mode == FilterbankMode.AUTO:
             fs = 1 / msg_in.axes["time"].gain if "time" in msg_in.axes else 1.0
             ax_ix = msg_in.get_axis_idx(axis)
+
+            # Determine if this will be operating with complex data.
+            b_complex = msg_in.data.dtype.kind == "c" or any([_.dtype.kind == "c" for _ in kernels])
+
+            # Calculate window_dur, window_shift, nfft
+            max_kernel_len = max([_.size for _ in kernels])
+            # From sps._calc_oa_lens, where s2=max_kernel_len,:
+            # fallback_nfft = n_input + max_kernel_len - 1, but n_input is unbound.
+            overlap = max_kernel_len - 1
+
+            # Prepare previous iteration's overlap tail to add to input -- all zeros.
+            tail_shape = msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix + 1:] + (len(kernels), overlap)
+            tail = np.zeros(tail_shape, dtype="complex" if b_complex else "float")
+
+            # Prepare output template
+            dummy_shape = msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix + 1:] + (len(kernels), 0)
+            template = AxisArray(
+                data=np.zeros(dummy_shape, dtype="complex" if b_complex else "float"),
+                dims=msg_in.dims[:ax_ix] + msg_in.dims[ax_ix + 1:] + [new_axis, axis],
+                axes=msg_in.axes.copy()  # No idea what to use to fill 'filter' axis.
+            )
+
+            # Determine optimal mode. Assumes 100 msec chunks.
             if mode == FilterbankMode.AUTO:
                 # concatenate kernels into 1 mega kernel then check what's faster.
                 # Will typically return fft when combined kernel length is > 1500.
@@ -65,36 +90,21 @@ def filterbank(
                 dummy_arr = np.zeros(n_dummy)
                 mode = sps.choose_conv_method(dummy_arr, concat_kernel, mode="full")
                 mode = FilterbankMode.CONV if mode == "direct" else FilterbankMode.FFT
+
             if mode == FilterbankMode.CONV:
-                # Note: Instead of filtergen, we could use np.convolve directly and manually manage overlap-add.
-                #  We should reconsider this after we finish managing overlap add for fft filtering.
-                #  out_full = np.apply_along_axis(lambda y: np.convolve(b, y), axis, x)
-                # TODO: Parallelize!
-                filtergens = [filtergen(axis="time", coefs=(_, 1.0), coef_type="ba") for _ in kernels]
-                # Prepare output template
-                template = AxisArray(
-                    data=np.zeros(msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix + 1:] + (len(kernels), 0)),
-                    dims=msg_in.dims[:ax_ix] + msg_in.dims[ax_ix + 1:] + ["filter", axis],
-                    axes=msg_in.axes.copy()  # No idea what to use to fill 'filter' axis.
-                )
+                # Prepare kernels
+                prep_kerns = np.array([k[..., ::-1].conj() for k in kernels])
+                prep_kerns = np.expand_dims(prep_kerns, -2)
             elif mode == FilterbankMode.FFT:
-                # Note: We should not pass this off to multiple (non-existing) fftconvolve nodes, because here we
-                #  can calculate the FFT on the data only once which is then shared across kernels.
-
-                # Determine if this will be operating with complex data.
-                b_complex = msg_in.data.dtype.kind == "c" or any([_.dtype.kind == "c" for _ in kernels])
-
-                # Calculate window_dur, window_shift, nfft
-                max_kernel_len = max([_.size for _ in kernels])
-                # From sps._calc_oa_lens, where s2=max_kernel_len,:
-                # fallback_nfft = n_input + max_kernel_len - 1, but n_input is unbound.
-                overlap = max_kernel_len - 1
+                # Calculate optimal nfft and windowing size.
                 opt_size = -overlap * lambertw(-1 / (2 * math.e * overlap), k=-1).real
                 nfft = sp_fft.next_fast_len(math.ceil(opt_size))
                 win_len = nfft - overlap
-                infft = win_len + overlap  # Same as nfft. Keeping additional variable because I might need it again.
+                infft = win_len + overlap  # Same as nfft. Keeping as separate variable because I might need it again.
 
-                # Create windowing node
+                # Create windowing node.
+                # Note: We could do windowing manually to avoid the overhead of the message structure,
+                #  but windowing is difficult to do correctly, so we lean on the heavily-tested `windowing` generator.
                 wingen = windowing(
                     axis=axis,
                     newaxis="win",  # Big data chunks might yield more than 1 window.
@@ -103,21 +113,13 @@ def filterbank(
                     zero_pad_until="none",
                 )
 
-                # Note: Instead of calculating fft in this node, we could use the spectrum node:
-                # specgen = spectrum(
-                #     axis=axis,
-                #     window=WindowFunction.NONE,
-                #     transform=SpectralTransform.RAW_COMPLEX if b_complex else SpectralTransform.REAL,
-                #     output=SpectralOutput.FULL if b_complex else SpectralOutput.POSITIVE,
-                #     norm="backward",
-                #     do_fftshift=False,
-                #     nfft=nfft,
-                # )
-                # However, this adds unnecessary overhead in creating the message structure and the calls to fft
-                #  are straightforward. We can revisit this if we add more fft optimization to spectrum.
-                # We accept that overhead for `windowing` because that is very difficult to implement correctly.
+                # Windowing output has an extra "win" dimension, so we need our tail to match.
+                tail = np.expand_dims(tail, -2)
 
                 # Prepare fft functions
+                # Note: We could instead use `spectrum` but this adds overhead in creating the message structure
+                #  for a rather simple calculation. We may revisit if `spectrum` gets additional features, such as
+                #  more fft backends.
                 if b_complex:
                     fft = functools.partial(sp_fft.fft, n=nfft, norm="backward")
                     ifft = functools.partial(sp_fft.ifft, n=infft, norm="backward")
@@ -126,60 +128,59 @@ def filterbank(
                     ifft = functools.partial(sp_fft.irfft, n=infft, norm="backward")
 
                 # Calculate fft of kernels
-                fft_kernels = np.array([fft(_) for _ in kernels])
-                fft_kernels = np.expand_dims(fft_kernels, -2)
+                prep_kerns = np.array([fft(_) for _ in kernels])
+                prep_kerns = np.expand_dims(prep_kerns, -2)
                 # TODO: If fft_kernels have significant stretches of zeros, convert to sparse array.
 
-                # Prepare previous iteration's overlap tail to add to input -- all zeros.
-                tail_shape = msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix+1:] + (len(kernels), 1, overlap)
-                tail = np.zeros(tail_shape, dtype="complex" if b_complex else "float")
-
-                # Prepare output template
-                template = AxisArray(
-                    data=np.zeros(tail_shape[:-2] + (0,), dtype="complex" if b_complex else "float"),
-                    dims=msg_in.dims[:ax_ix] + msg_in.dims[ax_ix+1:] + ["filter", axis],
-                    axes=msg_in.axes.copy()  # No idea what to use to fill 'filter' axis.
-                )
+        # Make sure target axis is in -1th position.
+        targ_ax_ix = msg_in.get_axis_idx(axis)
+        if targ_ax_ix != (msg_in.data.ndim - 1):
+            in_dat = np.moveaxis(msg_in.data, targ_ax_ix, -1)
+            if mode == FilterbankMode.FFT:
+                # Need to rebuild msg for wingen
+                move_dims = msg_in.dims[:targ_ax_ix] + msg_in.dims[targ_ax_ix + 1:] + [axis]
+                msg_in = replace(msg_in, data=in_dat, dims=move_dims)
+        else:
+            in_dat = msg_in.data
 
         if mode == FilterbankMode.CONV:
-            # for each filtergen, send the message, accumulate outputs, stack along "filter" axis.
-            filtres = [fg.send(msg_in).data for fg in filtergens]  # TODO: parallelize!?
-            msg_out = replace(
-                template,
-                data=np.stack(filtres, axis=-2),
-                axes={**template.axes, axis: msg_in.axes[axis]}
-            )
+            # TODO: Next line can be parallelized.
+            overlapped = [sps.correlate(in_dat, k, "full", "direct") for k in prep_kerns]
+            # overlapped = np.apply_along_axis(lambda y: np.convolve(k, y), -1, in_dat)
+            overlapped = np.stack(overlapped, axis=-2)
+            overlapped[..., :overlap] += tail  # Previous iteration's tail
+            new_tail = overlapped[..., -overlap:]
+            if new_tail.size > 0:
+                tail = new_tail
+            res = overlapped[..., :-overlap]
         elif mode == FilterbankMode.FFT:
-            # Make sure target axis is in -1th position.
-            targ_ax_ix = msg_in.get_axis_idx(axis)
-            if targ_ax_ix != (msg_in.data.ndim - 1):
-                in_dat = np.moveaxis(msg_in.data, targ_ax_ix, -1)
-                move_dims = msg_in.dims[:targ_ax_ix] + msg_in.dims[targ_ax_ix+1:] + [axis]
-                msg_in = replace(msg_in, data=in_dat, dims=move_dims)
             # Slice into non-overlapping windows
             win_msg = wingen.send(msg_in)
             # Calculate spectra of each window
             spec_dat = fft(win_msg.data, axis=-1)
             # Insert axis for filters
             spec_dat = np.expand_dims(spec_dat, -3)
+
             # Do the FFT convolution
             # TODO: handle fft_kernels being sparse. Maybe need np.dot.
-            conv_spec = spec_dat * fft_kernels
+            conv_spec = spec_dat * prep_kerns
             overlapped = ifft(conv_spec, axis=-1)
-            # Do the overlap-add on the `axis` axis, across rows in the "win" axis.
+
+            # Do the overlap-add on the `axis` axis
             overlapped[..., :1, :overlap] += tail  # Previous iteration's tail
-            overlapped[..., 1:, :overlap] += overlapped[..., :-1, -overlap:]
-            new_tail = overlapped[..., -1:, -overlap:]
+            overlapped[..., 1:, :overlap] += overlapped[..., :-1, -overlap:]  # window-to-window
+            new_tail = overlapped[..., -1:, -overlap:]  # Save tail
             if new_tail.size > 0:
                 # All of the above code works if input is size-zero, but we don't want to save a zero-size tail.
-                tail = overlapped[..., -1:, -overlap:]  # Save the tail for the next iteration.
+                tail = new_tail  # Save the tail for the next iteration.
             # Concat over win axis, without overlap.
             res = overlapped[..., :-overlap].reshape(overlapped.shape[:-2] + (-1,))
-            msg_out = replace(
-                template,
-                data=res,
-                axes={**template.axes, axis: msg_in.axes[axis]}
-            )
+
+        msg_out = replace(
+            template,
+            data=res,
+            axes={**template.axes, axis: msg_in.axes[axis]}
+        )
 
 
 class FilterbankSettings(ez.Settings):

--- a/src/ezmsg/sigproc/filterbank.py
+++ b/src/ezmsg/sigproc/filterbank.py
@@ -1,0 +1,171 @@
+from dataclasses import replace
+import functools
+import math
+import typing
+
+import numpy as np
+import scipy.signal as sps
+import scipy.fft as sp_fft
+from scipy.special import lambertw
+import numpy.typing as npt
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.generator import consumer
+from ezmsg.sigproc.filter import filtergen
+from ezmsg.sigproc.window import windowing
+
+
+@consumer
+def filterbank(
+    kernels: typing.Union[list[npt.NDArray], tuple[npt.NDArray, ...]],
+    mode: str = "conv",
+    axis: str = "time",
+) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Returns a generator that perform multiple (direct or fft) convolutions on a signal using a bank of kernels.
+    This generator is intended to be used during online processing, therefore both direct and fft convolutions
+    use the overlap-add method.
+    Args:
+        kernels:
+        mode: "conv", "fft", or "auto". If "auto", the mode is determined by the size of the input data.
+          fft mode is more efficient for long kernels. However, fft mode uses non-overlapping windows and will
+          incur a delay equal to the window length, which is larger than the largest kernel.
+          conv mode is less efficient but will return data for every incoming chunk regardless of how small it is
+          and thus can provide shorter latency updates.
+        axis: The name of the axis to operate on. This should usually be "time".
+
+    Returns:
+
+    """
+
+    template: typing.Optional[AxisArray] = None
+    msg_out: typing.Optional[AxisArray] = None
+
+    while True:
+        msg_in: AxisArray = yield msg_out
+
+        if template is None or mode == "auto":  # or (mode == "fft" and win_len < in_dat.shape[ax_ix] < max_win_len):
+            fs = 1 / msg_in.axes["time"].gain if "time" in msg_in.axes else 1.0
+            ax_ix = msg_in.get_axis_idx(axis)
+            if mode == "auto":
+                # concatenate kernels into 1 mega kernel then check what's faster.
+                # Will typically return fft when combined kernel length is > 1500.
+                concat_kernel = np.concatenate(kernels)
+                n_dummy = max(2 * len(concat_kernel), int(0.1 * fs))
+                dummy_arr = np.zeros(n_dummy)
+                mode = sps.choose_conv_method(dummy_arr, concat_kernel, mode="full")
+                mode = "conv" if mode == "direct" else "fft"
+            if mode == "conv":
+                # Note: Instead of filtergen, we could use np.convolve directly and manually manage overlap-add.
+                #  We should reconsider this after we finish managing overlap add for fft filtering.
+                #  out_full = np.apply_along_axis(lambda y: np.convolve(b, y), axis, x)
+                # TODO: Parallelize!
+                filtergens = [filtergen(axis="time", coefs=(_, 1.0), coef_type="ba") for _ in kernels]
+                # Prepare output template
+                template = AxisArray(
+                    data=np.zeros(msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix + 1:] + (len(kernels), 0)),
+                    dims=msg_in.dims[:ax_ix] + msg_in.dims[ax_ix + 1:] + ["filter", axis],
+                    axes=msg_in.axes.copy()  # No idea what to use to fill 'filter' axis.
+                )
+            elif mode == "fft":
+                # Note: We should not pass this off to multiple (non-existing) fftconvolve nodes, because here we
+                #  can calculate the FFT on the data only once which is then shared across kernels.
+
+                # Determine if this will be operating with complex data.
+                b_complex = msg_in.data.dtype.kind == "c" or any([_.dtype.kind == "c" for _ in kernels])
+
+                # Calculate window_dur, window_shift, nfft
+                max_kernel_len = max([_.size for _ in kernels])
+                # From sps._calc_oa_lens, where s2=max_kernel_len,:
+                # fallback_nfft = n_input + max_kernel_len - 1, but n_input is unbound.
+                overlap = max_kernel_len - 1
+                opt_size = -overlap * lambertw(-1 / (2 * math.e * overlap), k=-1).real
+                nfft = sp_fft.next_fast_len(math.ceil(opt_size))
+                win_len = nfft - overlap
+                infft = win_len + overlap  # Same as nfft. Keeping additional variable because I might need it again.
+
+                # Create windowing node
+                wingen = windowing(
+                    axis=axis,
+                    newaxis="win",  # Big data chunks might yield more than 1 window.
+                    window_dur=win_len / fs,
+                    window_shift=win_len / fs,  # Tumbling (not sliding) windows expected!
+                    zero_pad_until="none",
+                )
+
+                # Note: Instead of calculating fft in this node, we could use the spectrum node:
+                # specgen = spectrum(
+                #     axis=axis,
+                #     window=WindowFunction.NONE,
+                #     transform=SpectralTransform.RAW_COMPLEX if b_complex else SpectralTransform.REAL,
+                #     output=SpectralOutput.FULL if b_complex else SpectralOutput.POSITIVE,
+                #     norm="backward",
+                #     do_fftshift=False,
+                #     nfft=nfft,
+                # )
+                # However, this adds unnecessary overhead in creating the message structure and the calls to fft
+                #  are straightforward. We can revisit this if we add more fft optimization to spectrum.
+                # We accept that overhead for `windowing` because that is very difficult to implement correctly.
+
+                # Prepare fft functions
+                if b_complex:
+                    fft = functools.partial(sp_fft.fft, n=nfft, norm="backward")
+                    ifft = functools.partial(sp_fft.ifft, n=infft, norm="backward")
+                else:
+                    fft = functools.partial(sp_fft.rfft, n=nfft, norm="backward")
+                    ifft = functools.partial(sp_fft.irfft, n=infft, norm="backward")
+
+                # Calculate fft of kernels
+                fft_kernels = np.array([fft(_) for _ in kernels])
+                fft_kernels = np.expand_dims(fft_kernels, -2)
+                # TODO: If fft_kernels have significant stretches of zeros, convert to sparse array.
+
+                # Prepare previous iteration's overlap tail to add to input -- all zeros.
+                tail_shape = msg_in.data.shape[:ax_ix] + msg_in.data.shape[ax_ix+1:] + (len(kernels), 1, overlap)
+                tail = np.zeros(tail_shape, dtype="complex" if b_complex else "float")
+
+                # Prepare output template
+                template = AxisArray(
+                    data=np.zeros(tail_shape[:-2] + (0,), dtype="complex" if b_complex else "float"),
+                    dims=msg_in.dims[:ax_ix] + msg_in.dims[ax_ix+1:] + ["filter", axis],
+                    axes=msg_in.axes.copy()  # No idea what to use to fill 'filter' axis.
+                )
+
+        if mode == "conv":
+            # for each filtergen, send the message, accumulate outputs, stack along "filter" axis.
+            filtres = [fg.send(msg_in).data for fg in filtergens]  # TODO: parallelize!?
+            msg_out = replace(
+                template,
+                data=np.stack(filtres, axis=-2),
+                axes={**template.axes, axis: msg_in.axes[axis]}
+            )
+        elif mode == "fft":
+            # Make sure target axis is in -1th position.
+            targ_ax_ix = msg_in.get_axis_idx(axis)
+            if targ_ax_ix != (msg_in.data.ndim - 1):
+                in_dat = np.moveaxis(msg_in.data, targ_ax_ix, -1)
+                move_dims = msg_in.dims[:targ_ax_ix] + msg_in.dims[targ_ax_ix+1:] + [axis]
+                msg_in = replace(msg_in, data=in_dat, dims=move_dims)
+            # Slice into non-overlapping windows
+            win_msg = wingen.send(msg_in)
+            # Calculate spectra of each window
+            spec_dat = fft(win_msg.data, axis=-1)
+            # Insert axis for filters
+            spec_dat = np.expand_dims(spec_dat, -3)
+            # Do the FFT convolution
+            # TODO: handle fft_kernels being sparse. Maybe need np.dot.
+            conv_spec = spec_dat * fft_kernels
+            overlapped = ifft(conv_spec, axis=-1)
+            # Do the overlap-add on the `axis` axis, across rows in the "win" axis.
+            overlapped[..., :1, :overlap] += tail  # Previous iteration's tail
+            overlapped[..., 1:, :overlap] += overlapped[..., :-1, -overlap:]
+            new_tail = overlapped[..., -1:, -overlap:]
+            if new_tail.size > 0:
+                # All of the above code works if input is size-zero, but we don't want to save a zero-size tail.
+                tail = overlapped[..., -1:, -overlap:]  # Save the tail for the next iteration.
+            # Concat over win axis, without overlap.
+            res = overlapped[..., :-overlap].reshape(overlapped.shape[:-2] + (-1,))
+            msg_out = replace(
+                template,
+                data=res,
+                axes={**template.axes, axis: msg_in.axes[axis]}
+            )

--- a/src/ezmsg/sigproc/filterbank.py
+++ b/src/ezmsg/sigproc/filterbank.py
@@ -8,6 +8,7 @@ import scipy.signal as sps
 import scipy.fft as sp_fft
 from scipy.special import lambertw
 import numpy.typing as npt
+import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.generator import consumer
 from ezmsg.sigproc.filter import filtergen
@@ -179,3 +180,21 @@ def filterbank(
                 data=res,
                 axes={**template.axes, axis: msg_in.axes[axis]}
             )
+
+
+class FilterbankSettings(ez.Settings):
+    kernels: typing.Union[list[npt.NDArray], tuple[npt.NDArray, ...]]
+    mode: FilterbankMode = FilterbankMode.CONV
+    axis: str = "time"
+
+
+class Filterbank(GenAxisArray):
+    """Unit for :obj:`spectrum`"""
+    SETTINGS: FilterbankSettings
+
+    INPUT_SETTINGS = ez.InputStream(FilterbankSettings)
+
+    def construct_generator(self):
+        self.STATE.gen = filterbank(
+            kernels=self.SETTINGS.kernels, mode=self.SETTINGS.mode, axis=self.SETTINGS.axis
+        )

--- a/src/ezmsg/sigproc/filterbank.py
+++ b/src/ezmsg/sigproc/filterbank.py
@@ -222,7 +222,7 @@ class FilterbankSettings(ez.Settings):
 
 class Filterbank(GenAxisArray):
     """Unit for :obj:`spectrum`"""
-    SETTINGS: FilterbankSettings
+    SETTINGS = FilterbankSettings
 
     INPUT_SETTINGS = ez.InputStream(FilterbankSettings)
 

--- a/tests/test_filterbank.py
+++ b/tests/test_filterbank.py
@@ -1,0 +1,110 @@
+import typing
+
+import pytest
+import numpy as np
+import scipy.signal as sps
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.filterbank import filterbank
+
+
+def gaussian(x, x0, sigma):
+    return np.exp(-np.power((x - x0) / sigma, 2.0) / 2.0)
+
+
+def make_chirp(t, t0, a):
+    frequency = (a * (t + t0)) ** 2
+    chirp = np.sin(2 * np.pi * frequency * t)
+    return chirp, frequency
+
+
+def gen_signal(fs, dur):
+    # generate signal
+    f_gains = [9, 5]  # frequency will scale as square of this value * time.
+    t_offsets = [0.3 * dur, 0.1 * dur]  # When the chirp starts.
+    time = np.arange(int(dur*fs)) / fs
+    # TODO: Replace with sps.chirp?
+    chirp1, frequency1 = make_chirp(time, t_offsets[0], f_gains[0])
+    chirp2, frequency2 = make_chirp(time, t_offsets[1], f_gains[1])
+    chirp = chirp1 + 0.6 * chirp2
+    chirp *= gaussian(time, 0.5, 0.2)
+    return chirp, time
+
+
+def bandpass_kaiser(ntaps, lowcut, highcut, fs, width):
+    atten = sps.kaiser_atten(ntaps, width / (0.5 * fs))
+    beta = sps.kaiser_beta(atten)
+    taps = sps.firwin(ntaps, [lowcut, highcut], fs=fs, pass_zero="bandpass",
+                      window=("kaiser", beta), scale=False)
+    return taps
+
+
+@pytest.mark.parametrize("mode", ["fft", "conv", "auto"])
+@pytest.mark.parametrize("kernel_type", ["kaiser", "brickwall"])
+def test_filterbank(mode: str, kernel_type: str):
+    # Generate test signal
+    fs = 1000
+    dur = 5.0
+    chirp, tvec = gen_signal(fs, dur)
+    chirp = np.vstack((chirp, np.roll(chirp, fs)))
+
+    # Split signal into messages
+    step_size = 100
+    in_messages = []
+    for idx in range(0, len(tvec), step_size):
+        in_messages.append(
+            AxisArray(
+                data=chirp[:, idx:idx+step_size],
+                dims=["ch", "time"],
+                axes={
+                    "time": AxisArray.Axis.TimeAxis(offset=tvec[idx], fs=fs)
+                }
+            )
+        )
+
+    # Get kernels for 2 bandpass filters. 3-30 and 30-100 Hz.
+    kernels = []
+    bands = [(3, 10), (10, 30), (30, 50), (50, 70), (70, 100), (100, 300)]
+    if kernel_type == "kaiser":
+        # Decent FIR filter for a given number of taps
+        ntaps = 101
+        for band in bands:
+            k = bandpass_kaiser(ntaps, band[0], band[1], fs, 2)
+            kernels.append(k)
+    elif kernel_type == "brickwall":
+        # brickwall filter. Not very useful. Lots of transients. TODO: Use this to implement sparsity in the filterbank.
+        ntaps = fs // 2
+        fvec = np.arange(0, ntaps, 1)
+        for band in bands:
+            fft_kernel = np.zeros(ntaps)
+            fft_kernel[np.logical_and(fvec >= band[0], fvec <= band[1])] = 1
+            k = np.fft.irfft(fft_kernel, n=ntaps)
+            kernels.append(k)
+
+    # Prep filterbank
+    gen = filterbank(kernels=kernels, mode=mode, axis="time")
+
+    # Pass the messages
+    out_messages = [gen.send(msg_in) for msg_in in in_messages]
+    result = AxisArray.concatenate(*out_messages, dim="time")
+
+    # Compare to sps.oaconvolve(chirp), with the following differences:
+    #  - conv has transients at the beginning that we need to skip over
+    #  - oaconvolve assumes the data is finished so it returns the trailing windows,
+    #    but filterbank keeps the tail assuming more data is coming.
+    expected = np.stack([sps.oaconvolve(chirp, _[None, :], axes=1) for _ in kernels], axis=1)
+    idx0 = ntaps if mode in ["auto", "conv"] else 0
+    assert np.allclose(result.data[..., idx0:], expected[..., idx0:result.data.shape[-1]])
+
+    if False:
+        # Debug visualize result
+        import matplotlib.pyplot as plt
+        # tmp = result.data
+        tmp = expected
+        nch = tmp.shape[0]
+        fig, axes = plt.subplots(3, nch)
+        for ch_ix in range(nch):
+            axes[0, ch_ix].plot(tvec, chirp[ch_ix])
+            axes[1, ch_ix].imshow(tmp[ch_ix], aspect="auto", origin="lower")
+            axes[2, ch_ix].imshow(np.abs(tmp[ch_ix]), aspect="auto", origin="lower")
+        plt.show()

--- a/tests/test_filterbank.py
+++ b/tests/test_filterbank.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.signal as sps
 from ezmsg.util.messages.axisarray import AxisArray
 
-from ezmsg.sigproc.filterbank import filterbank
+from ezmsg.sigproc.filterbank import filterbank, FilterbankMode
 
 
 def gaussian(x, x0, sigma):
@@ -39,7 +39,7 @@ def bandpass_kaiser(ntaps, lowcut, highcut, fs, width):
     return taps
 
 
-@pytest.mark.parametrize("mode", ["fft", "conv", "auto"])
+@pytest.mark.parametrize("mode", [FilterbankMode.CONV, FilterbankMode.FFT, FilterbankMode.AUTO])
 @pytest.mark.parametrize("kernel_type", ["kaiser", "brickwall"])
 def test_filterbank(mode: str, kernel_type: str):
     # Generate test signal
@@ -93,7 +93,7 @@ def test_filterbank(mode: str, kernel_type: str):
     #  - oaconvolve assumes the data is finished so it returns the trailing windows,
     #    but filterbank keeps the tail assuming more data is coming.
     expected = np.stack([sps.oaconvolve(chirp, _[None, :], axes=1) for _ in kernels], axis=1)
-    idx0 = ntaps if mode in ["auto", "conv"] else 0
+    idx0 = ntaps if mode in [FilterbankMode.CONV, FilterbankMode.AUTO] else 0
     assert np.allclose(result.data[..., idx0:], expected[..., idx0:result.data.shape[-1]])
 
     if False:


### PR DESCRIPTION
This is built on top of PR #16. Only the commits since e5d98b46ccb53a1d4b60830a8107276ea3197baf are relevant here.

This PR adds a new generator + unit tests as well as a ez.Unit for doing filterbank processing. The filter kernels are arguments to pass in and it's up to the user to design them.

The filtering is done either via convolution or with an overlap-add fft-convolution. The kernels are 1D and thus only approximate an FIR, not IIR. Convolution mode uses `filtergen` with ba coefficients and `a=[1.0]`. FFT-mode will estimate the optimal number of samples then use `windowing` to slice the data into windows of this size before doing the fft->multiplication->ifft.