### PR TITLE
Do not append header to existing profiling logfile

### DIFF
--- a/src/ezmsg/sigproc/util/profile.py
+++ b/src/ezmsg/sigproc/util/profile.py
@@ -8,6 +8,9 @@ import typing
 import ezmsg.core as ez
 
 
+HEADER = "Time,Source,Topic,SampleTime,PerfCounter,Elapsed"
+
+
 def get_logger_path() -> Path:
     # Retrieve the logfile name from the environment variable
     logfile = os.environ.get("EZMSG_PROFILE", None)
@@ -26,9 +29,23 @@ def _setup_logger(append: bool = False) -> logging.Logger:
     logpath = get_logger_path()
     logpath.parent.mkdir(parents=True, exist_ok=True)
 
-    if not append:
-        # Remove the file if it exists
-        logpath.unlink(missing_ok=True)
+    write_header = True
+    if logpath.exists() and logpath.is_file():
+        if append:
+            with open(logpath) as f:
+                first_line = f.readline().rstrip()
+            if first_line == HEADER:
+                write_header = False
+            else:
+                # Remove the file if appending, but headers do not match
+                ezmsg_logger = logging.getLogger("ezmsg")
+                ezmsg_logger.warning(
+                    "Profiling header mismatch: please make sure to use the same version of ezmsg for all processes."
+                )
+                logpath.unlink()
+        else:
+            # Remove the file if not appending
+            logpath.unlink()
 
     # Create a logger with the name "ezprofile"
     _logger = logging.getLogger("ezprofile")
@@ -43,13 +60,13 @@ def _setup_logger(append: bool = False) -> logging.Logger:
     # Add the file handler to the logger
     _logger.addHandler(fh)
 
-    # Add the first row without formatting.
-    _logger.debug(",".join(["Time", "Source", "Topic", "SampleTime", "PerfCounter", "Elapsed"]))
+    # Add the header if writing to new file or if header matched header in file.
+    if write_header:
+        _logger.debug(HEADER)
 
     # Set the log message format
     formatter = logging.Formatter(
-        "%(asctime)s,%(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S%z"
+        "%(asctime)s,%(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"
     )
     fh.setFormatter(formatter)
 
@@ -89,18 +106,31 @@ def profile_method(trace_oldest: bool = True):
     Returns:
         Callable: The decorated function with profiling.
     """
+
     def profiling_decorator(func: typing.Callable):
         @functools.wraps(func)
         def wrapped_func(caller, *args, **kwargs):
             start = time.perf_counter()
             res = func(caller, *args, **kwargs)
             stop = time.perf_counter()
-            source = '.'.join((caller.__class__.__module__, caller.__class__.__name__))
+            source = ".".join((caller.__class__.__module__, caller.__class__.__name__))
             topic = f"{caller.address}"
             samp_time = _process_obj(res, trace_oldest=trace_oldest)
-            logger.debug(",".join([source, topic, f"{samp_time}", f"{stop}", f"{(stop - start) * 1e3:0.4f}"]))
+            logger.debug(
+                ",".join(
+                    [
+                        source,
+                        topic,
+                        f"{samp_time}",
+                        f"{stop}",
+                        f"{(stop - start) * 1e3:0.4f}",
+                    ]
+                )
+            )
             return res
+
         return wrapped_func if logger.level == logging.DEBUG else func
+
     return profiling_decorator
 
 
@@ -115,17 +145,30 @@ def profile_subpub(trace_oldest: bool = True):
     Returns:
         Callable: The decorated async task with profiling.
     """
+
     def profiling_decorator(func: typing.Callable):
         @functools.wraps(func)
-        async def wrapped_task(unit: ez.Unit, msg: typing.Any = None) -> None:
-            source = '.'.join((unit.__class__.__module__, unit.__class__.__name__))
+        async def wrapped_task(unit: ez.Unit, msg: typing.Any = None):
+            source = ".".join((unit.__class__.__module__, unit.__class__.__name__))
             topic = f"{unit.address}"
             start = time.perf_counter()
             async for stream, obj in func(unit, msg):
                 stop = time.perf_counter()
                 samp_time = _process_obj(obj, trace_oldest=trace_oldest)
