### PR TITLE
slicer - Briefly convert labels to ndarray before slicing

### DIFF
--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -98,7 +98,8 @@ def slicer(
                 and hasattr(msg_in.axes[axis], "labels")
                 and len(msg_in.axes[axis].labels) > 0
             ):
-                new_labels = msg_in.axes[axis].labels[_slice]
+                in_labels = np.array(msg_in.axes[axis].labels)
+                new_labels = in_labels[_slice].tolist()
                 new_axis = replace(msg_in.axes[axis], labels=new_labels)
 
         replace_kwargs = {}

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,11 +1,29 @@
 import copy
+from dataclasses import dataclass, field
+import typing
 
 import numpy as np
 from ezmsg.util.messages.axisarray import AxisArray
+import pytest
 
 from ezmsg.sigproc.slicer import slicer, parse_slice
 
 from util import assert_messages_equal
+
+
+@dataclass
+class CustomAxis(AxisArray.Axis):
+    labels: typing.List[str] = field(default_factory=lambda: [])
+
+    @classmethod
+    def SpaceAxis(
+        cls, labels: typing.List[str]
+    ):  # , locs: typing.Optional[npt.NDArray] = None):
+        return cls(unit="mm", labels=labels)
+
+
+# Monkey-patch AxisArray with our customized Axis
+AxisArray.Axis = CustomAxis
 
 
 def test_parse_slice():
@@ -76,3 +94,31 @@ def test_slicer_gen_drop_dim():
     assert_messages_equal([msg_in], backup)
     assert msg_out.data.shape == (n_times,)
     assert np.array_equal(msg_out.data, msg_in.data[:, 5])
+
+
+@pytest.mark.parametrize("selection", [":3", "0, 1, 2"])
+def test_slicer_label(selection: str):
+    """
+    We use the monkey-patched AxisArray `labels` field that exists in several other ezmsg
+    modules that generate data.
+    """
+    n_times = 50
+    n_chans = 10
+    in_dat = np.arange(n_times * n_chans).reshape(n_times, n_chans)
+    msg_in = AxisArray(
+        in_dat,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.Axis.TimeAxis(fs=100.0, offset=0.1),
+            "ch": CustomAxis.SpaceAxis(labels=[str(_) for _ in range(n_chans)]),
+        },
+    )
+    backup = [copy.deepcopy(msg_in)]
+
+    gen = slicer(selection=selection, axis="ch")
+    # gen = slicer(selection=":3", axis="ch")
+    msg_out = gen.send(msg_in)
+    assert_messages_equal([msg_in], backup)
+    assert msg_out.data.shape == (n_times, 3)
+    assert np.array_equal(msg_out.data, msg_in.data[:, :3])
+    assert msg_out.axes["ch"].labels == msg_in.axes["ch"].labels[:3]


### PR DESCRIPTION
Some selections -- i.e., those that resulted in the slice being an array of integers -- would not slice the labels which are a simple list. With this change, we convert the labels to an array before slicing, then back to a list.