### PR TITLE
Wavelets

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -319,6 +319,51 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pywavelets"
+version = "1.6.0"
+description = "PyWavelets, wavelet transform module"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pywavelets-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ddc1ff5ad706313d930f857f9656f565dfb81b85bbe58a9db16ad8fa7d1537c5"},
+    {file = "pywavelets-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:78feab4e0c25fa32034b6b64cb854c6ce15663b4f0ffb25d8f0ee58915300f9b"},
+    {file = "pywavelets-1.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be36f08efe9bc3abf40cf40cd2ee0aa0db26e4894e13ce5ac178442864161e8c"},
+    {file = "pywavelets-1.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0595c51472c9c5724fe087cb73e2797053fd25c788d6553fdad6ff61abc60e91"},
+    {file = "pywavelets-1.6.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:058a750477dde633ac53b8806f835af3559d52db6532fb2b93c1f4b5441365b8"},
+    {file = "pywavelets-1.6.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:538795d9c4181152b414285b5a7f72ac52581ecdcdce74b6cca3fa0b8a5ab0aa"},
+    {file = "pywavelets-1.6.0-cp310-cp310-win32.whl", hash = "sha256:47de024ba4f9df97e98b5f540340e1a9edd82d2c477450bef8c9b5381487128e"},
+    {file = "pywavelets-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:e2c44760c0906ddf2176920a2613287f6eea947f166ce7eee9546081b06a6835"},
+    {file = "pywavelets-1.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d91aaaf6de53b758bcdc96c81cdb5a8607758602be49f691188c0e108cf1e738"},
+    {file = "pywavelets-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b5302edb6d1d1ff6636d37c9ff29c4892f2a3648d736cc1df01f3f36e25c8cf"},
+    {file = "pywavelets-1.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5e655446e37a3c87213d5c6386b86f65c4d61736b4432d720171e7dd6523d6a"},
+    {file = "pywavelets-1.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ec7d69b746a0eaa327b829a3252a63619f2345e263177be5dd9bf30d7933c8d"},
+    {file = "pywavelets-1.6.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:97ea9613bd6b7108ebb44b709060adc7e2d5fac73be7152342bdd5513d75f84e"},
+    {file = "pywavelets-1.6.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:48b3813c6d1a7a8194f37dbb5dbbdf2fe1112152c91445ea2e54f64ff6350c36"},
+    {file = "pywavelets-1.6.0-cp311-cp311-win32.whl", hash = "sha256:4ffb484d096a5eb10af7121e0203546a03e1369328df321a33ef91f67bac40cf"},
+    {file = "pywavelets-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:274bc47b289585383aa65519b3fcae5b4dee5e31db3d4198d4fad701a70e59f7"},
+    {file = "pywavelets-1.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d6ec113386a432e04103f95e351d2657b42145bd1e1ed26513423391bcb5f011"},
+    {file = "pywavelets-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab652112d3932d21f020e281e06926a751354c2b5629fb716f5eb9d0104b84e5"},
+    {file = "pywavelets-1.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47b0314a22616c5f3f08760f0e00b4a15b7c7dadca5e39bb701cf7869a4207c5"},
+    {file = "pywavelets-1.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:138471513bc0a4cd2ddc4e50c7ec04e3468c268e101a0d02f698f6aedd1d5e79"},
+    {file = "pywavelets-1.6.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:67936491ae3e5f957c428e34fdaed21f131535b8d60c7c729a1b539ce8864837"},
+    {file = "pywavelets-1.6.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:dd798cee3d28fb3d32a26a00d9831a20bf316c36d685e4ced01b4e4a8f36f5ce"},
+    {file = "pywavelets-1.6.0-cp312-cp312-win32.whl", hash = "sha256:e772f7f0c16bfc3be8ac3cd10d29a9920bb7a39781358856223c491b899e6e79"},
+    {file = "pywavelets-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:4ef15a63a72afa67ae9f4f3b06c95c5382730fb3075e668d49a880e65f2f089c"},
+    {file = "pywavelets-1.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:627df378e63e9c789b6f2e7060cb4264ebae6f6b0efc1da287a2c060de454a1f"},
+    {file = "pywavelets-1.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a413b51dc19e05243fe0b0864a8e8a16b5ca9bf2e4713da00a95b1b5747a5367"},
+    {file = "pywavelets-1.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be615c6c1873e189c265d4a76d1751ec49b17e29725e6dd2e9c74f1868f590b7"},
+    {file = "pywavelets-1.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4021ef69ec9f3862f66580fc4417be728bd78722914394594b48212fd1fcaf21"},
+    {file = "pywavelets-1.6.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8fbf7b61b28b5457693c034e58a01622756d1fd60a80ae13ac5888b1d3e57e80"},
+    {file = "pywavelets-1.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f58ddbb0a6cd243928876edfc463b990763a24fb94498607d6fea690e32cca4c"},
+    {file = "pywavelets-1.6.0-cp39-cp39-win32.whl", hash = "sha256:42a22e68e345b6de7d387ef752111ab4530c98048d2b4bdac8ceefb078b4ead6"},
+    {file = "pywavelets-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:32198de321892743c1a3d1957fe1cd8a8ecc078bfbba6b8f3982518e897271d7"},
+    {file = "pywavelets-1.6.0.tar.gz", hash = "sha256:ea027c70977122c5fc27b2510f0a0d9528f9c3df6ea3e4c577ca55fd00325a5b"},
+]
+
+[package.dependencies]
+numpy = ">=1.22.4,<3"
+
+[[package]]
 name = "scipy"
 version = "1.9.3"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -380,5 +425,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "0341722f99d38a67fec168d3926e2f2d1a2c385a6beddf5486f51e80fa82db23"
