### PR TITLE
adaptive standard scaler performance improvement

### DIFF
--- a/src/ezmsg/sigproc/ewmfilter.py
+++ b/src/ezmsg/sigproc/ewmfilter.py
@@ -24,7 +24,8 @@ class EWMState(ez.State):
 
 class EWM(ez.Unit):
     """
-    Exponentially Weighted Moving Average Standardization
+    Exponentially Weighted Moving Average Standardization.
+    This is deprecated. Please use :obj:`ezmsg.sigproc.scaler.AdaptiveStandardScaler` instead.
 
     References https://stackoverflow.com/a/42926270
     """
@@ -37,6 +38,9 @@ class EWM(ez.Unit):
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
 
     async def initialize(self) -> None:
+        ez.logger.warning(
+            "EWM/EWMFilter is deprecated and will be removed in a future version. Use AdaptiveStandardScaler instead."
+        )
         self.STATE.signal_queue = asyncio.Queue()
         self.STATE.buffer_queue = asyncio.Queue()
 
@@ -113,7 +117,7 @@ class EWMFilter(ez.Collection):
     leads to :obj:`Window` which then feeds into :obj:`EWM` 's INPUT_BUFFER
     and another branch that feeds directly into :obj:`EWM` 's INPUT_SIGNAL.
 
-    Consider :obj:`scaler` for a more efficient alternative.
+    This is deprecated. Please use :obj:`ezmsg.sigproc.scaler.AdaptiveStandardScaler` instead.
     """
 
     SETTINGS = EWMFilterSettings

--- a/src/ezmsg/sigproc/scaler.py
+++ b/src/ezmsg/sigproc/scaler.py
@@ -1,7 +1,9 @@
+import functools
 import typing
 
 import numpy as np
 import numpy.typing as npt
+import scipy.signal
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.messages.util import replace
@@ -26,6 +28,138 @@ def _alpha_from_tau(tau: float, dt: float) -> float:
     :return: alpha, the "fading factor" in exponential smoothing.
     """
     return 1 - np.exp(-dt / tau)
