### PR TITLE
Refactor filter 

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os:
           - "ubuntu-latest"
           - "windows-latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10.15"
 dynamic = ["version"]
 dependencies = [
     "ezmsg>=3.6.0",

--- a/src/ezmsg/sigproc/butterworthfilter.py
+++ b/src/ezmsg/sigproc/butterworthfilter.py
@@ -99,7 +99,7 @@ def butter_design_fun(
             fs=fs,
             output=coef_type,
         )
-    if coef_type == "ba":
+    if coefs is not None and coef_type == "ba":
         coefs = normalize(*coefs)
     return coefs
 

--- a/src/ezmsg/sigproc/butterworthfilter.py
+++ b/src/ezmsg/sigproc/butterworthfilter.py
@@ -3,6 +3,7 @@ import typing
 
 import scipy.signal
 from ezmsg.util.messages.axisarray import AxisArray
+from scipy.signal import normalize
 
 from .filter import (
     FilterBaseSettings,
@@ -98,6 +99,8 @@ def butter_design_fun(
             fs=fs,
             output=coef_type,
         )
+    if coef_type == "ba":
+        coefs = normalize(*coefs)
     return coefs
 
 

--- a/src/ezmsg/sigproc/butterworthfilter.py
+++ b/src/ezmsg/sigproc/butterworthfilter.py
@@ -35,6 +35,11 @@ class ButterworthFilterSettings(FilterBaseSettings):
     or if this is less than `cuton` then this is the beginning of the bandstop. 
     """
 
+    wn_hz: bool = True
+    """
+    Set False if provided Wn are normalized from 0 to 1, where 1 is the Nyquist frequency
+    """
+
     def filter_specs(
         self,
     ) -> typing.Optional[
@@ -68,6 +73,7 @@ def butter_design_fun(
     cuton: typing.Optional[float] = None,
     cutoff: typing.Optional[float] = None,
     coef_type: str = "ba",
+    wn_hz: bool = True,
 ) -> typing.Optional[FilterCoefsMultiType]:
     """
     See :obj:`ButterworthFilterSettings.filter_specs` for an explanation of specifying different
@@ -81,6 +87,7 @@ def butter_design_fun(
         cuton: Corner frequency of the filter in Hz.
         cutoff: Corner frequency of the filter in Hz.
         coef_type: "ba", "sos", or "zpk"
+        wn_hz: Set False if provided Wn are normalized from 0 to 1, where 1 is the Nyquist frequency
 
     Returns:
         The filter coefficients as a tuple of (b, a) for coef_type "ba", or as a single ndarray for "sos",
@@ -96,7 +103,7 @@ def butter_design_fun(
             order,
             Wn=cutoffs,
             btype=btype,
-            fs=fs,
+            fs=fs if wn_hz else None,
             output=coef_type,
         )
     if coefs is not None and coef_type == "ba":

--- a/src/ezmsg/sigproc/cheby.py
+++ b/src/ezmsg/sigproc/cheby.py
@@ -2,6 +2,7 @@ import functools
 import typing
 
 import scipy.signal
+from scipy.signal import normalize
 
 from .filter import (
     FilterBaseSettings,
@@ -88,6 +89,8 @@ def cheby_design_fun(
                 output=coef_type,
                 fs=fs,
             )
+    if coef_type == "ba":
+        coefs = normalize(*coefs)
     return coefs
 
 

--- a/src/ezmsg/sigproc/cheby.py
+++ b/src/ezmsg/sigproc/cheby.py
@@ -89,7 +89,7 @@ def cheby_design_fun(
                 output=coef_type,
                 fs=fs,
             )
-    if coef_type == "ba":
+    if coefs is not None and coef_type == "ba":
         coefs = normalize(*coefs)
     return coefs
 

--- a/src/ezmsg/sigproc/cheby.py
+++ b/src/ezmsg/sigproc/cheby.py
@@ -28,7 +28,7 @@ class ChebyshevFilterSettings(FilterBaseSettings):
     """
     A scalar or length-2 sequence giving the critical frequencies.
     For Type I filters, this is the point in the transition band at which the gain first drops below -rp.
-    For digital filters, Wn are in the same units as fs.
+    For digital filters, Wn are in the same units as fs unless wn_hz is False.
     For analog filters, Wn is an angular frequency (e.g., rad/s).
     """
 
@@ -47,6 +47,11 @@ class ChebyshevFilterSettings(FilterBaseSettings):
     Which type of Chebyshev filter to design. Either "cheby1" or "cheby2".
     """
 
+    wn_hz: bool = True
+    """
+    Set False if provided Wn are normalized from 0 to 1, where 1 is the Nyquist frequency
+    """
+
 
 def cheby_design_fun(
     fs: float,
@@ -57,6 +62,7 @@ def cheby_design_fun(
     analog: bool = False,
     coef_type: str = "ba",
     cheby_type: str = "cheby1",
+    wn_hz: bool = True,
 ) -> typing.Optional[FilterCoefsMultiType]:
     """
     Chebyshev type I and type II digital and analog filter design.
@@ -77,7 +83,7 @@ def cheby_design_fun(
                 btype=btype,
                 analog=analog,
                 output=coef_type,
-                fs=fs,
+                fs=fs if wn_hz else None,
             )
         elif cheby_type == "cheby2":
             coefs = scipy.signal.cheby2(
@@ -109,4 +115,5 @@ class ChebyshevFilter(FilterBase):
             analog=self.SETTINGS.analog,
             coef_type=self.SETTINGS.coef_type,
             cheby_type=self.SETTINGS.cheby_type,
+            wn_hz=self.SETTINGS.wn_hz,
         )

--- a/src/ezmsg/sigproc/cheby.py
+++ b/src/ezmsg/sigproc/cheby.py
@@ -1,0 +1,109 @@
+import functools
+import typing
+
+import scipy.signal
+
+from .filter import (
+    FilterBaseSettings,
+    FilterCoefsMultiType,
+    FilterBase,
+)
+
+
+class ChebyshevFilterSettings(FilterBaseSettings):
+    """Settings for :obj:`ButterworthFilter`."""
+
+    order: int = 0
+    """
+    Filter order
+    """
+
+    ripple_tol: typing.Optional[float] = None
+    """
+    The maximum ripple allowed below unity gain in the passband. Specified in decibels, as a positive number.
+    """
+
+    Wn: typing.Optional[typing.Union[float, typing.Tuple[float, float]]] = None
+    """
+    A scalar or length-2 sequence giving the critical frequencies.
+    For Type I filters, this is the point in the transition band at which the gain first drops below -rp.
+    For digital filters, Wn are in the same units as fs.
+    For analog filters, Wn is an angular frequency (e.g., rad/s).
+    """
+
+    btype: str = "lowpass"
+    """
+    {‘lowpass’, ‘highpass’, ‘bandpass’, ‘bandstop’}
+    """
+
+    analog: bool = False
+    """
+    When True, return an analog filter, otherwise a digital filter is returned.
+    """
+
+    cheby_type: str = "cheby1"
+    """
+    Which type of Chebyshev filter to design. Either "cheby1" or "cheby2".
+    """
+
+
+def cheby_design_fun(
+    fs: float,
+    order: int = 0,
+    ripple_tol: typing.Optional[float] = None,
+    Wn: typing.Optional[typing.Union[float, typing.Tuple[float, float]]] = None,
+    btype: str = "lowpass",
+    analog: bool = False,
+    coef_type: str = "ba",
+    cheby_type: str = "cheby1",
+) -> typing.Optional[FilterCoefsMultiType]:
+    """
+    Chebyshev type I and type II digital and analog filter design.
+    Design an `order`th-order digital or analog Chebyshev type I or type II filter and return the filter coefficients.
+    See :obj:`ChebyFilterSettings` for argument description.
+
+    Returns:
+        The filter coefficients as a tuple of (b, a) for coef_type "ba", or as a single ndarray for "sos",
+        or (z, p, k) for "zpk".
+    """
+    coefs = None
+    if order > 0:
+        if cheby_type == "cheby1":
+            coefs = scipy.signal.cheby1(
+                order,
+                ripple_tol,
+                Wn,
+                btype=btype,
+                analog=analog,
+                output=coef_type,
+                fs=fs,
+            )
+        elif cheby_type == "cheby2":
+            coefs = scipy.signal.cheby2(
+                order,
+                ripple_tol,
+                Wn,
+                btype=btype,
+                analog=analog,
+                output=coef_type,
+                fs=fs,
+            )
+    return coefs
+
+
+class ChebyshevFilter(FilterBase):
+    SETTINGS = ChebyshevFilterSettings
+
+    def design_filter(
+        self,
+    ) -> typing.Callable[[float], typing.Optional[FilterCoefsMultiType]]:
+        return functools.partial(
+            cheby_design_fun,
+            order=self.SETTINGS.order,
+            ripple_tol=self.SETTINGS.ripple_tol,
+            Wn=self.SETTINGS.Wn,
+            btype=self.SETTINGS.btype,
+            analog=self.SETTINGS.analog,
+            coef_type=self.SETTINGS.coef_type,
+            cheby_type=self.SETTINGS.cheby_type,
+        )

--- a/src/ezmsg/sigproc/decimate.py
+++ b/src/ezmsg/sigproc/decimate.py
@@ -26,14 +26,14 @@ class Decimate(ez.Collection):
         if self.SETTINGS.factor < 1:
             raise ValueError("Decimation factor must be >= 1 (no decimation")
         elif self.SETTINGS.factor == 1:
-            filt = FilterCoefficients()
+            coefs = FilterCoefficients()
         else:
             # See scipy.signal.decimate for IIR Filter Condition
             b, a = scipy.signal.cheby1(8, 0.05, 0.8 / self.SETTINGS.factor)
             system = scipy.signal.dlti(b, a)
-            filt = FilterCoefficients(b=system.num, a=system.den)  # type: ignore
+            coefs = FilterCoefficients(b=system.num, a=system.den)  # type: ignore
 
-        self.FILTER.apply_settings(FilterSettings(filt=filt))
+        self.FILTER.apply_settings(FilterSettings(coefs=coefs))
 
     def network(self) -> ez.NetworkDefinition:
         return (

--- a/tests/test_butter.py
+++ b/tests/test_butter.py
@@ -31,10 +31,9 @@ def test_butterworth_legacy_filter_settings(cutoff: float, cuton: float, order: 
             If cuton is larger than cutoff we assume bandstop.
         order (int): The order of the filter.
     """
-    settings_obj = LegacyButterSettings(
-        axis="time", fs=500, order=order, cuton=cuton, cutoff=cutoff
-    )
-    btype, Wn = settings_obj.filter_specs()
+    btype, Wn = LegacyButterSettings(
+        order=order, cuton=cuton, cutoff=cutoff
+    ).filter_specs()
     if cuton is None:
         assert btype == "lowpass"
         assert Wn == cutoff
@@ -98,7 +97,7 @@ def test_butterworth(
 
     # Calculate Expected Result
     btype, Wn = LegacyButterSettings(
-        axis="time", fs=500, order=order, cuton=cuton, cutoff=cutoff
+        order=order, cuton=cuton, cutoff=cutoff
     ).filter_specs()
     coefs = scipy.signal.butter(order, Wn, btype=btype, output=coef_type, fs=fs)
     tmp_dat = np.moveaxis(in_dat, time_ax, -1)
@@ -115,7 +114,7 @@ def test_butterworth(
         if n_dims == 3:
             zi = np.tile(zi[:, None, None, :], (1, n_freqs, n_chans, 1))
         out_dat, _ = scipy.signal.sosfilt(coefs, tmp_dat, zi=zi)
-    out_dat = np.moveaxis(out_dat, -1, time_ax)
+    expected = np.moveaxis(out_dat, -1, time_ax)
 
     # Split the data into multiple messages
     n_seen = 0
@@ -143,7 +142,7 @@ def test_butterworth(
     )
 
     result = np.concatenate([gen.send(_).data for _ in messages], axis=time_ax)
-    assert np.allclose(result, out_dat)
+    assert np.allclose(result, expected)
 
 
 def test_butterworth_empty_msg():

--- a/tests/test_decimate.py
+++ b/tests/test_decimate.py
@@ -15,7 +15,7 @@ from ezmsg.sigproc.synth import EEGSynth
 from util import get_test_fn
 
 
-@pytest.mark.parametrize("factor", [1.0, 5.0, 0.0])
+@pytest.mark.parametrize("factor", [5.0, 1.0])
 def test_decimate_system(factor: float):
     test_filename = get_test_fn()
     test_filename_raw = test_filename.parent / (
@@ -40,12 +40,8 @@ def test_decimate_system(factor: float):
         (comps["SRC"].OUTPUT_SIGNAL, comps["LOGRAW"].INPUT_MESSAGE),
         (comps["LOGFILT"].OUTPUT_MESSAGE, comps["TERM"].INPUT_MESSAGE),
     )
-    if factor < 1:
-        with pytest.raises(ValueError):
-            ez.run(components=comps, connections=conns)
-        return
-    else:
-        ez.run(components=comps, connections=conns)
+    ez.run(components=comps, connections=conns)
+    # Unfortunately, we can't test the factor < 1 error because MessageLogger raises its own 0-msg error.
 
     messages: typing.List[AxisArray] = [_ for _ in message_log(test_filename)]
     assert len(messages) >= n_total
@@ -63,3 +59,9 @@ def test_decimate_system(factor: float):
         expected = antialiased[:: int(factor)]
 
     assert np.allclose(outputs.data, expected)
+    """
+    import matplotlib.pyplot as plt
+    plt.plot(expected[:, 0])
+    plt.plot(outputs.data[:, 0])
+    plt.show()
+    """

--- a/tests/test_decimate.py
+++ b/tests/test_decimate.py
@@ -59,9 +59,3 @@ def test_decimate_system(factor: float):
         expected = antialiased[:: int(factor)]
 
     assert np.allclose(outputs.data, expected)
-    """
-    import matplotlib.pyplot as plt
-    plt.plot(expected[:, 0])
-    plt.plot(outputs.data[:, 0])
-    plt.show()
-    """

--- a/tests/test_decimate.py
+++ b/tests/test_decimate.py
@@ -1,0 +1,65 @@
+import typing
+
+import pytest
+import numpy as np
+import scipy.signal
+import ezmsg.core as ez
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messagecodec import message_log
+from ezmsg.util.messagelogger import MessageLogger
+from ezmsg.util.terminate import TerminateOnTotal
+
+from ezmsg.sigproc.decimate import Decimate
+from ezmsg.sigproc.synth import EEGSynth
+
+from util import get_test_fn
+
+
+@pytest.mark.parametrize("factor", [1.0, 5.0, 0.0])
+def test_decimate_system(factor: float):
+    test_filename = get_test_fn()
+    test_filename_raw = test_filename.parent / (
+        test_filename.stem + "raw" + test_filename.suffix
+    )
+
+    fs = 500.0
+    n_ch = 8
+    n_time = 100
+    n_total = int(fs / n_time)  # 1 second of messages
+
+    comps = {
+        "SRC": EEGSynth(n_time=n_time, fs=fs, n_ch=n_ch, alpha_freq=10.5),
+        "DECIMATE": Decimate(axis="time", factor=factor),
+        "LOGRAW": MessageLogger(output=test_filename_raw),
+        "LOGFILT": MessageLogger(output=test_filename),
+        "TERM": TerminateOnTotal(n_total),
+    }
+    conns = (
+        (comps["SRC"].OUTPUT_SIGNAL, comps["DECIMATE"].INPUT_SIGNAL),
+        (comps["DECIMATE"].OUTPUT_SIGNAL, comps["LOGFILT"].INPUT_MESSAGE),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["LOGRAW"].INPUT_MESSAGE),
+        (comps["LOGFILT"].OUTPUT_MESSAGE, comps["TERM"].INPUT_MESSAGE),
+    )
+    if factor < 1:
+        with pytest.raises(ValueError):
+            ez.run(components=comps, connections=conns)
+        return
+    else:
+        ez.run(components=comps, connections=conns)
+
+    messages: typing.List[AxisArray] = [_ for _ in message_log(test_filename)]
+    assert len(messages) >= n_total
+    inputs = [_ for _ in message_log(test_filename_raw)]
+    inputs = AxisArray.concatenate(*inputs, dim="time")
+    outputs = AxisArray.concatenate(*messages, dim="time")
+
+    if factor == 1:
+        expected = inputs.data
+    else:
+        b, a = scipy.signal.cheby1(8, 0.05, 0.8 / factor)
+        b, a = scipy.signal.normalize(b, a)
+        zi = scipy.signal.lfilter_zi(b, a)[:, None]
+        antialiased, _ = scipy.signal.lfilter(b, a, inputs.data, axis=0, zi=zi)
+        expected = antialiased[:: int(factor)]
+
+    assert np.allclose(outputs.data, expected)

--- a/tests/test_filter_system.py
+++ b/tests/test_filter_system.py
@@ -1,0 +1,72 @@
+import typing
+
+import pytest
+import numpy as np
+import scipy.signal
+import ezmsg.core as ez
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messagecodec import message_log
+from ezmsg.util.messagelogger import MessageLogger
+from ezmsg.util.terminate import TerminateOnTotal
+
+from ezmsg.sigproc.butterworthfilter import ButterworthFilter
+from ezmsg.sigproc.synth import EEGSynth
+
+from util import get_test_fn
+
+
+@pytest.mark.parametrize("filter_type", ["butter"])  # , "cheby"])
+def test_filter_system(filter_type: str):
+    test_filename = get_test_fn()
+    test_filename_raw = test_filename.parent / (
+        test_filename.stem + "raw" + test_filename.suffix
+    )
+
+    order = 4
+    cuton = 5.0
+    cutoff = 20.0
+    fs = 500.0
+
+    # if filter_type == "butter":
+    filter_comp = ButterworthFilter(
+        order=order, cuton=cuton, cutoff=cutoff, axis="time"
+    )
+    # elif filter_type == "cheby":
+    #     # signal.cheby1(4, 5, 100, 'low', analog=True)
+    #     filter_comp = ChebyshevFilter()
+
+    comps = {
+        "SRC": EEGSynth(n_time=100, fs=fs, n_ch=8, alpha_freq=10.5),  # 2 seconds
+        "FILTER": filter_comp,
+        "LOGRAW": MessageLogger(output=test_filename_raw),
+        "LOGFILT": MessageLogger(output=test_filename),
+        "TERM": TerminateOnTotal(10),
+    }
+    conns = (
+        (comps["SRC"].OUTPUT_SIGNAL, comps["FILTER"].INPUT_SIGNAL),
+        (comps["FILTER"].OUTPUT_SIGNAL, comps["LOGFILT"].INPUT_MESSAGE),
+        (comps["SRC"].OUTPUT_SIGNAL, comps["LOGRAW"].INPUT_MESSAGE),
+        (comps["LOGFILT"].OUTPUT_MESSAGE, comps["TERM"].INPUT_MESSAGE),
+    )
+    ez.run(components=comps, connections=conns)
+
+    messages: typing.List[AxisArray] = [_ for _ in message_log(test_filename)]
+    assert len(messages) >= 10
+    inputs = AxisArray.concatenate(
+        *[_ for _ in message_log(test_filename_raw)], dim="time"
+    )
+    outputs = AxisArray.concatenate(*messages, dim="time")
+
+    # Calculate expected
+    coefs = scipy.signal.butter(
+        order,
+        Wn=(5.0, 20.0),
+        btype="bandpass",
+        fs=fs,
+        output="ba",
+    )
+    zi = scipy.signal.lfilter_zi(*coefs)[:, None]
+    expected, _ = scipy.signal.lfilter(
+        coefs[0], coefs[1], inputs.data, axis=inputs.get_axis_idx("time"), zi=zi
+    )
+    assert np.allclose(outputs.data, expected)

--- a/tests/test_filter_system.py
+++ b/tests/test_filter_system.py
@@ -18,13 +18,13 @@ from util import get_test_fn
 
 @pytest.mark.parametrize("filter_type", ["butter", "cheby1", "cheby2"])
 @pytest.mark.parametrize("coef_type", ["ba", "sos"])
-def test_filter_system(filter_type: str, coef_type: str):
+@pytest.mark.parametrize("order", [4, 0])
+def test_filter_system(filter_type: str, coef_type: str, order: int):
     test_filename = get_test_fn()
     test_filename_raw = test_filename.parent / (
         test_filename.stem + "raw" + test_filename.suffix
     )
 
-    order = 4
     cuton = 5.0
     cutoff = 20.0
     Wn = (cuton, cutoff)
@@ -70,6 +70,11 @@ def test_filter_system(filter_type: str, coef_type: str):
         *[_ for _ in message_log(test_filename_raw)], dim="time"
     )
     outputs = AxisArray.concatenate(*messages, dim="time")
+
+    if order == 0:
+        # Passthrough
+        assert np.allclose(outputs.data, inputs.data)
+        return
 
     # Calculate expected
     if filter_type == "butter":

--- a/tests/test_filter_system.py
+++ b/tests/test_filter_system.py
@@ -10,13 +10,15 @@ from ezmsg.util.messagelogger import MessageLogger
 from ezmsg.util.terminate import TerminateOnTotal
 
 from ezmsg.sigproc.butterworthfilter import ButterworthFilter
+from ezmsg.sigproc.cheby import ChebyshevFilter
 from ezmsg.sigproc.synth import EEGSynth
 
 from util import get_test_fn
 
 
-@pytest.mark.parametrize("filter_type", ["butter"])  # , "cheby"])
-def test_filter_system(filter_type: str):
+@pytest.mark.parametrize("filter_type", ["butter", "cheby1", "cheby2"])
+@pytest.mark.parametrize("coef_type", ["ba", "sos"])
+def test_filter_system(filter_type: str, coef_type: str):
     test_filename = get_test_fn()
     test_filename_raw = test_filename.parent / (
         test_filename.stem + "raw" + test_filename.suffix
@@ -25,18 +27,28 @@ def test_filter_system(filter_type: str):
     order = 4
     cuton = 5.0
     cutoff = 20.0
+    Wn = (cuton, cutoff)
+    btype = "bandpass"
     fs = 500.0
+    n_ch = 8
 
-    # if filter_type == "butter":
-    filter_comp = ButterworthFilter(
-        order=order, cuton=cuton, cutoff=cutoff, axis="time"
-    )
-    # elif filter_type == "cheby":
-    #     # signal.cheby1(4, 5, 100, 'low', analog=True)
-    #     filter_comp = ChebyshevFilter()
+    if filter_type == "butter":
+        filter_comp = ButterworthFilter(
+            order=order, cuton=cuton, cutoff=cutoff, axis="time", coef_type=coef_type
+        )
+    else:
+        filter_comp = ChebyshevFilter(
+            order=order,
+            ripple_tol=0.1,
+            Wn=Wn,
+            btype=btype,
+            cheby_type=filter_type,
+            axis="time",
+            coef_type=coef_type,
+        )
 
     comps = {
-        "SRC": EEGSynth(n_time=100, fs=fs, n_ch=8, alpha_freq=10.5),  # 2 seconds
+        "SRC": EEGSynth(n_time=100, fs=fs, n_ch=n_ch, alpha_freq=10.5),  # 2 seconds
         "FILTER": filter_comp,
         "LOGRAW": MessageLogger(output=test_filename_raw),
         "LOGFILT": MessageLogger(output=test_filename),
@@ -58,15 +70,40 @@ def test_filter_system(filter_type: str):
     outputs = AxisArray.concatenate(*messages, dim="time")
 
     # Calculate expected
-    coefs = scipy.signal.butter(
-        order,
-        Wn=(5.0, 20.0),
-        btype="bandpass",
-        fs=fs,
-        output="ba",
-    )
-    zi = scipy.signal.lfilter_zi(*coefs)[:, None]
-    expected, _ = scipy.signal.lfilter(
-        coefs[0], coefs[1], inputs.data, axis=inputs.get_axis_idx("time"), zi=zi
-    )
+    if filter_type == "butter":
+        coefs = scipy.signal.butter(
+            order,
+            Wn=Wn,
+            btype=btype,
+            fs=fs,
+            output=coef_type,
+        )
+    elif filter_type == "cheby1":
+        coefs = scipy.signal.cheby1(
+            order,
+            rp=0.1,
+            Wn=Wn,
+            btype=btype,
+            fs=fs,
+            output=coef_type,
+        )
+    else:  # filter_type == "cheby2":
+        coefs = scipy.signal.cheby2(
+            order,
+            rs=0.1,
+            Wn=(5.0, 20.0),
+            btype=btype,
+            fs=fs,
+            output=coef_type,
+        )
+    if coef_type == "ba":
+        zi = scipy.signal.lfilter_zi(*coefs)[:, None]
+        expected, _ = scipy.signal.lfilter(
+            coefs[0], coefs[1], inputs.data, axis=inputs.get_axis_idx("time"), zi=zi
+        )
+    else:  # coef_type == "sos":
+        zi = scipy.signal.sosfilt_zi(coefs)[:, :, None] + np.zeros((1, 1, n_ch))
+        expected, _ = scipy.signal.sosfilt(
+            coefs, inputs.data, axis=inputs.get_axis_idx("time"), zi=zi
+        )
     assert np.allclose(outputs.data, expected)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.9"
+requires-python = ">=3.10.15"
 
 [[package]]
 name = "cfgv"
@@ -75,16 +75,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/d9/3d820c00066ae55d69e6d0eae11d6149a5ca7546de469ba9d597f01bf2d7/coverage-7.6.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cc8ff50b50ce532de2fa7a7daae9dd12f0a699bfcd47f20945364e5c31799fef", size = 247510 },
     { url = "https://files.pythonhosted.org/packages/8f/c3/4fa1eb412bb288ff6bfcc163c11700ff06e02c5fad8513817186e460ed43/coverage-7.6.4-cp313-cp313t-win32.whl", hash = "sha256:b8d3a03d9bfcaf5b0141d07a88456bb6a4c3ce55c080712fec8418ef3610230e", size = 210353 },
     { url = "https://files.pythonhosted.org/packages/7e/77/03fc2979d1538884d921c2013075917fc927f41cd8526909852fe4494112/coverage-7.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:f3ddf056d3ebcf6ce47bdaf56142af51bb7fad09e4af310241e9db7a3a8022e1", size = 211502 },
-    { url = "https://files.pythonhosted.org/packages/fb/27/7efede2355bd1417137246246ab0980751b3ba6065102518a2d1eba6a278/coverage-7.6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9cb7fa111d21a6b55cbf633039f7bc2749e74932e3aa7cb7333f675a58a58bf3", size = 206714 },
-    { url = "https://files.pythonhosted.org/packages/f3/94/594af55226676d078af72b329372e2d036f9ba1eb6bcf1f81debea2453c7/coverage-7.6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:11a223a14e91a4693d2d0755c7a043db43d96a7450b4f356d506c2562c48642c", size = 207146 },
-    { url = "https://files.pythonhosted.org/packages/d5/13/19de1c5315b22795dd67dbd9168281632424a344b648d23d146572e42c2b/coverage-7.6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a413a096c4cbac202433c850ee43fa326d2e871b24554da8327b01632673a076", size = 235180 },
-    { url = "https://files.pythonhosted.org/packages/db/26/8fba01ce9f376708c7efed2761cea740f50a1b4138551886213797a4cecd/coverage-7.6.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00a1d69c112ff5149cabe60d2e2ee948752c975d95f1e1096742e6077affd376", size = 233100 },
-    { url = "https://files.pythonhosted.org/packages/74/66/4db60266551b89e820b457bc3811a3c5eaad3c1324cef7730c468633387a/coverage-7.6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f76846299ba5c54d12c91d776d9605ae33f8ae2b9d1d3c3703cf2db1a67f2c0", size = 234231 },
-    { url = "https://files.pythonhosted.org/packages/2a/9b/7b33f0892fccce50fc82ad8da76c7af1731aea48ec71279eef63a9522db7/coverage-7.6.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fe439416eb6380de434886b00c859304338f8b19f6f54811984f3420a2e03858", size = 233383 },
-    { url = "https://files.pythonhosted.org/packages/91/49/6ff9c4e8a67d9014e1c434566e9169965f970350f4792a0246cd0d839442/coverage-7.6.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0294ca37f1ba500667b1aef631e48d875ced93ad5e06fa665a3295bdd1d95111", size = 231863 },
-    { url = "https://files.pythonhosted.org/packages/81/f9/c9d330dec440676b91504fcceebca0814718fa71c8498cf29d4e21e9dbfc/coverage-7.6.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6f01ba56b1c0e9d149f9ac85a2f999724895229eb36bd997b61e62999e9b0901", size = 232854 },
-    { url = "https://files.pythonhosted.org/packages/ee/d9/605517a023a0ba8eb1f30d958f0a7ff3a21867b07dcb42618f862695ca0e/coverage-7.6.4-cp39-cp39-win32.whl", hash = "sha256:bc66f0bf1d7730a17430a50163bb264ba9ded56739112368ba985ddaa9c3bd09", size = 209437 },
-    { url = "https://files.pythonhosted.org/packages/aa/79/2626903efa84e9f5b9c8ee6972de8338673fdb5bb8d8d2797740bf911027/coverage-7.6.4-cp39-cp39-win_amd64.whl", hash = "sha256:c481b47f6b5845064c65a7bc78bc0860e635a9b055af0df46fdf1c58cebf8e8f", size = 210209 },
     { url = "https://files.pythonhosted.org/packages/cc/56/e1d75e8981a2a92c2a777e67c26efa96c66da59d645423146eb9ff3a851b/coverage-7.6.4-pp39.pp310-none-any.whl", hash = "sha256:3c65d37f3a9ebb703e710befdc489a38683a5b152242664b973a7b7b22348a4e", size = 198954 },
 ]
 
@@ -125,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "ezmsg-sigproc"
-version = "1.4.3.dev16+gc644fc1"
+version = "1.4.3.dev34+gbfb0671.d20241122"
 source = { editable = "." }
 dependencies = [
     { name = "ezmsg" },
@@ -205,14 +195,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ae/af06a8bde1947277aad895c2f26c3b8b8b6ee9c0c2ad988fb58a9d1dde3f/frozendict-2.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c9905dcf7aa659e6a11b8051114c9fa76dfde3a6e50e6dc129d5aece75b449a2", size = 117329 },
     { url = "https://files.pythonhosted.org/packages/d2/df/be3fa0457ff661301228f4c59c630699568c8ed9b5480f113b3eea7d0cb3/frozendict-2.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:323f1b674a2cc18f86ab81698e22aba8145d7a755e0ac2cccf142ee2db58620d", size = 37522 },
     { url = "https://files.pythonhosted.org/packages/4a/6f/c22e0266b4c85f58b4613fec024e040e93753880527bf92b0c1bc228c27c/frozendict-2.4.6-cp310-cp310-win_arm64.whl", hash = "sha256:eabd21d8e5db0c58b60d26b4bb9839cac13132e88277e1376970172a85ee04b3", size = 34056 },
-    { url = "https://files.pythonhosted.org/packages/eb/7e/5d6e86b01742468e5265401529b60d4d24e4b61a751d24473a324da71b55/frozendict-2.4.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a76cee5c4be2a5d1ff063188232fffcce05dde6fd5edd6afe7b75b247526490e", size = 38143 },
-    { url = "https://files.pythonhosted.org/packages/93/d0/3d66be6d154e2bbb4d49445c557f722b248c019b70982654e2440f303671/frozendict-2.4.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ba5ef7328706db857a2bdb2c2a17b4cd37c32a19c017cff1bb7eeebc86b0f411", size = 37954 },
-    { url = "https://files.pythonhosted.org/packages/b8/a2/5a178339345edff643240e48dd276581df64b1dd93eaa7d26556396a145b/frozendict-2.4.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:669237c571856be575eca28a69e92a3d18f8490511eff184937283dc6093bd67", size = 117093 },
-    { url = "https://files.pythonhosted.org/packages/41/df/09a752239eb0661eeda0f34f14577c10edc6f3e4deb7652b3a3efff22ad4/frozendict-2.4.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0aaa11e7c472150efe65adbcd6c17ac0f586896096ab3963775e1c5c58ac0098", size = 116883 },
-    { url = "https://files.pythonhosted.org/packages/22/d4/619d1cfbc74be5641d839a5a2e292f9eac494aa557bfe7c266542c4014a2/frozendict-2.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b8f2829048f29fe115da4a60409be2130e69402e29029339663fac39c90e6e2b", size = 116314 },
-    { url = "https://files.pythonhosted.org/packages/41/b9/40042606a4ac458046ebeecc34cec2971e78e029ea3b6ad4e35833c7f8e6/frozendict-2.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:94321e646cc39bebc66954a31edd1847d3a2a3483cf52ff051cd0996e7db07db", size = 117017 },
-    { url = "https://files.pythonhosted.org/packages/e1/6d/e99715f406d8f4297d08b5591365e7d91b39a24cdbaabd3861f95e283c52/frozendict-2.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:74b6b26c15dddfefddeb89813e455b00ebf78d0a3662b89506b4d55c6445a9f4", size = 37815 },
-    { url = "https://files.pythonhosted.org/packages/80/75/cad77ff4bb58277a557becf837345de8f6384d3b1d71f932d22a13223b9e/frozendict-2.4.6-cp39-cp39-win_arm64.whl", hash = "sha256:7088102345d1606450bd1801a61139bbaa2cb0d805b9b692f8d81918ea835da6", size = 34368 },
     { url = "https://files.pythonhosted.org/packages/04/13/d9839089b900fa7b479cce495d62110cddc4bd5630a04d8469916c0e79c5/frozendict-2.4.6-py311-none-any.whl", hash = "sha256:d065db6a44db2e2375c23eac816f1a022feb2fa98cbb50df44a9e83700accbea", size = 16148 },
     { url = "https://files.pythonhosted.org/packages/ba/d0/d482c39cee2ab2978a892558cf130681d4574ea208e162da8958b31e9250/frozendict-2.4.6-py312-none-any.whl", hash = "sha256:49344abe90fb75f0f9fdefe6d4ef6d4894e640fadab71f11009d52ad97f370b9", size = 16146 },
     { url = "https://files.pythonhosted.org/packages/a5/8e/b6bf6a0de482d7d7d7a2aaac8fdc4a4d0bb24a809f5ddd422aa7060eb3d2/frozendict-2.4.6-py313-none-any.whl", hash = "sha256:7134a2bb95d4a16556bb5f2b9736dceb6ea848fa5b6f3f6c2d6dba93b44b4757", size = 16146 },
@@ -290,20 +272,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/71/af/a469674070c8d8408384e3012e064299f7a2de540738a8e414dcfd639996/numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded", size = 14099701 },
     { url = "https://files.pythonhosted.org/packages/d0/3d/08ea9f239d0e0e939b6ca52ad403c84a2bce1bde301a8eb4888c1c1543f1/numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5", size = 6174313 },
     { url = "https://files.pythonhosted.org/packages/b2/b5/4ac39baebf1fdb2e72585c8352c56d063b6126be9fc95bd2bb5ef5770c20/numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a", size = 15606179 },
-    { url = "https://files.pythonhosted.org/packages/43/c1/41c8f6df3162b0c6ffd4437d729115704bd43363de0090c7f913cfbc2d89/numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c", size = 21169942 },
-    { url = "https://files.pythonhosted.org/packages/39/bc/fd298f308dcd232b56a4031fd6ddf11c43f9917fbc937e53762f7b5a3bb1/numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd", size = 13711512 },
-    { url = "https://files.pythonhosted.org/packages/96/ff/06d1aa3eeb1c614eda245c1ba4fb88c483bee6520d361641331872ac4b82/numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b", size = 5306976 },
-    { url = "https://files.pythonhosted.org/packages/2d/98/121996dcfb10a6087a05e54453e28e58694a7db62c5a5a29cee14c6e047b/numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729", size = 6906494 },
-    { url = "https://files.pythonhosted.org/packages/15/31/9dffc70da6b9bbf7968f6551967fc21156207366272c2a40b4ed6008dc9b/numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1", size = 13912596 },
-    { url = "https://files.pythonhosted.org/packages/b9/14/78635daab4b07c0930c919d451b8bf8c164774e6a3413aed04a6d95758ce/numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd", size = 19526099 },
-    { url = "https://files.pythonhosted.org/packages/26/4c/0eeca4614003077f68bfe7aac8b7496f04221865b3a5e7cb230c9d055afd/numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d", size = 19932823 },
-    { url = "https://files.pythonhosted.org/packages/f1/46/ea25b98b13dccaebddf1a803f8c748680d972e00507cd9bc6dcdb5aa2ac1/numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d", size = 14404424 },
-    { url = "https://files.pythonhosted.org/packages/c8/a6/177dd88d95ecf07e722d21008b1b40e681a929eb9e329684d449c36586b2/numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa", size = 6476809 },
-    { url = "https://files.pythonhosted.org/packages/ea/2b/7fc9f4e7ae5b507c1a3a21f0f15ed03e794c1242ea8a242ac158beb56034/numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73", size = 15911314 },
-    { url = "https://files.pythonhosted.org/packages/8f/3b/df5a870ac6a3be3a86856ce195ef42eec7ae50d2a202be1f5a4b3b340e14/numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8", size = 21025288 },
-    { url = "https://files.pythonhosted.org/packages/2c/97/51af92f18d6f6f2d9ad8b482a99fb74e142d71372da5d834b3a2747a446e/numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4", size = 6762793 },
-    { url = "https://files.pythonhosted.org/packages/12/46/de1fbd0c1b5ccaa7f9a005b66761533e2f6a3e560096682683a223631fe9/numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c", size = 19334885 },
-    { url = "https://files.pythonhosted.org/packages/cc/dc/d330a6faefd92b446ec0f0dfea4c3207bb1fef3c4771d19cf4543efd2c78/numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385", size = 15828784 },
 ]
 
 [[package]]
@@ -442,14 +410,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/6e/331f42142e5e4783e64286f31d31667017fb474cd2b263000a0204c79c22/pywavelets-1.6.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:dd798cee3d28fb3d32a26a00d9831a20bf316c36d685e4ced01b4e4a8f36f5ce", size = 4504579 },
     { url = "https://files.pythonhosted.org/packages/a6/2e/3a43ac2cfdb122614a0a1c68869f8497831bbacb012b2739c784a197b8fb/pywavelets-1.6.0-cp312-cp312-win32.whl", hash = "sha256:e772f7f0c16bfc3be8ac3cd10d29a9920bb7a39781358856223c491b899e6e79", size = 4169388 },
     { url = "https://files.pythonhosted.org/packages/7a/11/7cebd91be700652f786305754ef13cacfde4598c320b59cbe2c340e8c646/pywavelets-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:4ef15a63a72afa67ae9f4f3b06c95c5382730fb3075e668d49a880e65f2f089c", size = 4244482 },
-    { url = "https://files.pythonhosted.org/packages/26/68/e1453bd31c7c942e6ffcc0c71e7df488f36dfc16f8effef1f331a2e3c373/pywavelets-1.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:627df378e63e9c789b6f2e7060cb4264ebae6f6b0efc1da287a2c060de454a1f", size = 4363690 },
-    { url = "https://files.pythonhosted.org/packages/02/c5/a225bfdf5532dfe4fbc823f1bb038949a4e7cd9d43a3ad23fe84cd365b98/pywavelets-1.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a413b51dc19e05243fe0b0864a8e8a16b5ca9bf2e4713da00a95b1b5747a5367", size = 4327278 },
-    { url = "https://files.pythonhosted.org/packages/0a/51/981d04e4c9b66565e0a2a1f394572f67bedeadaff9bf9282ef9b711d31b1/pywavelets-1.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be615c6c1873e189c265d4a76d1751ec49b17e29725e6dd2e9c74f1868f590b7", size = 4449088 },
-    { url = "https://files.pythonhosted.org/packages/82/ac/2430589380ab236891481c2261b2743010927db10437cffe0329de342ffd/pywavelets-1.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4021ef69ec9f3862f66580fc4417be728bd78722914394594b48212fd1fcaf21", size = 4528220 },
-    { url = "https://files.pythonhosted.org/packages/70/5a/32ecb4a8b43745fbda380aafbcb0da51640aacf96c7f3cf4ab890d22f193/pywavelets-1.6.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8fbf7b61b28b5457693c034e58a01622756d1fd60a80ae13ac5888b1d3e57e80", size = 4469082 },
-    { url = "https://files.pythonhosted.org/packages/7f/ce/9964a6f611aca4d87af395d8bf1991ce209277ca5da12242b02296882710/pywavelets-1.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f58ddbb0a6cd243928876edfc463b990763a24fb94498607d6fea690e32cca4c", size = 4547619 },
-    { url = "https://files.pythonhosted.org/packages/c3/46/ce31fab7866c41984a0ed76452c239ecaa3e70d9b32911167dd8e5ac72b4/pywavelets-1.6.0-cp39-cp39-win32.whl", hash = "sha256:42a22e68e345b6de7d387ef752111ab4530c98048d2b4bdac8ceefb078b4ead6", size = 4179812 },
-    { url = "https://files.pythonhosted.org/packages/5c/17/5da7f90673319b664025ade3e55d68ea2eb53bead6a8aece042a804977f2/pywavelets-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:32198de321892743c1a3d1957fe1cd8a8ecc078bfbba6b8f3982518e897271d7", size = 4253407 },
 ]
 
 [[package]]
@@ -494,15 +454,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
-    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
-    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
-    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
-    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
-    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
-    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
-    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
-    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
 ]
 
 [[package]]
@@ -557,12 +508,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ab/6ecdc526d509d33814835447bbbeedbebdec7cca46ef495a61b00a35b4bf/scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884", size = 38218311 },
     { url = "https://files.pythonhosted.org/packages/0b/00/9f54554f0f8318100a71515122d8f4f503b1a2c4b4cfab3b4b68c0eb08fa/scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16", size = 38442493 },
     { url = "https://files.pythonhosted.org/packages/3e/df/963384e90733e08eac978cd103c34df181d1fec424de383cdc443f418dd4/scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949", size = 45910955 },
-    { url = "https://files.pythonhosted.org/packages/7f/29/c2ea58c9731b9ecb30b6738113a95d147e83922986b34c685b8f6eefde21/scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5", size = 39352927 },
-    { url = "https://files.pythonhosted.org/packages/5c/c0/e71b94b20ccf9effb38d7147c0064c08c622309fd487b1b677771a97d18c/scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24", size = 30324538 },
-    { url = "https://files.pythonhosted.org/packages/6d/0f/aaa55b06d474817cea311e7b10aab2ea1fd5d43bc6a2861ccc9caec9f418/scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004", size = 33732190 },
-    { url = "https://files.pythonhosted.org/packages/35/f5/d0ad1a96f80962ba65e2ce1de6a1e59edecd1f0a7b55990ed208848012e0/scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d", size = 38612244 },
-    { url = "https://files.pythonhosted.org/packages/8d/02/1165905f14962174e6569076bcc3315809ae1291ed14de6448cc151eedfd/scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c", size = 38845637 },
-    { url = "https://files.pythonhosted.org/packages/3e/77/dab54fe647a08ee4253963bcd8f9cf17509c8ca64d6335141422fe2e2114/scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2", size = 46227440 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR closes #6 by refactoring the `filter` module with the following changes:

* new `filter_gen_by_design` generator method applies the filter designed by the callable passed in as an argument
* new FilterBase class
    * `apply_filter` is now gone. Despite not being an underscored method, I think this is safe to change because I don't think this was used anywhere else.
    * abstract method `design_filter` must return a callable that accepts `fs` and nothing else. For most filters, this means using a lambda or functools.partial to prepare the typical design function.
* `Filter` now inherits this base class and its `design_filter` is simply a lambda that returns the coefficients from SETTINGS.
* new `ChebyshevFilter` with type I or type II designs.
* new `test_filter_system`
* new `test_decimate_system` because Decimate was affected by the filter change.
* Modified Decimate to use the new `ChebyshevFilter` unit instead of the IMO confusing legacy `Filter`

Importantly, the API is backwards compatible except for the loss of `apply_filter` and I changed the `FilterSettings` field name from `filt` to `coefs`.