+python-versions = "^3.9"
+content-hash = "852100d652b91ff54907649e340e5cdb0c3f20a46fa2e580f5d8347036dae16f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,11 @@ readme = "README.md"
 packages = [{ include = "ezmsg", from = "src" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ezmsg = { git = "https://github.com/ezmsg-org/ezmsg.git", rev = "dev" }
 numpy = "^1.19.5"
 scipy = "^1.6.3"
+pywavelets = "^1.6.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.0.0"

--- a/src/ezmsg/sigproc/wavelets.py
+++ b/src/ezmsg/sigproc/wavelets.py
@@ -121,7 +121,7 @@ class CWT(GenAxisArray):
     """
     :obj:`Unit` for :obj:`common_rereference`.
     """
-    SETTINGS: CWTSettings
+    SETTINGS = CWTSettings
 
     def construct_generator(self):
         self.STATE.gen = cwt(

--- a/src/ezmsg/sigproc/wavelets.py
+++ b/src/ezmsg/sigproc/wavelets.py
@@ -1,0 +1,104 @@
+from dataclasses import replace
+import typing
+
+import numpy as np
+import numpy.typing as npt
+import pywt
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.generator import consumer
+
+from ezmsg.sigproc.filterbank import filterbank, FilterbankMode, MinPhaseMode
+
+
+@consumer
+def cwt(
+    scales: typing.Union[list, tuple, npt.NDArray],
+    wavelet: typing.Union[str, pywt.ContinuousWavelet, pywt.Wavelet],
+    min_phase: MinPhaseMode = MinPhaseMode.NONE,
+    axis: str = "time",
+) -> typing.Generator[AxisArray, AxisArray, None]:
+    """
+    Build a generator to perform a continuous wavelet transform on sent AxisArray messages.
+    The function is equivalent to the `pywt.cwt` function, but is designed to work with streaming data.
+
+    Args:
+        scales: The wavelet scales to use.
+        wavelet: Wavelet object or name of wavelet to use.
+        min_phase: See filterbank MinPhaseMode for details.
+        axis: The target axis for operation. Note that this will be moved to the -1th dimension
+          because fft and matrix multiplication is much faster on the last axis.
+
+    Returns:
+        A Generator object that expects `.send(axis_array)` of continuous data
+    """
+    assert np.all(scales > 0), "Scales must be positive."
+    scales = np.array(scales)
+    assert scales.ndim == 1, "Scales must be a 1D list, tuple, or array."
+    neg_rt_scales = -np.sqrt(scales)[:, None]
+
+    if not isinstance(wavelet, (pywt.ContinuousWavelet, pywt.Wavelet)):
+        wavelet = pywt.DiscreteContinuousWavelet(wavelet)
+    precision = 10
+    int_psi, x = pywt.integrate_wavelet(wavelet, precision=precision)
+    int_psi = np.conj(int_psi) if wavelet.complex_cwt else int_psi
+
+    msg_out: typing.Optional[AxisArray] = None
+    template: typing.Optional[AxisArray] = None
+
+    while True:
+        msg_in: AxisArray = yield msg_out
+        ax_idx = msg_in.get_axis_idx(axis)
+
+        if msg_in.data.size and template is None:
+            # convert int_psi, x to the same precision as the data
+            dt_data = msg_in.data.dtype  # _check_dtype(msg_in.data)
+            dt_cplx = np.result_type(dt_data, np.complex64)
+            dt_psi = dt_cplx if int_psi.dtype.kind == 'c' else dt_data
+            int_psi = np.asarray(int_psi, dtype=dt_psi)
+            x = np.asarray(x, dtype=msg_in.data.real.dtype)
+            wave_range = x[-1] - x[0]
+            step = x[1] - x[0]
+            int_psi_scales = []
+            for scale in scales:
+                reix = (np.arange(scale * wave_range + 1) / (scale * step)).astype(int)
+                if reix[-1] >= int_psi.size:
+                    reix = np.extract(reix < int_psi.size, reix)
+                int_psi_scales.append(int_psi[reix][::-1])
+
+            # CONV is probably best because we often get huge kernels.
+            fbgen = filterbank(int_psi_scales, mode=FilterbankMode.CONV, min_phase=min_phase, axis=axis)
+
+            freqs = pywt.scale2frequency(wavelet, scales, precision) / msg_in.axes[axis].gain
+            fstep = (freqs[1] - freqs[0]) if len(freqs) > 1 else 1.0
+            # Create output template
+            dummy_shape = msg_in.data.shape[:ax_idx] + msg_in.data.shape[ax_idx + 1:] + (len(scales), 0)
+            template = AxisArray(
+                np.zeros(dummy_shape, dtype=dt_cplx if wavelet.complex_cwt else dt_data),
+                dims=msg_in.dims[:ax_idx] + msg_in.dims[ax_idx + 1:] + ["freq", axis],
+                axes={
+                    **msg_in.axes,
+                    "freq": AxisArray.Axis("Hz", offset=freqs[0], gain=fstep)
+                },
+            )
+            last_conv_samp = np.zeros(dummy_shape[:-1] + (1,), dtype=template.data.dtype)
+
+        conv_msg = fbgen.send(msg_in)
+
+        # Prepend with last_conv_samp before doing diff
+        dat = np.concatenate((last_conv_samp, conv_msg.data), axis=-1)
+        coef = neg_rt_scales * np.diff(dat, axis=-1)
+        # Store last_conv_samp for next iteration.
+        last_conv_samp = conv_msg.data[..., -1:]
+
+        if template.data.dtype.kind != 'c':
+            coef = coef.real
+
+        # pywt.cwt slices off the beginning and end of the result where the convolution overran. We don't have
+        #  that luxury when streaming.
+        # d = (coef.shape[-1] - msg_in.data.shape[ax_idx]) / 2.
+        # coef = coef[..., math.floor(d):-math.ceil(d)]
+        msg_out = replace(
+            template,
+            data=coef,
+            axes={**template.axes, axis: msg_in.axes[axis]}
+        )

--- a/src/ezmsg/sigproc/wavelets.py
+++ b/src/ezmsg/sigproc/wavelets.py
@@ -33,8 +33,8 @@ def cwt(
     Returns:
         A Generator object that expects `.send(axis_array)` of continuous data
     """
-    assert np.all(scales > 0), "Scales must be positive."
     scales = np.array(scales)
+    assert np.all(scales > 0), "Scales must be positive."
     assert scales.ndim == 1, "Scales must be a 1D list, tuple, or array."
     neg_rt_scales = -np.sqrt(scales)[:, None]
 

--- a/src/ezmsg/sigproc/wavelets.py
+++ b/src/ezmsg/sigproc/wavelets.py
@@ -4,9 +4,11 @@ import typing
 import numpy as np
 import numpy.typing as npt
 import pywt
+import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.generator import consumer
 
+from ezmsg.sigproc.base import GenAxisArray
 from ezmsg.sigproc.filterbank import filterbank, FilterbankMode, MinPhaseMode
 
 
@@ -101,4 +103,30 @@ def cwt(
             template,
             data=coef,
             axes={**template.axes, axis: msg_in.axes[axis]}
+        )
+
+
+class CWTSettings(ez.Settings):
+    """
+    Settings for :obj:`CWT`
+    See :obj:`cwt` for argument details.
+    """
+    scales: typing.Union[list, tuple, npt.NDArray]
+    wavelet: typing.Union[str, pywt.ContinuousWavelet, pywt.Wavelet]
+    min_phase: MinPhaseMode = MinPhaseMode.NONE
+    axis: str = "time"
+
+
+class CWT(GenAxisArray):
+    """
+    :obj:`Unit` for :obj:`common_rereference`.
+    """
+    SETTINGS: CWTSettings
+
+    def construct_generator(self):
+        self.STATE.gen = cwt(
+            scales=self.SETTINGS.scales,
+            wavelet=self.SETTINGS.wavelet,
+            min_phase=self.SETTINGS.min_phase,
+            axis=self.SETTINGS.axis
         )

--- a/tests/test_wavelets.py
+++ b/tests/test_wavelets.py
@@ -15,7 +15,7 @@ def make_chirp(t, t0, a):
     return chirp, frequency
 
 
-def test_scratch():
+def scratch():
     scales = np.geomspace(4, 256, num=35)
     wavelets = [f"cmor{x:.1f}-{y:.1f}" for x in [0.5, 1.5, 2.5] for y in [0.5, 1.0, 1.5]]
     wavelet = wavelets[1]
@@ -102,7 +102,6 @@ def test_cwt():
     out_messages = [gen.send(in_messages[0])]
     out_messages += [gen.send(msg_in) for msg_in in in_messages[1:]]
     result = AxisArray.concatenate(*out_messages, dim="time")
-    print("Done")
 
     # TODO: Compare result to expected
 

--- a/tests/test_wavelets.py
+++ b/tests/test_wavelets.py
@@ -1,0 +1,124 @@
+import numpy as np
+from ezmsg.util.messages.axisarray import AxisArray
+import pywt
+
+from ezmsg.sigproc.wavelets import cwt, MinPhaseMode
+
+
+def gaussian(x, x0, sigma):
+    return np.exp(-np.power((x - x0) / sigma, 2.0) / 2.0)
+
+
+def make_chirp(t, t0, a):
+    frequency = (a * (t + t0)) ** 2
+    chirp = np.sin(2 * np.pi * frequency * t)
+    return chirp, frequency
+
+
+def test_scratch():
+    scales = np.geomspace(4, 256, num=35)
+    wavelets = [f"cmor{x:.1f}-{y:.1f}" for x in [0.5, 1.5, 2.5] for y in [0.5, 1.0, 1.5]]
+    wavelet = wavelets[1]
+
+    # Generate test signal
+    fs = 1000
+    dur = 2.0
+    tvec = np.arange(int(dur * fs)) / fs
+    chirp1, frequency1 = make_chirp(tvec, 0.2, 9)
+    chirp2, frequency2 = make_chirp(tvec, 0.1, 5)
+    chirp = chirp1 + 0.6 * chirp2
+    chirp *= gaussian(tvec, 0.5, 0.2)
+    chirp = np.vstack((chirp, np.roll(chirp, fs)))
+    # TODO: Replace with sps.chirp?
+
+    precision = 10
+    int_psi, x = pywt.integrate_wavelet(wavelet, precision=precision)
+    int_psi = np.conj(int_psi)
+    int_psi = np.asarray(int_psi, dtype="complex")
+    x = np.asarray(x, dtype=chirp.real.dtype)
+
+    wave_range = x[-1] - x[0]
+    step = x[1] - x[0]
+    int_psi_scales = []
+    for scale in scales:
+        reix = (np.arange(scale * wave_range + 1) / (scale * step)).astype(int)
+        if reix[-1] >= int_psi.size:
+            reix = np.extract(reix < int_psi.size, reix)
+        int_psi_scales.append(int_psi[reix][::-1])
+
+    # Try different kinds of convolutions.
+    # np.convolve: 1d, 1d only
+    conv = np.convolve(chirp[0], int_psi_scales[-1])
+
+    import matplotlib.pyplot as plt
+    plt.plot(chirp[0])
+    plt.plot(int_psi_scales[-1])
+    plt.plot(conv)
+    plt.show()
+    print("DONE")
+
+
+def test_cwt():
+    # scale near 1 is approx fs, 256 is approx 256 Hz
+    # we want up to ~ 200 Hz, so that's a scale of 256
+    scales = np.geomspace(4, 256, num=70)
+    # wavelets = [f"cmor{x:.1f}-{y:.1f}" for x in [0.5, 1.5, 2.5] for y in [0.5, 1.0, 1.5]]
+    # wavelet = wavelets[4]
+    wavelet = "morl"
+
+    # Generate test signal
+    fs = 1000
+    dur = 2.0
+    tvec = np.arange(int(dur*fs)) / fs
+    chirp1, frequency1 = make_chirp(tvec, 0.2, 9)
+    chirp2, frequency2 = make_chirp(tvec, 0.1, 5)
+    chirp = chirp1 + 0.6 * chirp2
+    chirp *= gaussian(tvec, 0.5, 0.2)
+    chirp = np.vstack((chirp, np.roll(chirp, fs)))
+    # TODO: Replace with sps.chirp?
+
+    # Split signal into messages
+    step_size = 100
+    in_messages = []
+    for idx in range(0, len(tvec), step_size):
+        in_messages.append(
+            AxisArray(
+                data=chirp[:, idx:idx+step_size],
+                dims=["ch", "time"],
+                axes={
+                    "time": AxisArray.Axis.TimeAxis(offset=tvec[idx], fs=fs)
+                }
+            )
+        )
+
+    # Prepare expected output from pywt.cwt
+    expected, freqs = pywt.cwt(chirp, scales, wavelet, 1/fs, method="conv", axis=-1)
+    expected = np.swapaxes(expected, 0, 1)  # Swap scales and channels -> ch, freqs, time
+
+    # Prep filterbank
+    gen = cwt(scales=scales, wavelet=wavelet, min_phase=MinPhaseMode.HOMOMORPHIC, axis="time")
+
+    # Pass the messages
+    out_messages = [gen.send(in_messages[0])]
+    out_messages += [gen.send(msg_in) for msg_in in in_messages[1:]]
+    result = AxisArray.concatenate(*out_messages, dim="time")
+    print("Done")
+
+    # TODO: Compare result to expected
+
+    if False:
+        # Debug visualize result
+        import matplotlib.pyplot as plt
+        tmp = result.data; title = "ezmsg minphase homomorphic"
+        # tmp = expected; title = "pywavelets"
+        nch = tmp.shape[0]
+        fig, axes = plt.subplots(2, nch)
+        fig.suptitle(title)
+        for ch_ix in range(nch):
+            axes[0, ch_ix].set_title(f"Channel {ch_ix}")
+            axes[0, ch_ix].plot(tvec, chirp[ch_ix])
+            pcm = axes[1, ch_ix].pcolormesh(tvec[:tmp.shape[-1]], freqs, np.abs(tmp[ch_ix, :-1, :-1]))
+            axes[1, ch_ix].set_yscale("log")
+            axes[1, ch_ix].set_xlabel("Time (s)")
+            axes[1, ch_ix].set_ylabel("Frequency (Hz)")
+        plt.show()


### PR DESCRIPTION
This extends from PRs #16 and #17 and should be evaluated after those are merged.

This PR adds a Continuous Wavelet Transform module. `pywavelets` is used to construct a set of filter kernels, which are then passed to `filterbank`. Note that the generated kernels will have very different lengths and delays according to their scale, so there is a `min_phase` option that will take the 'pristine' wavelet kernels and recalculate them as their min-phase equivalents. min-phase kernels have worse performance (weaker stop-band, more phase distortion in pass-band) but have much less delay so the synchronization between e.g. alpha decrease and gamma increase is preserved.