-                logger.debug(",".join([source, topic, f"{samp_time}", f"{stop}", f"{(stop - start) * 1e3:0.4f}"]))
+                logger.debug(
+                    ",".join(
+                        [
+                            source,
+                            topic,
+                            f"{samp_time}",
+                            f"{stop}",
+                            f"{(stop - start) * 1e3:0.4f}",
+                        ]
+                    )
+                )
                 start = stop
                 yield stream, obj
+
         return wrapped_task if logger.level == logging.DEBUG else func
+
     return profiling_decorator

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,191 @@
+from datetime import datetime
+import os
+import pytest
+import logging
+from pathlib import Path
+from unittest.mock import patch
+from ezmsg.sigproc.util.profile import (
+    _setup_logger,
+    profile_method,
+    profile_subpub,
+    get_logger_path,
+    HEADER,
+)
+
+
+def test_logger_creation():
+    """Test that the ezprofile logger is created when importing from ezmsg.sigproc.util.profile."""
+    logger_name = "ezprofile"
+    assert logger_name in logging.Logger.manager.loggerDict
+    logger = logging.getLogger(logger_name)
+    assert logger.level == logging.INFO
+    assert len(logger.handlers) == 1
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.FileHandler)
+    assert handler.level == logging.DEBUG
+    assert Path(handler.baseFilename) == get_logger_path()
+
+    # Remove and close all handlers
+    logger.removeHandler(handler)
+    handler.close()
+
+
+@pytest.fixture
+def mock_env():
+    """Fixture to mock environment variables."""
+    with patch.dict(
+        os.environ, {"EZMSG_PROFILE": "test_profiler.log", "EZMSG_LOGLEVEL": "DEBUG"}
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_logger_path(mock_env):
+    """Fixture to mock the logger path."""
+    logpath = get_logger_path()
+    yield logpath
+
+
+def test_logger_not_append(mock_logger_path):
+    """Test that the logger creates a new file if append==False."""
+    some_text = "Some,Previous,Logger,Text"
+    correct_header = HEADER
+
+    # Create a file with some text
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(some_text + "\n")
+
+    logger = _setup_logger(append=False)
+    assert mock_logger_path.exists() and mock_logger_path.is_file()
+    assert logger.name == "ezprofile"
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.FileHandler)
+    assert handler.level == logging.DEBUG
+    assert Path(handler.baseFilename) == test_logpath
+
+    with open(mock_logger_path, "r") as f:
+        first_line = f.readline().strip()
+    assert first_line == correct_header
+
+    # Clean up the logger file handler
+    logger.removeHandler(handler)
+    handler.close()
+
+
+def test_logger_append_header_mismatch(mock_logger_path):
+    """Test that the logger deletes the file if the header mismatches when append=True."""
+    incorrect_header = "Incorrect,Header,Format"
+    correct_header = HEADER
+
+    # Create a file with an incorrect header
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(incorrect_header + "\n")
+
+    logger = _setup_logger(append=True)
+
+    # Assert that the file was deleted and recreated
+    assert test_logpath.exists()
+    with open(test_logpath, "r") as f:
+        first_line = f.readline().strip()
+    assert first_line == correct_header
+
+    # Clean up the logger handlers
+    handlers = logger.handlers
+    for handler in handlers:
+        logger.removeHandler(handler)
+        handler.close()
+
+
+def test_logger_append_header_match(mock_logger_path):
+    """Test that the logger correctly appends to the logfile if append=True and the header is correct."""
+    correct_header = HEADER
+    next_line = "Some,New,Logger,Text"
+
+    # Create a file with the correct header
+    test_logpath = mock_logger_path
+    with open(test_logpath, "w") as f:
+        f.truncate(0)
+        f.write(correct_header + "\n")
+        f.write(next_line + "\n")
+
+    logger = _setup_logger(append=True)
+    logger.debug("Some,Added,Logger,Text")
+
+    # Assert that the file was appended to
+    assert test_logpath.exists()
+    with open(test_logpath, "r") as f:
+        first_line = f.readline().strip()
+        second_line = f.readline().strip()
+        third_line = f.readline().strip()
+    assert first_line == correct_header
+    assert second_line == next_line
+    assert "Some,Added,Logger,Text" in third_line
+
+    # Clean up the logger handlers
+    handlers = logger.handlers
+    for handler in handlers:
+        if isinstance(handler, logging.FileHandler):
+            logger.removeHandler(handler)
+            handler.close()
+
+
+def test_profile_method_decorator():
+    """Test the profile_method decorator."""
+
+    class DummyClass:
+        address = "dummy_address"
+
+        @profile_method(trace_oldest=True)
+        def sample_method(self, x, y):
+            return x + y
+
+    instance = DummyClass()
+
+    with patch("ezmsg.sigproc.util.profile.logger") as mock_logger:
+        result = instance.sample_method(2, 3)
+        assert result == 5
+
+        # Assert the logger was called
+        mock_logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_profile_subpub_decorator(mock_logger_path):
+    """Test the profile_subpub decorator."""
+    test_logpath = mock_logger_path
+    _setup_logger()
+
+    class DummyUnit:
+        address = "dummy_address"
+
+        @profile_subpub(trace_oldest=True)
+        async def sample_subpub(self, msg):
+            yield "stream", msg
+
+    unit = DummyUnit()
+
+    async for stream, obj in unit.sample_subpub("message"):
+        # Assert the generator yields correctly
+        assert stream == "stream"
+        assert obj == "message"
+
+    # Assert the logger was called and printed in the correct format
+    with open(test_logpath, "r") as f:
+        f.readline()
+        second_line = f.readline().strip()
+    log_text = second_line.split(",")
+    assert len(log_text) == 6
+    datetime.strptime(
+        log_text[0], "%Y-%m-%dT%H:%M:%S%z"
+    )  # Will throw if format is incorrect
+    assert log_text[1] == "test_profile.DummyUnit"
+    assert log_text[2] == "dummy_address"
+    assert log_text[3] == "None"
+    float(log_text[4])  # Will throw if not float
+    float(log_text[5])  # Will throw if not float


