### PR TITLE
Fix spectrogram windowing zero_pad_until parameter.

### DIFF
--- a/src/ezmsg/sigproc/spectrogram.py
+++ b/src/ezmsg/sigproc/spectrogram.py
@@ -39,7 +39,11 @@ def spectrogram(
 
     pipeline = compose(
         windowing(
-            axis="time", newaxis="win", window_dur=window_dur, window_shift=window_shift
+            axis="time",
+            newaxis="win",
+            window_dur=window_dur,
+            window_shift=window_shift,
+            zero_pad_until="shift" if window_shift is not None else "input",
         ),
         spectrum(axis="time", window=window, transform=transform, output=output),
         modify_axis(name_map={"win": "time"}),


### PR DESCRIPTION
This makes spectrogram's use of the windowing node deterministic when window_shift is not None, with a side benefit of suppressing a warning.

Note: This really only impacts offline pipelines when the chunk-size was non-deterministic. In all other scenarios, this will have no effect. Unit tests still pass.