+
+
+def ewma_step(
+    sample: npt.NDArray, zi: npt.NDArray, alpha, beta: typing.Optional[None] = None
+):
+    """
+    Do an exponentially weighted moving average step.
+
+    Args:
+        sample: The new sample.
+        zi: The output of the previous step.
+        alpha: Fading factor.
+        beta: Persisting factor. If None, it is calculated as 1-alpha.
+
+    Returns:
+        alpha * sample + beta * zi
+
+    """
+    # Potential micro-optimization:
+    #  Current: scalar-arr multiplication, scalar-arr multiplication, arr-arr addition
+    #  Alternative: arr-arr subtraction, arr-arr multiplication, arr-arr addition
+    # return zi + alpha * (new_sample - zi)
+    beta = beta or (1 - alpha)
+    return alpha * sample + beta * zi
+
+
+class EWMA:
+    def __init__(self, alpha: float):
+        self.beta = 1 - alpha
+        self._filt_func = functools.partial(
+            scipy.signal.lfilter, [alpha], [1.0, alpha - 1.0], axis=0
+        )
+        self.prev = None
+
+    def compute(self, arr: npt.NDArray) -> npt.NDArray:
+        if self.prev is None:
+            self.prev = self.beta * arr[:1]
+        expected, self.prev = self._filt_func(arr, zi=self.prev)
+        return expected
+
+
+class EWMA_Deprecated:
+    """
+    Grabbed these methods from https://stackoverflow.com/a/70998068 and other answers in that topic,
+    but they ended up being slower than the scipy.signal.lfilter method.
+    Additionally, `compute` and `compute2` suffer from potential errors as the vector length increases
+    and beta**n approaches zero.
+    """
+
+    def __init__(self, alpha: float, max_len: int):
+        self.alpha = alpha
+        self.beta = 1 - alpha
+        self.prev: typing.Optional[npt.NDArray] = None
+        self.weights = np.empty((max_len + 1,), float)
+        self._precalc_weights(max_len)
+        self._step_func = functools.partial(ewma_step, alpha=self.alpha, beta=self.beta)
+
+    def _precalc_weights(self, n: int):
+        #   (1-α)^0, (1-α)^1, (1-α)^2, ..., (1-α)^n
+        np.power(self.beta, np.arange(n + 1), out=self.weights)
+
+    def compute(
+        self, arr: npt.NDArray, out: typing.Optional[npt.NDArray] = None
+    ) -> npt.NDArray:
+        if out is None:
+            out = np.empty(arr.shape, arr.dtype)
+
+        n = arr.shape[0]
+        weights = self.weights[:n]
+        weights = np.expand_dims(weights, list(range(1, arr.ndim)))
+
+        #   α*P0, α*P1, α*P2, ..., α*Pn
+        np.multiply(self.alpha, arr, out)
+
+        #   α*P0/(1-α)^0, α*P1/(1-α)^1, α*P2/(1-α)^2, ..., α*Pn/(1-α)^n
+        np.divide(out, weights, out)
+
+        #   α*P0/(1-α)^0, α*P0/(1-α)^0 + α*P1/(1-α)^1, ...
+        np.cumsum(out, axis=0, out=out)
+
+        #   (α*P0/(1-α)^0)*(1-α)^0, (α*P0/(1-α)^0 + α*P1/(1-α)^1)*(1-α)^1, ...
+        np.multiply(out, weights, out)
+
+        # Add the previous output
+        if self.prev is None:
+            self.prev = arr[:1]
+
+        out += self.prev * np.expand_dims(
+            self.weights[1 : n + 1], list(range(1, arr.ndim))
+        )
+
+        self.prev = out[-1:]
+
+        return out
+
+    def compute2(self, arr: npt.NDArray) -> npt.NDArray:
+        """
+        Compute the Exponentially Weighted Moving Average (EWMA) of the input array.
+
+        Args:
+            arr: The input array to be smoothed.
+
+        Returns:
+            The smoothed array.
+        """
+        n = arr.shape[0]
+        if n > len(self.weights):
+            self._precalc_weights(n)
+        weights = self.weights[:n][::-1]
+        weights = np.expand_dims(weights, list(range(1, arr.ndim)))
+
+        result = np.cumsum(self.alpha * weights * arr, axis=0)
+        result = result / weights
+
+        # Handle the first call when prev is unset
+        if self.prev is None:
+            self.prev = arr[:1]
+
+        result += self.prev * np.expand_dims(
+            self.weights[1 : n + 1], list(range(1, arr.ndim))
+        )
+
+        # Store the result back into prev
+        self.prev = result[-1]
+
+        return result
+
+    def compute_sample(self, new_sample: npt.NDArray) -> npt.NDArray:
+        if self.prev is None:
+            self.prev = new_sample
+        self.prev = self._step_func(new_sample, self.prev)
+        return self.prev
 
 
 @consumer
