### PR TITLE
State reset upon input change

### DIFF
--- a/src/ezmsg/sigproc/bandpower.py
+++ b/src/ezmsg/sigproc/bandpower.py
@@ -26,8 +26,7 @@ def bandpower(
     Returns:
         A primed generator object ready to yield an AxisArray for each .send(axis_array)
     """
-    axis_arr_in = AxisArray(np.array([]), dims=[""])
-    axis_arr_out = AxisArray(np.array([]), dims=[""])
+    msg_out = AxisArray(np.array([]), dims=[""])
 
     f_spec = spectrogram(
         window_dur=spectrogram_settings.window_dur,
@@ -44,8 +43,8 @@ def bandpower(
     pipeline = compose(f_spec, f_agg)
 
     while True:
-        axis_arr_in = yield axis_arr_out
-        axis_arr_out = pipeline(axis_arr_in)
+        msg_in: AxisArray = yield msg_out
+        msg_out = pipeline(msg_in)
 
 
 class BandPowerSettings(ez.Settings):

--- a/src/ezmsg/sigproc/butterworthfilter.py
+++ b/src/ezmsg/sigproc/butterworthfilter.py
@@ -76,8 +76,7 @@ def butter(
 
     """
     # IO
-    axis_arr_in = AxisArray(np.array([]), dims=[""])
-    axis_arr_out = AxisArray(np.array([]), dims=[""])
+    msg_out = AxisArray(np.array([]), dims=[""])
 
     btype, cutoffs = ButterworthFilterSettings(
         order=order, cuton=cuton, cutoff=cutoff
@@ -88,15 +87,15 @@ def butter(
     filter_gen = filtergen(axis, coefs, coef_type)  # Passthrough.
 
     while True:
-        axis_arr_in = yield axis_arr_out
+        msg_in: AxisArray = yield msg_out
         if coefs is None and order > 0:
-            fs = 1 / axis_arr_in.axes[axis or axis_arr_in.dims[0]].gain
+            fs = 1 / msg_in.axes[axis or msg_in.dims[0]].gain
             coefs = scipy.signal.butter(
                 order, Wn=cutoffs, btype=btype, fs=fs, output=coef_type
             )
             filter_gen = filtergen(axis, coefs, coef_type)
 
-        axis_arr_out = filter_gen.send(axis_arr_in)
+        msg_out = filter_gen.send(msg_in)
 
 
 class ButterworthFilterState(FilterState):

--- a/src/ezmsg/sigproc/sampler.py
+++ b/src/ezmsg/sigproc/sampler.py
@@ -66,7 +66,6 @@ def sampler(
         A generator that expects `.send` either an :obj:`AxisArray` containing streaming data messages,
         or a :obj:`SampleTriggerMessage` containing a trigger, and yields the list of :obj:`SampleMessage` s.
     """
-    msg_in = None
     msg_out: Optional[list[SampleMessage]] = None
 
     # State variables (most shared between trigger- and data-processing.

--- a/src/ezmsg/sigproc/spectrogram.py
+++ b/src/ezmsg/sigproc/spectrogram.py
@@ -49,12 +49,11 @@ def spectrogram(
     )
 
     # State variables
-    axis_arr_in = AxisArray(np.array([]), dims=[""])
-    axis_arr_out: typing.Optional[AxisArray] = None
+    msg_out: typing.Optional[AxisArray] = None
 
     while True:
-        axis_arr_in = yield axis_arr_out
-        axis_arr_out = pipeline(axis_arr_in)
+        msg_in: AxisArray = yield msg_out
+        msg_out = pipeline(msg_in)
 
 
 class SpectrogramSettings(ez.Settings):

--- a/src/ezmsg/sigproc/synth.py
+++ b/src/ezmsg/sigproc/synth.py
@@ -285,22 +285,21 @@ def sin(
         A primed generator that expects .send(axis_array) of sample counts
         and yields an AxisArray of sinusoids.
     """
-    axis_arr_in = AxisArray(np.array([]), dims=[""])
-    axis_arr_out = AxisArray(np.array([]), dims=[""])
+    msg_out = AxisArray(np.array([]), dims=[""])
 
     ang_freq = 2.0 * np.pi * freq
 
     while True:
-        axis_arr_in = yield axis_arr_out
-        # axis_arr_in is expected to be sample counts
+        msg_in: AxisArray = yield msg_out
+        # msg_in is expected to be sample counts
 
         axis_name = axis
         if axis_name is None:
-            axis_name = axis_arr_in.dims[0]
+            axis_name = msg_in.dims[0]
 
-        w = (ang_freq * axis_arr_in.get_axis(axis_name).gain) * axis_arr_in.data
+        w = (ang_freq * msg_in.get_axis(axis_name).gain) * msg_in.data
         out_data = amp * np.sin(w + phase)
-        axis_arr_out = replace(axis_arr_in, data=out_data)
+        msg_out = replace(msg_in, data=out_data)
 
 
 class SinGeneratorSettings(ez.Settings):

--- a/src/ezmsg/sigproc/window.py
+++ b/src/ezmsg/sigproc/window.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 import traceback
-from typing import AsyncGenerator, Optional, Tuple, List, Generator
+import typing
 
 import ezmsg.core as ez
 import numpy as np
@@ -14,12 +14,12 @@ from .base import GenAxisArray
 
 @consumer
 def windowing(
-    axis: Optional[str] = None,
+    axis: typing.Optional[str] = None,
     newaxis: str = "win",
-    window_dur: Optional[float] = None,
-    window_shift: Optional[float] = None,
+    window_dur: typing.Optional[float] = None,
+    window_shift: typing.Optional[float] = None,
     zero_pad_until: str = "input"
-) -> Generator[AxisArray, AxisArray, None]:
+) -> typing.Generator[AxisArray, AxisArray, None]:
     """
     Construct a generator that yields windows of data from an input :obj:`AxisArray`.
 
@@ -48,6 +48,7 @@ def windowing(
         A (primed) generator that accepts .send(an AxisArray object) and yields a list of windowed
         AxisArray objects. The list will always be length-1 if `newaxis` is not None or `window_shift` is None.
     """
+    # Check arguments
     if newaxis is None:
         ez.logger.warning("`newaxis` must not be None. Setting to 'win'.")
         newaxis = "win"
@@ -61,15 +62,16 @@ def windowing(
     msg_out = AxisArray(np.array([]), dims=[""])
 
     # State variables
-    prev_samp_shape: Optional[Tuple[int, ...]] = None
-    prev_fs: Optional[float] = None
-    buffer: Optional[npt.NDArray] = None
-    window_samples: Optional[int] = None
-    window_shift_samples: Optional[int] = None
+    buffer: typing.Optional[npt.NDArray] = None
+    window_samples: typing.Optional[int] = None
+    window_shift_samples: typing.Optional[int] = None
     shift_deficit: int = 0  # Number of incoming samples to ignore. Only relevant when shift > window.
     b_1to1 = window_shift is None
     newaxis_warned: bool = b_1to1
-    out_newaxis: Optional[AxisArray.Axis] = None
+    out_newaxis: typing.Optional[AxisArray.Axis] = None
+    out_dims: typing.typing.Optional[typing.List[str]] = None
+
+    check_inputs = {"samp_shape": None, "fs": None, "key": None}
 
     while True:
         msg_in: AxisArray = yield msg_out
@@ -78,8 +80,7 @@ def windowing(
             msg_out = msg_in
             continue
 
-        if axis is None:
-            axis = msg_in.dims[0]
+        axis = axis or msg_in.dims[0]
         axis_idx = msg_in.get_axis_idx(axis)
         axis_info = msg_in.get_axis(axis)
         fs = 1.0 / axis_info.gain
@@ -92,7 +93,16 @@ def windowing(
         samp_shape = msg_in.data.shape[:axis_idx] + msg_in.data.shape[axis_idx + 1:]
 
         # If buffer unset or input stats changed, create a new buffer
-        if buffer is None or samp_shape != prev_samp_shape or fs != prev_fs:
+        b_reset = buffer is None
+        b_reset = b_reset or samp_shape != check_inputs["samp_shape"]
+        b_reset = b_reset or fs != check_inputs["fs"]
+        b_reset = b_reset or msg_in.key != check_inputs["key"]
+        if b_reset:
+            # Update check variables
+            check_inputs["samp_shape"] = samp_shape
+            check_inputs["fs"] = fs
+            check_inputs["key"] = msg_in.key
+
             window_samples = int(window_dur * fs)
             if not b_1to1:
                 window_shift_samples = int(window_shift * fs)
@@ -104,8 +114,6 @@ def windowing(
                 req_samples = msg_in.data.shape[axis_idx]
             n_zero = max(0, window_samples - req_samples)
             buffer = np.zeros(msg_in.data.shape[:axis_idx] + (n_zero,) + msg_in.data.shape[axis_idx + 1:])
-            prev_samp_shape = samp_shape
-            prev_fs = fs
 
         # Add new data to buffer.
         # Currently, we concatenate the new time samples and clip the output.
@@ -127,7 +135,7 @@ def windowing(
         if not b_1to1 and shift_deficit > 0:
             n_skip = min(buffer.shape[axis_idx], shift_deficit)
             if n_skip > 0:
-                buffer = slice_along_axis(buffer, np.s_[n_skip:], axis_idx)
+                buffer = slice_along_axis(buffer, slice(n_skip, None), axis_idx)
                 buffer_offset = buffer_offset[n_skip:]
                 shift_deficit -= n_skip
 
@@ -151,20 +159,20 @@ def windowing(
         # How we update .data and .axes[newaxis] depends on the windowing mode.
         if b_1to1:
             # one-to-one mode -- Each send yields exactly one window containing only the most recent samples.
-            buffer = slice_along_axis(buffer, np.s_[-window_samples:], axis_idx)
+            buffer = slice_along_axis(buffer, slice(-window_samples, None), axis_idx)
             out_dat = np.expand_dims(buffer, axis=axis_idx)
             out_newaxis = replace(out_newaxis, offset=buffer_offset[-window_samples])
         elif buffer.shape[axis_idx] >= window_samples:
             # Deterministic window shifts.
             out_dat = sliding_win_oneaxis(buffer, window_samples, axis_idx)
-            out_dat = slice_along_axis(out_dat, np.s_[::window_shift_samples], axis_idx)
+            out_dat = slice_along_axis(out_dat, slice(None, None, window_shift_samples), axis_idx)
             offset_view = sliding_win_oneaxis(buffer_offset, window_samples, 0)[::window_shift_samples]
             out_newaxis = replace(out_newaxis, offset=offset_view[0, 0])
 
             # Drop expired beginning of buffer and update shift_deficit
             multi_shift = window_shift_samples * out_dat.shape[axis_idx]
             shift_deficit = max(0, multi_shift - buffer.shape[axis_idx])
-            buffer = slice_along_axis(buffer, np.s_[multi_shift:], axis_idx)
+            buffer = slice_along_axis(buffer, slice(multi_shift, None), axis_idx)
         else:
             # Not enough data to make a new window. Return empty data.
             empty_data_shape = (
@@ -188,16 +196,16 @@ def windowing(
 
 
 class WindowSettings(ez.Settings):
-    axis: Optional[str] = None
-    newaxis: Optional[str] = None  # new axis for output. No new axes if None
-    window_dur: Optional[float] = None  # Sec. passthrough if None
-    window_shift: Optional[float] = None  # Sec. Use "1:1 mode" if None
+    axis: typing.Optional[str] = None
+    newaxis: typing.Optional[str] = None  # new axis for output. No new axes if None
+    window_dur: typing.Optional[float] = None  # Sec. passthrough if None
+    window_shift: typing.Optional[float] = None  # Sec. Use "1:1 mode" if None
     zero_pad_until: str = "full"  # "full", "shift", "input", "none"
 
 
 class WindowState(ez.State):
     cur_settings: WindowSettings
-    gen: Generator
+    gen: typing.Generator
 
 
 class Window(GenAxisArray):
@@ -218,7 +226,7 @@ class Window(GenAxisArray):
 
     @ez.subscriber(INPUT_SIGNAL, zero_copy=True)
     @ez.publisher(OUTPUT_SIGNAL)
-    async def on_signal(self, msg: AxisArray) -> AsyncGenerator:
+    async def on_signal(self, msg: AxisArray) -> typing.AsyncGenerator:
         try:
             out_msg = self.STATE.gen.send(msg)
             if out_msg.data.size > 0:

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -31,6 +31,9 @@ def test_affine_generator():
     expected_out = in_dat @ weights.T
     # Same result: expected_out = np.vstack([(step[None, :] * weights).sum(axis=1) for step in in_dat])
 
+    # Send again just to make sure the generator doesn't crash
+    _ = gen.send(msg_in)
+
     gen = affine_transform(weights=csv_path, axis="ch", right_multiply=False)
     msg_out = gen.send(msg_in)
     assert np.allclose(msg_out.data, expected_out)

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -13,17 +13,17 @@ def test_affine_generator():
     n_times = 13
     n_chans = 64
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
-    backup = [copy.deepcopy(axis_arr_in)]
+    backup = [copy.deepcopy(msg_in)]
 
     gen = affine_transform(weights=np.eye(n_chans), axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert ax_arr_out.data.shape == in_dat.shape
-    assert np.allclose(ax_arr_out.data, in_dat)
-    assert not np.may_share_memory(ax_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert msg_out.data.shape == in_dat.shape
+    assert np.allclose(msg_out.data, in_dat)
+    assert not np.may_share_memory(msg_out.data, in_dat)
 
-    assert_messages_equal([axis_arr_in], backup)
+    assert_messages_equal([msg_in], backup)
 
     # Test with weights from a CSV file.
     csv_path = Path(__file__).parent / "resources" / "xform.csv"
@@ -32,55 +32,55 @@ def test_affine_generator():
     # Same result: expected_out = np.vstack([(step[None, :] * weights).sum(axis=1) for step in in_dat])
 
     gen = affine_transform(weights=csv_path, axis="ch", right_multiply=False)
-    ax_arr_out = gen.send(axis_arr_in)
-    assert np.allclose(ax_arr_out.data, expected_out)
+    msg_out = gen.send(msg_in)
+    assert np.allclose(msg_out.data, expected_out)
 
     # Try again as str, not Path
     gen = affine_transform(weights=str(csv_path), axis="ch", right_multiply=False)
-    ax_arr_out = gen.send(axis_arr_in)
-    assert np.allclose(ax_arr_out.data, expected_out)
+    msg_out = gen.send(msg_in)
+    assert np.allclose(msg_out.data, expected_out)
 
     # Try again as direct ndarray
     gen = affine_transform(weights=weights, axis="ch", right_multiply=False)
-    ax_arr_out = gen.send(axis_arr_in)
-    assert np.allclose(ax_arr_out.data, expected_out)
+    msg_out = gen.send(msg_in)
+    assert np.allclose(msg_out.data, expected_out)
 
     # One more time, but we pre-transpose the weights and do not override right_multiply
     gen = affine_transform(weights=weights.T, axis="ch", right_multiply=True)
-    ax_arr_out = gen.send(axis_arr_in)
-    assert np.allclose(ax_arr_out.data, expected_out)
+    msg_out = gen.send(msg_in)
+    assert np.allclose(msg_out.data, expected_out)
 
 
 def test_affine_passthrough():
     n_times = 13
     n_chans = 64
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
-    backup = [copy.deepcopy(axis_arr_in)]
+    backup = [copy.deepcopy(msg_in)]
 
     gen = affine_transform(weights="passthrough", axis="does not matter")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert ax_arr_out.data is in_dat  # This is not desirable in ezmsg pipeline but fine for the generator
-    assert_messages_equal([ax_arr_out], backup)
+    msg_out = gen.send(msg_in)
+    assert msg_out.data is in_dat  # This is not desirable in ezmsg pipeline but fine for the generator
+    assert_messages_equal([msg_out], backup)
 
 
 def test_common_rereference():
     n_times = 300
     n_chans = 64
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
-    backup = [copy.deepcopy(axis_arr_in)]
+    backup = [copy.deepcopy(msg_in)]
 
     gen = common_rereference(mode="mean", axis="ch", include_current=True)
-    axis_arr_out = gen.send(axis_arr_in)
+    msg_out = gen.send(msg_in)
     assert np.array_equal(
-        axis_arr_out.data,
-        axis_arr_in.data - np.mean(axis_arr_in.data, axis=1, keepdims=True),
+        msg_out.data,
+        msg_in.data - np.mean(msg_in.data, axis=1, keepdims=True),
     )
 
-    assert_messages_equal([axis_arr_in], backup)
+    assert_messages_equal([msg_in], backup)
 
     # Use a slow deliberate way of calculating the CAR uniquely for each channel, excluding itself.
     #  common_rereference uses a faster way of doing this, but we test against something intuitive.
@@ -89,13 +89,13 @@ def test_common_rereference():
         idx = np.arange(n_chans)
         idx = np.hstack((idx[:ch_ix], idx[ch_ix + 1 :]))
         expected_out.append(
-            axis_arr_in.data[..., ch_ix] - np.mean(axis_arr_in.data[..., idx], axis=1)
+            msg_in.data[..., ch_ix] - np.mean(msg_in.data[..., idx], axis=1)
         )
     expected_out = np.stack(expected_out).T
 
     gen = common_rereference(mode="mean", axis="ch", include_current=False)
-    axis_arr_out = gen.send(axis_arr_in)  # 41 us
-    assert np.allclose(axis_arr_out.data, expected_out)
+    msg_out = gen.send(msg_in)  # 41 us
+    assert np.allclose(msg_out.data, expected_out)
 
     # Instead of CAR, we could use affine_transform with weights that reproduce CAR.
     # However, this method is 30x slower than above. (Actual difference varies depending on data shape).
@@ -103,17 +103,17 @@ def test_common_rereference():
         weights = -np.ones((n_chans, n_chans)) / (n_chans - 1)
         np.fill_diagonal(weights, 1)
         gen = affine_transform(weights=weights, axis="ch")
-        axis_arr_out = gen.send(axis_arr_in)
-        assert np.allclose(axis_arr_out.data, expected_out)
+        msg_out = gen.send(msg_in)
+        assert np.allclose(msg_out.data, expected_out)
 
 
 def test_car_passthrough():
     n_times = 300
     n_chans = 64
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
     gen = common_rereference(mode="passthrough")
-    axis_arr_out = gen.send(axis_arr_in)
-    assert np.array_equal(axis_arr_out.data, in_dat)
-    assert not np.may_share_memory(axis_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert np.array_equal(msg_out.data, in_dat)
+    assert not np.may_share_memory(msg_out.data, in_dat)

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -40,7 +40,8 @@ def test_downsample_core(block_size: int, factor: int):
             msg = AxisArray(
                 data=msg_sig,
                 dims=["time", "ch", "feat"],
-                axes=frozendict({"time": AxisArray.Axis.TimeAxis(fs=in_fs, offset=msg_offs)})
+                axes=frozendict({"time": AxisArray.Axis.TimeAxis(fs=in_fs, offset=msg_offs)}),
+                key="test_downsample_core"
             )
             yield msg
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -27,13 +27,13 @@ def test_clip(a_min: float, a_max: float):
     n_times = 130
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
     proc = clip(a_min, a_max)
-    axis_arr_out = proc.send(axis_arr_in)
+    msg_out = proc.send(msg_in)
 
-    assert all(axis_arr_out.data[np.where(in_dat < a_min)] == a_min)
-    assert all(axis_arr_out.data[np.where(in_dat > a_max)] == a_max)
+    assert all(msg_out.data[np.where(in_dat < a_min)] == a_min)
+    assert all(msg_out.data[np.where(in_dat > a_max)] == a_max)
 
 
 @pytest.mark.parametrize("value", [-100, 0, 100])
@@ -42,21 +42,21 @@ def test_const_difference(value: float, subtrahend: bool):
     n_times = 130
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
     proc = const_difference(value, subtrahend)
-    axis_arr_out = proc.send(axis_arr_in)
-    assert np.array_equal(axis_arr_out.data, (in_dat - value) if subtrahend else (value - in_dat))
+    msg_out = proc.send(msg_in)
+    assert np.array_equal(msg_out.data, (in_dat - value) if subtrahend else (value - in_dat))
 
 
 def test_invert():
     n_times = 130
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
     proc = invert()
-    axis_arr_out = proc.send(axis_arr_in)
-    assert np.array_equal(axis_arr_out.data, 1 / in_dat)
+    msg_out = proc.send(msg_in)
+    assert np.array_equal(msg_out.data, 1 / in_dat)
 
 
 @pytest.mark.parametrize("base", [np.e, 2, 10])
@@ -64,10 +64,10 @@ def test_log(base: float):
     n_times = 130
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
     proc = log(base)
-    axis_arr_out = proc.send(axis_arr_in)
-    assert np.array_equal(axis_arr_out.data, np.log(in_dat) / np.log(base))
+    msg_out = proc.send(msg_in)
+    assert np.array_equal(msg_out.data, np.log(in_dat) / np.log(base))
 
 
 @pytest.mark.parametrize("scale_factor", [0.1, 0.5, 2.0, 10.0])
@@ -75,10 +75,10 @@ def test_scale(scale_factor: float):
     n_times = 130
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
 
     proc = scale(scale_factor)
-    axis_arr_out = proc.send(axis_arr_in)
+    msg_out = proc.send(msg_in)
 
-    assert axis_arr_out.data.shape == (n_times, n_chans)
-    assert np.array_equal(axis_arr_out.data, in_dat * scale_factor)
+    assert msg_out.data.shape == (n_times, n_chans)
+    assert np.array_equal(msg_out.data, in_dat * scale_factor)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,6 +1,5 @@
 import copy
 
-from frozendict import frozendict
 import numpy as np
 from ezmsg.util.messages.axisarray import AxisArray
 
@@ -27,53 +26,53 @@ def test_slicer_generator():
     n_times = 13
     n_chans = 255
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(in_dat, dims=["time", "ch"])
-    backup = [copy.deepcopy(axis_arr_in)]
+    msg_in = AxisArray(in_dat, dims=["time", "ch"])
+    backup = [copy.deepcopy(msg_in)]
 
     gen = slicer(selection=":2", axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert_messages_equal([axis_arr_in], backup)
-    assert ax_arr_out.data.shape == (n_times, 2)
-    assert np.array_equal(ax_arr_out.data, in_dat[:, :2])
-    assert np.may_share_memory(ax_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert msg_out.data.shape == (n_times, 2)
+    assert np.array_equal(msg_out.data, in_dat[:, :2])
+    assert np.may_share_memory(msg_out.data, in_dat)
 
     gen = slicer(selection="::3", axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert_messages_equal([axis_arr_in], backup)
-    assert ax_arr_out.data.shape == (n_times, n_chans // 3)
-    assert np.array_equal(ax_arr_out.data, in_dat[:, ::3])
-    assert np.may_share_memory(ax_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert msg_out.data.shape == (n_times, n_chans // 3)
+    assert np.array_equal(msg_out.data, in_dat[:, ::3])
+    assert np.may_share_memory(msg_out.data, in_dat)
 
     gen = slicer(selection="4:64", axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert_messages_equal([axis_arr_in], backup)
-    assert ax_arr_out.data.shape == (n_times, 60)
-    assert np.array_equal(ax_arr_out.data, in_dat[:, 4:64])
-    assert np.may_share_memory(ax_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert msg_out.data.shape == (n_times, 60)
+    assert np.array_equal(msg_out.data, in_dat[:, 4:64])
+    assert np.may_share_memory(msg_out.data, in_dat)
 
     # Discontiguous slices leads to a copy
     gen = slicer(selection="1, 3:5", axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert_messages_equal([axis_arr_in], backup)
-    assert np.array_equal(ax_arr_out.data, axis_arr_in.data[:, [1, 3, 4]])
-    assert not np.may_share_memory(ax_arr_out.data, in_dat)
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert np.array_equal(msg_out.data, msg_in.data[:, [1, 3, 4]])
+    assert not np.may_share_memory(msg_out.data, in_dat)
 
 
 def test_slicer_gen_drop_dim():
     n_times = 50
     n_chans = 10
     in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
-    axis_arr_in = AxisArray(
+    msg_in = AxisArray(
         in_dat,
         dims=["time", "ch"],
-        axes=frozendict({
+        axes={
             "time": AxisArray.Axis.TimeAxis(fs=100.0, offset=0.1),
-        })
+        }
     )
-    backup = [copy.deepcopy(axis_arr_in)]
+    backup = [copy.deepcopy(msg_in)]
 
     gen = slicer(selection="5", axis="ch")
-    ax_arr_out = gen.send(axis_arr_in)
-    assert_messages_equal([axis_arr_in], backup)
-    assert ax_arr_out.data.shape == (n_times,)
-    assert np.array_equal(ax_arr_out.data, axis_arr_in.data[:, 5])
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert msg_out.data.shape == (n_times,)
+    assert np.array_equal(msg_out.data, msg_in.data[:, 5])

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -6,7 +6,6 @@ import typing
 
 import numpy as np
 import pytest
-from frozendict import frozendict
 
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
@@ -143,11 +142,11 @@ async def test_acounter(
     messages = [await agen.__anext__() for _ in range(target_messages)]
 
     # Test contents of individual messages
-    for ax_arr in messages:
-        assert type(ax_arr) is AxisArray
-        assert ax_arr.data.shape == (block_size, n_ch)
-        assert "time" in ax_arr.axes
-        assert ax_arr.axes["time"].gain == 1 / fs
+    for msg in messages:
+        assert type(msg) is AxisArray
+        assert msg.data.shape == (block_size, n_ch)
+        assert "time" in msg.axes
+        assert msg.axes["time"].gain == 1 / fs
 
     agg = AxisArray.concatenate(*messages, dim="time")
 
@@ -286,11 +285,7 @@ def test_sin_gen(
     for split_dat in np.array_split(np.arange(n_samples)[:, None], n_msgs, axis=axis_idx):
         _time_axis = AxisArray.Axis.TimeAxis(fs=srate, offset=float(split_dat[0, 0]))
         messages.append(
-            AxisArray(
-                split_dat,
-                dims=["time", "ch"],
-                axes=frozendict({"time": _time_axis})
-            )
+            AxisArray(split_dat, dims=["time", "ch"], axes={"time": _time_axis})
         )
 
     def f_test(t): return amp * np.sin(2 * np.pi * freq * t + phase)


### PR DESCRIPTION
Fixes #21 

There are a couple formatting changes in here (axis_arr_in --> msg_in; from typing import X, Y --> import typing) that aren't really related to the main topic.

The main topic is that this PR enables nodes to detect changes to inputs that invalidate state variables then recalculate state variables. The nodes can then live on in the graph despite their inputs changing. This has the downside that there are now more checks happening on EVERY message, when input changes should ideally be infrequent.

I kind of need this for a particular workflow -- ezmsg is running as a service and the pipeline source is an LSLInlet node that might change the stream it is pulling from. Resetting the whole pipeline is proving to be very slow.

I'm considering adding another argument to each of these nodes like `detect_change: bool = False` and simply not doing the reset check if that is False. (I'm open to other name suggestions. `input_changeable`, `adapt_input`, etc.). But before I do that, I want to profile this PR so far, compared to upstream, and see how much of a performance penalty these comparisons really are.