### PR DESCRIPTION
# Description
When "ezprofile" logger initialises, it will no longer append a header line if the existing header line is the same. 

If there is a header mismatch (implying different versions of the profiling code), the logfile will be emptied and written to afresh. 

## Reason for change
To improve analysis and visualization of profiling data, want to remove spurious copies of header line deep into the logfile. 

## Type of change
Change in behaviour of profiling logger. 

## Change details
1. Amended "ezprofile" logger initialization method when in `append` mode, to check existing logfile to see if there is a header match. If there is, suppress writing a header. If there is not, empty file and write header. In the latter case, we also send a warning to the "ezmsg" (not profiling logger) about the profiling version mismatch.
2. Added unit tests for behaviour in 1.
3. Added unit tests for profile logging decorators `@profile_method` and `@profile_subpub` in file `test_profile.py`.

## How Has This Been Tested?
Added unit tests in `test_profile.py`:
- `test_logger_creation()`: checks logger and logger file handler created with default settings during `profile` module import. 
- `test_logger_not_append()`: checks logger will empty logfile if it exists and write to it if `append==False`.
- `test_logger_append_header_mismatch()`: checks logger will empty logfile and write new header if `append==True`, but logfile has a different header line. 
- `test_logger_append_header_match()`: checks logger will simply append to logfile and that a new header line is not printed if `append==True` and the logfile header matches the logger header.
- `test_profile_method_decorator()`: checks correct behaviour of `profile_method` decorator.
- `test_profile_subpub_decorator()`: checks correct behaviour of `profile_subpub` decorator. 

All ezmsg-sigproc tests pass. Passes formatter and linter checks.