@@ -96,10 +230,8 @@ def scaler_np(
     msg_out = AxisArray(np.array([]), dims=[""])
 
     # State variables
-    alpha: float = 0.0
-    means: typing.Optional[npt.NDArray] = None
-    vars_means: typing.Optional[npt.NDArray] = None
-    vars_sq_means: typing.Optional[npt.NDArray] = None
+    samps_ewma: typing.Optional[EWMA] = None
+    vars_sq_ewma: typing.Optional[EWMA] = None
 
     # Reset if input changes
     check_input = {
@@ -108,45 +240,32 @@ def scaler_np(
         "key": None,  # Key change implies buffered means/vars are invalid.
     }
 
-    def _ew_update(arr, prev, _alpha):
-        if np.all(prev == 0):
-            return arr
-        # return _alpha * arr + (1 - _alpha) * prev
-        # Micro-optimization: sub, mult, add (below) is faster than sub, mult, mult, add (above)
-        return prev + _alpha * (arr - prev)
-
     while True:
         msg_in: AxisArray = yield msg_out
 
         axis = axis or msg_in.dims[0]
         axis_idx = msg_in.get_axis_idx(axis)
 
-        if msg_in.axes[axis].gain != check_input["gain"]:
-            alpha = _alpha_from_tau(time_constant, msg_in.axes[axis].gain)
-            check_input["gain"] = msg_in.axes[axis].gain
-
         data: npt.NDArray = np.moveaxis(msg_in.data, axis_idx, 0)
         b_reset = data.shape[1:] != check_input["shape"]
-        b_reset |= msg_in.key != check_input["key"]
+        b_reset = b_reset or msg_in.axes[axis].gain != check_input["gain"]
+        b_reset = b_reset or msg_in.key != check_input["key"]
         if b_reset:
             check_input["shape"] = data.shape[1:]
+            check_input["gain"] = msg_in.axes[axis].gain
             check_input["key"] = msg_in.key
-            vars_sq_means = np.zeros_like(data[0], dtype=float)
-            vars_means = np.zeros_like(data[0], dtype=float)
-            means = np.zeros_like(data[0], dtype=float)
+            alpha = _alpha_from_tau(time_constant, msg_in.axes[axis].gain)
+            samps_ewma = EWMA(alpha=alpha)
+            vars_sq_ewma = EWMA(alpha=alpha)
 
-        result = np.zeros_like(data)
-        for sample_ix in range(data.shape[0]):
-            sample = data[sample_ix]
-            # Update step
-            vars_means = _ew_update(sample, vars_means, alpha)
-            vars_sq_means = _ew_update(sample**2, vars_sq_means, alpha)
-            means = _ew_update(sample, means, alpha)
-            # Get step
-            varis = vars_sq_means - vars_means**2
-            y = (sample - means) / (varis**0.5)
-            result[sample_ix] = y
+        # Update step
+        means = samps_ewma.compute(data)
+        vars_sq_means = vars_sq_ewma.compute(data**2)
 
+        # Get step
+        varis = vars_sq_means - means**2
+        with np.errstate(divide="ignore", invalid="ignore"):
+            result = (data - means) / (varis**0.5)
         result[np.isnan(result)] = 0.0
         result = np.moveaxis(result, 0, axis_idx)
         msg_out = replace(msg_in, data=result)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -20,14 +20,20 @@ from ezmsg.sigproc.synth import Counter, CounterSettings
 from util import get_test_fn, assert_messages_equal
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("river") is None, reason="requires `river` package"
-)
-def test_adaptive_standard_scaler_river():
+@pytest.fixture
+def fixture_arrays():
     # Test data values taken from river:
     # https://github.com/online-ml/river/blob/main/river/preprocessing/scale.py#L511-L536C17
     data = np.array([5.278, 5.050, 6.550, 7.446, 9.472, 10.353, 11.784, 11.173])
     expected_result = np.array([0.0, -0.816, 0.812, 0.695, 0.754, 0.598, 0.651, 0.124])
+    return data, expected_result
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("river") is None, reason="requires `river` package"
+)
+def test_adaptive_standard_scaler_river(fixture_arrays):
+    data, expected_result = fixture_arrays
 
     test_input = AxisArray(
         np.tile(data, (2, 1)),
@@ -46,10 +52,9 @@ def test_adaptive_standard_scaler_river():
     assert_messages_equal([test_input], backup)
 
 
-def test_scaler_np():
-    data = np.array([5.278, 5.050, 6.550, 7.446, 9.472, 10.353, 11.784, 11.173])
-    expected_result = np.array([0.0, -0.816, 0.812, 0.695, 0.754, 0.598, 0.651, 0.124])
-    chunker = array_chunker(data, 3, fs=100.0)
+def test_scaler_np(fixture_arrays):
+    data, expected_result = fixture_arrays
+    chunker = array_chunker(data, 4, fs=100.0)
     test_input = list(chunker)
     backup = copy.deepcopy(test_input)
 

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -2,9 +2,11 @@ import copy
 import os
 from typing import Optional, List
 from dataclasses import field
+import importlib.util
 
 import numpy as np
 from frozendict import frozendict
+import pytest
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.terminate import TerminateOnTotalSettings, TerminateOnTotal
@@ -18,37 +20,35 @@ from ezmsg.sigproc.synth import Counter, CounterSettings
 from util import get_test_fn, assert_messages_equal
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("river") is None, reason="requires `river` package"
+)
 def test_adaptive_standard_scaler_river():
-    try:
-        # Test data values taken from river:
-        # https://github.com/online-ml/river/blob/main/river/preprocessing/scale.py#L511-L536C17
-        data = np.array([5.278, 5.050, 6.550, 7.446, 9.472, 10.353, 11.784, 11.173])
-        expected_result = np.array(
-            [0.0, -0.816, 0.812, 0.695, 0.754, 0.598, 0.651, 0.124]
-        )
+    # Test data values taken from river:
+    # https://github.com/online-ml/river/blob/main/river/preprocessing/scale.py#L511-L536C17
+    data = np.array([5.278, 5.050, 6.550, 7.446, 9.472, 10.353, 11.784, 11.173])
+    expected_result = np.array([0.0, -0.816, 0.812, 0.695, 0.754, 0.598, 0.651, 0.124])
 
