### PR TITLE
`GenAxisArray` -- Check data is non-empty with `prod(data.shape)`

### DIFF
--- a/src/ezmsg/sigproc/base.py
+++ b/src/ezmsg/sigproc/base.py
@@ -1,3 +1,4 @@
+import math
 import traceback
 import typing
 
@@ -30,7 +31,7 @@ class GenAxisArray(ez.Unit):
     async def on_signal(self, message: AxisArray) -> typing.AsyncGenerator:
         try:
             ret = self.STATE.gen.send(message)
-            if ret.data.size > 0:
+            if math.prod(ret.data.shape) > 0:
                 yield self.OUTPUT_SIGNAL, ret
         except (StopIteration, GeneratorExit):
             ez.logger.debug(f"Generator closed in {self.address}")


### PR DESCRIPTION
This change modifies the GenAxisArray(ez.Unit) class to use a different method to check the shape of the message before determining whether to pass it on.

The previous method checked that `data.size > 0`, however this fails on sparse arrays that have a shape to them but no nonzero values. The point of the check is to see if the array has no dimensionality on the iterated axis (usually "time"), not whether it has non-zero entries. In the case of sparse arrays with no events, we still want to pass those through to make sure downstream processors that are calculating rates are still working correctly.

I tried a few options. None are quite as fast as `data.size > 0`, but the chosen method was the next fastest.

```Python
temp = np.zeros((3, 4, 5))
timeit.timeit(lambda: temp.size > 0, number=1_000_000)
0.10326883299998713
timeit.timeit(lambda: math.prod(temp.shape) > 0, number=1_000_000)
0.17543374999999628
timeit.timeit(lambda: temp.shape[-1] > 0, number=1_000_000)
0.12488395900000171
timeit.timeit(lambda: all([_ > 0 for _ in temp.shape]), number=1_000_000)
0.3415230840000163
timeit.timeit(lambda: np.prod(temp.shape) > 0, number=1_000_000)
2.319005000000004
```

This block of code doesn't know the important axis to check so the option with `temp.shape` is not a realistic option, just useful for comparison.

The difference between the old method and the new method is 10s of nanoseconds per check so I think we're still OK performance wise ;)