-        test_input = AxisArray(
-            np.tile(data, (2, 1)),
-            dims=["ch", "time"],
-            axes=frozendict({"time": AxisArray.TimeAxis(fs=100.0)}),
-        )
+    test_input = AxisArray(
+        np.tile(data, (2, 1)),
+        dims=["ch", "time"],
+        axes=frozendict({"time": AxisArray.TimeAxis(fs=100.0)}),
+    )
 
-        backup = [copy.deepcopy(test_input)]
+    backup = [copy.deepcopy(test_input)]
 
-        # The River example used alpha = 0.6
-        # tau = -gain / np.log(1 - alpha) and here we're using gain = 1.0
-        tau = 1.0914
-        _scaler = scaler(time_constant=tau, axis="time")
-        output = _scaler.send(test_input)
-        assert np.allclose(output.data[0], expected_result, atol=1e-3)
-        assert_messages_equal([test_input], backup)
+    # The River example used alpha = 0.6
+    # tau = -gain / np.log(1 - alpha) and here we're using gain = 1.0
+    tau = 1.0914
+    _scaler = scaler(time_constant=tau, axis="time")
+    output = _scaler.send(test_input)
+    assert np.allclose(output.data[0], expected_result, atol=1e-3)
+    assert_messages_equal([test_input], backup)
 
-        _scaler_np = scaler_np(time_constant=tau, axis="time")
-        output = _scaler_np.send(test_input)
-        assert np.allclose(output.data[0], expected_result, atol=1e-3)
-        assert_messages_equal([test_input], backup)
-    except ModuleNotFoundError:
-        pass  # Do not fail if river not installed.
+    _scaler_np = scaler_np(time_constant=tau, axis="time")
+    output = _scaler_np.send(test_input)
+    assert np.allclose(output.data[0], expected_result, atol=1e-3)
+    assert_messages_equal([test_input], backup)
 
 
 class ScalerTestSystemSettings(ez.Settings):

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -13,11 +13,31 @@ from ezmsg.util.terminate import TerminateOnTotalSettings, TerminateOnTotal
 from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
 from ezmsg.util.messagecodec import message_log
 
-from ezmsg.sigproc.scaler import scaler, scaler_np
+from ezmsg.sigproc.scaler import scaler, scaler_np, EWMA, ewma_step
 from ezmsg.sigproc.scaler import AdaptiveStandardScalerSettings, AdaptiveStandardScaler
 from ezmsg.sigproc.synth import Counter, CounterSettings
 
 from util import get_test_fn, assert_messages_equal
+
+
+def test_ewma():
+    alpha = 0.6
+    n_times = 100
+    n_ch = 32
+    n_feat = 4
+    data = np.arange(1, n_times * n_ch * n_feat + 1, dtype=float).reshape(
+        n_times, n_ch, n_feat
+    )
+
+    # Expected
+    expected = [data[0]]
+    for ix, dat in enumerate(data):
+        expected.append(ewma_step(dat, expected[-1], alpha))
+    expected = np.stack(expected)[1:]
+
+    ewma = EWMA(alpha=alpha)
+    res = ewma.compute(data)
+    assert np.allclose(res, expected)
 
 
 @pytest.fixture

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Optional, List
+import typing
 import importlib.util
 
 import numpy as np
@@ -72,7 +72,7 @@ def test_scaler_system(
     tau: float = 1.0,
     fs: float = 10.0,
     duration: float = 2.0,
-    test_name: Optional[str] = None,
+    test_name: typing.Optional[str] = None,
 ):
     """
     For this test, we assume that Counter and scaler_np are functioning properly.
@@ -116,7 +116,7 @@ def test_scaler_system(
     ez.run(components=comps, connections=conns)
 
     # Collect result
-    messages: List[AxisArray] = [_ for _ in message_log(test_filename)]
+    messages: typing.List[AxisArray] = [_ for _ in message_log(test_filename)]
     os.remove(test_filename)
 
     data = np.concatenate([_.data for _ in messages]).squeeze()


### PR DESCRIPTION
Fixes #52 

* Adds more robust unit tests to the `scaler` module.
* Simplify ewma calculation by using `lfilter` instead for loop and instead of complicated vectorized numpy code.
    * Simple lfilter was faster than creating vectorized numpy calculations, and is _much_ simpler.
* Adds a class with some test implementations of vectorized numpy ewma.
    * I tested these to ensure they all give identical results to the previous and new algos.
    * Vectorized numpy algos took half the compute time of the previous implementation, but still twice as long as the new algo (i.e., new algo is ~1/4 original time).