### PR TITLE
Base.py enhancements - robust type resolution, typeright fixes and testing

### DIFF
--- a/docs/ProcessorsBase.md
+++ b/docs/ProcessorsBase.md
@@ -4,6 +4,9 @@ The `ezmsg.sigproc.base` module contains the base classes for the signal process
 
 > The information below was written at the time of a major refactor to `ezmsg.sigproc.base` to help collate the design decisions and to help with future refactoring.  However, it may be outdated or incomplete. Please refer to the source code for the most accurate information.
 
+> Updates: Added CompositeProducer, BaseProcessorUnit.
+
+
 ### Generic TypeVars
 
 | Idx | Class                 | Description                                                                |
@@ -13,15 +16,16 @@ The `ezmsg.sigproc.base` module contains the base classes for the signal process
 | 3   | `SettingsType`        | bound to ez.Settings                                                       |
 | 4   | `StateType` (St)      | bound to ProcessorState which is simply ez.State with a `hash: int` field. |
 
+
 ### Protocols
 
 | Idx | Class                 | Parent | State | `__call__` sig           | @state | partial_fit |
 |-----|-----------------------|--------|-------|--------------------------|--------|-------------|
-| 1   | `Processor`           | -      | No    | [Mi, None] ->[Mo, None]  | -      | -           |
-| 2   | `Producer`            | -      | No    | Mi -> Mo                 | -      | -           |
+| 1   | `Processor`           | -      | No    | Any -> Any               | -      | -           |
+| 2   | `Producer`            | -      | No    | None -> Mo               | -      | -           |
 | 3   | `Consumer`            | 1      | No    | Mi -> None               | -      | -           |
 | 4   | `Transformer`         | 1      | No    | Mi -> Mo                 | -      | -           |
-| 5   | `StatefulProcessor`   | -      | Yes   | [Mi, None] -> [Mo, None] | Y      | -           |
+| 5   | `StatefulProcessor`   | -      | Yes   | Any -> Any               | Y      | -           |
 | 6   | `StatefulProducer`    | -      | Yes   | None -> Mo               | Y      | -           |
 | 7   | `StatefulConsumer`    | 5      | Yes   | Mi -> None               | Y      | -           |
 | 8   | `StatefulTransformer` | 5      | Yes   | Mi -> Mo                 | Y      | -           |
@@ -29,94 +33,107 @@ The `ezmsg.sigproc.base` module contains the base classes for the signal process
 
 Note: `__call__` and `partial_fit` both have asynchronous alternatives: `__acall__` and `apartial_fit` respectively.
 
+
 ### Abstract implementations (Base Classes) for standalone processors
 
-| Idx | Class                     | Parent | Protocol | Features                                                                           |
-|-----|---------------------------|--------|----------|------------------------------------------------------------------------------------|
-| 1   | `BaseProcessor`           | -      | 1        | `__init__` for settings; `__call__` (alias: `send`) wraps abstract `_process`.     |
-| 2   | `BaseProducer`            | -      | 2        | Similar to `BaseProcessor`; next/anext instead of send/asend aliases. async first! |
-| 3   | `BaseConsumer`            | 1      | 3        | Override return types only                                                         |
-| 4   | `BaseTransformer`         | 1      | 4        | Override return types only                                                         |
-| 5   | `BaseStatefulProcessor`   | 1      | 5        | `state` setter unpickles arg; `stateful_op` wraps `__call__`                       |
-| 6   | `BaseStatefulProducer`    | 2      | 6        | `state` setter and getter; `stateful_op` wraps `__call__` which runs `__acall__`.  |
-| 7   | `BaseStatefulConsumer`    | 5      | 7        | Override return types only                                                         |
-| 8   | `BaseStatefulTransformer` | 5      | 8        | Override return types only                                                         |
-| 9   | `BaseAdaptiveTransformer` | 8      | 9        | Implements `partial_fit`. __call__` may call partial_fit if message has .trigger   |
-| 10  | `BaseAsyncTransformer`    | 8      | 8        | `__acall__` wraps abstract `_aprocess`; `__call__` runs `__acall__`.               |
-| 11  | `CompositeProcessor`      | 1      | 5        | Methods iterate over sequence of processors created in `_initialize_processors`.   |
+| Idx | Class                     | Parent | Protocol | Features                                                                                   |
+|-----|---------------------------|--------|----------|--------------------------------------------------------------------------------------------|
+| 1   | `BaseProcessor`           | -      | 1        | `__init__` for settings; `__call__` (alias: `send`) wraps abstract `_process`.             |
+| 2   | `BaseProducer`            | -      | 2        | Similar to `BaseProcessor`; `next`/`anext` instead of `send`/`asend` aliases. async first! |
+| 3   | `BaseConsumer`            | 1      | 3        | Overrides return type to None                                                              |
+| 4   | `BaseTransformer`         | 1      | 4        | Overrides input and return types                                                           |
+| 5   | `BaseStatefulProcessor`   | 1      | 5        | `state` setter unpickles arg; `stateful_op` wraps `__call__`                               |
+| 6   | `BaseStatefulProducer`    | 2      | 6        | `state` setter and getter; `stateful_op` wraps `__call__` which runs `__acall__`.          |
+| 7   | `BaseStatefulConsumer`    | 5      | 7        | Overrides return type to None                                                              |
+| 8   | `BaseStatefulTransformer` | 5      | 8        | Overrides input and return types                                                           |
+| 9   | `BaseAdaptiveTransformer` | 8      | 9        | Implements `partial_fit`. `__call__` may call `partial_fit` if message has `.trigger`.     |
+| 10  | `BaseAsyncTransformer`    | 8      | 8        | `__acall__` wraps abstract `_aprocess`; `__call__` runs `__acall__`.                       |
+| 11  | `CompositeProcessor`      | 1      | 5        | Methods iterate over sequence of processors created in `_initialize_processors`.           |
+| 12  | `CompositeProducer`       | 2      | 6        | Similar to `CompositeProcessor`, but first processor must be a producer.                   |
 
-For most base classes, the async methods simply call the synchronous methods where the processor logic is expected. Exceptions are `BaseProducer` (and its children) and `BaseAsyncTransformer` which are async-first and should be strongly considered for operations that are I/O bound.
+NOTES:
+1. Producers do not inherit from `BaseProcessor`, so concrete implementations should subclass `BaseProducer` or `BaseStatefulProducer`.
+2. For concrete implementations of non-producer processors, inherit from the base subclasses of `BaseProcessor` (eg. `BaseConsumer`, `BaseTransformer`) and from base subclasses of `BaseStatefulProcessor`. These two processor classes are primarily used for efficient abstract base class construction.
+3. For most base classes, the async methods simply call the synchronous methods where the processor logic is expected. Exceptions are `BaseProducer` (and its children) and `BaseAsyncTransformer` which are async-first and should be strongly considered for operations that are I/O bound.
+4. For async-first classes, the logic is implemented in the async methods and the sync methods are thin wrappers around the async methods. The wrapper uses a helper method called `run_coroutine_sync` to run the async method in a synchronous context, but this adds some noticeable processing overhead.
+5. If you need to call your processor outside ezmsg (which uses async), and you cannot easily add an async context* in your processing, then you might want to consider duplicating the processor logic in the sync methods. __Note__: Jupyter notebooks are async by default, so you can await async code in a notebook without any extra setup.
+6. `CompositeProcessor` and `CompositeProducer` are stateful, and structurally subclass the `StatefulProcessor` and `StatefulProducer` protocols, but they
+do not inherit from `BaseStatefulProcessor` and `BaseStatefulProducer`. They accomplish statefulness by inheriting from the mixin abstract base class `CompositeStateful`, which implements the state related methods: `get_state_type`, `state.setter`, `state.getter`, `_hash_message`, `_reset_state`, and `stateful_op` (as well as composite processor chain related methods). However, `BaseStatefulProcessor`, `BaseStatefulProducer` implement `stateful_op` method for a single processor in an incompatible way to what is required for composite chains of processors. 
 
-For async-first classes, the logic is implemented in the async methods and the sync methods are thin wrappers around the async methods. The wrapper uses a helper method called `run_coroutine_sync` to run the async method in a synchronous context, but this adds some noticeable processing overhead.
-
-If you need to call your processor outside ezmsg (which uses async), and you cannot easily add an async context* in your processing, then you might want to consider duplicating the processor logic in the sync methods.
-
-* Note: Jupyter notebooks are async by default, so you can await async code in a notebook without any extra setup.
 
 ### Generic TypeVars for ezmsg Units
 
-| Idx | Class                     | Description                                                                                 |
-|-----|---------------------------|---------------------------------------------------------------------------------------------|
-| 4   | `ProducerType`            | bound to BaseProducer, BaseStatefulProducer                                                 |
-| 5   | `ConsumerType`            | bound to BaseConsumer, BaseStatefulConsumer                                                 |
-| 6   | `TransformerType`         | bound to BaseTransformer, BaseStatefulTransformer, BaseAsyncTransformer, CompositeProcessor |
-| 7   | `AdaptiveTransformerType` | bound to BaseAdaptiveTransformer                                                            |
+| Idx | Class                     | Description                                                                                                      |
+|-----|---------------------------|------------------------------------------------------------------------------------------------------------------|
+| 5   | `ProducerType`            | bound to `BaseProducer` (hence, also `BaseStatefulProducer`, `CompositeProducer`)                                |
+| 6   | `ConsumerType`            | bound to `BaseConsumer`, `BaseStatefulConsumer`                                                                  |
+| 7   | `TransformerType`         | bound to `BaseTransformer`, `BaseStatefulTransformer`, `CompositeProcessor` (hence, also `BaseAsyncTransformer`) |
+| 8   | `AdaptiveTransformerType` | bound to `BaseAdaptiveTransformer`                                                                               |
 
 
 ### Abstract implementations (Base Classes) for ezmsg Units using processors:
 
 | Idx | Class                         | Parents | Expected TypeVars         |
 |-----|-------------------------------|---------|---------------------------|
-| 1   | `BaseConsumerUnit`            | -       | `ConsumerType`            |
+| 1   | `BaseProcessorUnit`           | -       | -                         |
 | 2   | `BaseProducerUnit`            | -       | `ProducerType`            |
-| 3   | `BaseTransformerUnit`         | 1       | `TransformerType`         |
-| 4   | `BaseAdaptiveTransformerUnit` | 3       | `AdaptiveTransformerType` |
+| 3   | `BaseConsumerUnit`            | 1       | `ConsumerType`            |
+| 4   | `BaseTransformerUnit`         | 1       | `TransformerType`         |
+| 5   | `BaseAdaptiveTransformerUnit` | 1       | `AdaptiveTransformerType` |
+
+Note, it is strongly recommended to use `BaseConsumerUnit`, `BaseTransformerUnit`, or `BaseAdaptiveTransformerUnit` for implementing concrete subclasses rather than `BaseProcessorUnit`.
 
 
 ## Implementing a custom standalone processor
 
 1. Create a new settings dataclass: `class MySettings(ez.Settings):`
-2. Create a new state dataclass: `class MyState(ProcessorState):`
+2. Create a new state dataclass: 
+```
+@processor_state
+class MyState:
+```
 3. Decide on your base processor class, considering the protocol, whether it should be async-first, and other factors.
 
 ```mermaid
 flowchart TD
-    AA{Multiple Processors?};
-    A{Receives Input?};
-    B(Producer);
-    C{Produces Output?};
-    D(Consumer);
-    E(Transformer);
-    AA -->|no| A;
-    AA -->|single chain| CompositeProcessor;
-    AA -->|branching| BB[no base class];
-    A -->|no| B;
-    A -->|yes| C;
-    C -->|no| D;
-    C -->|yes| E;
-    B --> F{Stateful?};
-    F -->|no| BaseProducer;
-    F -->|yes| BaseStatefulProducer;
-    D --> H{Stateful?};
-    H -->|no| BaseConsumer;
-    H -->|yes| BaseStatefulConsumer;
-    E --> G{Stateful?};
-    G -->|no| BaseTransformer;
-    G -->|yes| I{Adaptive?};
-    I -->|no| BaseStatefulTransformer;
-    I -->|yes| J{async first?};
-    J -->|no| BaseAdaptiveTransformer;
-    J -->|yes| BaseAsyncTransformer;
+    AMP{Multiple Processors?};
+    AMP -->|no| ARI{Receives Input?};
+    AMP -->|yes| ACB{Single Chain / Branching?}
+    ARI -->|no| P(Producer);
+    ARI -->|yes| APO{Produces Output?};
+    ACB -->|branching| NBC[no base class];
+    ACB -->|single chain| ACRI{Receives Input?};
+    P --> PS{Stateful?};
+    APO -->|no| C(Consumer);
+    APO -->|yes| T(Transformer);
+    ACRI -->|no| CompositeProducer;
+    ACRI -->|yes| CompositeProcessor;
+    PS -->|no| BaseProducer;
+    PS -->|yes| BaseStatefulProducer;
+    C --> CS{Stateful?};
+    T --> TS{Stateful?};
+    CS -->|no| BaseConsumer;
+    CS -->|yes| BaseStatefulConsumer;
+    TS -->|no| BaseTransformer;
+    TS -->|yes| TSA{Adaptive?};
+    TSA -->|no| TSAF{Async First?};
+    TSA -->|yes| BaseAdaptiveTransformer;
+    TSAF -->|no| BaseStatefulTransformer;
+    TSAF -->|yes| BaseAsyncTransformer;
 ```
 
 4. Implement the child class.
-    * The minimum implementation is `_process` for sync processors and `_aprocess` for async processors.
+    * The minimum implementation is `_process` for sync processors, `_aprocess` for async processors, and `_produce` for producers.
     * For any stateful processor, implement `_reset_state`.
     * For stateful processors that need to respond to a change in the incoming data, implement `_hash_message`.
+    * For adaptive transformers, implement `partial_fit`.
+    * For chains of processors (`CompositeProcessor`/ `CompositeProducer`), need to implement `_initialize_processors`.
     * See processors in `ezmsg.sigproc` for examples.
 5. Override non-abstract methods if you need special behaviour. For example:
     * `WindowTransformer` overrides `__init__` to do some sanity checks on the provided settings.
     * `TransposeTransformer` and `WindowTransformer` override `__call__` to provide a passthrough shortcut when the settings allow for it.
+    * `ClockProducer` overrides `__call__` in order to provide a synchronous call bypassing the default async behaviour.
+
 
 ## Implementing a custom ezmsg Unit
 
@@ -152,3 +169,5 @@ class CustomUnit(BaseTransformerUnit[
     ]):
         SETTINGS = CustomTransformerSettings
 ```
+
+__Note__, the type of ProcessorUnit is based on the internal processor and not the input or output of the unit. Input streams are allowed in ProducerUnits and output streams in ConsumerUnits. For an example of such a use case, see `BaseCounterFirstProducerUnit` and its subclasses. `BaseCounterFirstProducerUnit` has an input stream that receives a flag signal from a clock that triggers a call to the internal producer. 

--- a/src/ezmsg/sigproc/bandpower.py
+++ b/src/ezmsg/sigproc/bandpower.py
@@ -10,6 +10,7 @@ from .aggregate import (
     RangedAggregateSettings,
 )
 from .base import (
+    BaseProcessor,
     CompositeProcessor,
     BaseStatefulProcessor,
     BaseTransformerUnit,
@@ -40,7 +41,7 @@ class BandPowerTransformer(CompositeProcessor[BandPowerSettings, AxisArray, Axis
     @staticmethod
     def _initialize_processors(
         settings: BandPowerSettings,
-    ) -> dict[str, BaseStatefulProcessor]:
+    ) -> dict[str, BaseProcessor | BaseStatefulProcessor]:
         return {
             "spectrogram": SpectrogramTransformer(
                 settings=settings.spectrogram_settings

--- a/src/ezmsg/sigproc/diff.py
+++ b/src/ezmsg/sigproc/diff.py
@@ -29,7 +29,7 @@ class DiffTransformer(
         sample_shape = message.data.shape[:ax_idx] + message.data.shape[ax_idx + 1 :]
         return hash((sample_shape, message.key))
 
-    def _reset_state(self, message):
+    def _reset_state(self, message) -> None:
         ax_idx = message.get_axis_idx(self.settings.axis)
         self.state.last_dat = slice_along_axis(message.data, slice(0, 1), axis=ax_idx)
         if self.settings.scale_by_fs:

--- a/src/ezmsg/sigproc/ewma.py
+++ b/src/ezmsg/sigproc/ewma.py
@@ -176,7 +176,7 @@ class EWMATransformer(
         )
         self._state.zi = (1 - self._state.alpha) * sub_dat
 
-    def _process(self, message: npt.NDArray) -> npt.NDArray:
+    def _process(self, message: AxisArray) -> AxisArray:
         axis = self.settings.axis or message.dims[0]
         axis_idx = message.get_axis_idx(axis)
         expected, self._state.zi = sps.lfilter(

--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -218,8 +218,11 @@ class FilterByDesignTransformer(
     """Abstract base class for filter design transformers."""
 
     @classmethod
-    def get_message_type(cls, _) -> typing.Type[AxisArray]:
-        return AxisArray
+    def get_message_type(cls, dir: str) -> type[AxisArray]:
+        if dir in ("in", "out"):
+            return AxisArray
+        else:
+            raise ValueError(f"Invalid direction: {dir}. Must be 'in' or 'out'.")
 
     @abstractmethod
     def get_design_function(self) -> typing.Callable[[float], FilterCoefsType | None]:

--- a/src/ezmsg/sigproc/resample.py
+++ b/src/ezmsg/sigproc/resample.py
@@ -141,7 +141,7 @@ class ResampleProcessor(
         buf.tvec = np.hstack((buf.tvec, in_tvec))
         buf.last_update = time.time()
 
-    def push_reference(self, message: AxisArray):
+    def push_reference(self, message: AxisArray) -> None:
         ax = message.axes[self.settings.axis]
         ax_idx = message.get_axis_idx(self.settings.axis)
         n_new = message.data.shape[ax_idx]
@@ -173,7 +173,7 @@ class ResampleProcessor(
                 ref_tvec = self.state.ref_axis[0].data[:2]
             self.state.last_t_out = 2 * ref_tvec[0] - ref_tvec[1]
 
-    def __next__(self):
+    def __next__(self) -> AxisArray:
         buf = self.state.signal_buffer
 
         if buf is None:

--- a/src/ezmsg/sigproc/spectrogram.py
+++ b/src/ezmsg/sigproc/spectrogram.py
@@ -1,3 +1,4 @@
+from typing import Generator
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import AxisArray
 from ezmsg.util.messages.modify import modify_axis
@@ -46,7 +47,7 @@ class SpectrogramTransformer(
     @staticmethod
     def _initialize_processors(
         settings: SpectrogramSettings,
-    ) -> dict[str, BaseStatefulProcessor]:
+    ) -> dict[str, BaseStatefulProcessor | Generator[AxisArray, AxisArray, None]]:
         return {
             "windowing": WindowTransformer(
                 axis="time",

--- a/src/ezmsg/sigproc/synth.py
+++ b/src/ezmsg/sigproc/synth.py
@@ -65,10 +65,10 @@ class AddProcessor:
         return run_coroutine_sync(self.__acall__())
 
     # Aliases for legacy interface
-    async def __anext__(self):
+    async def __anext__(self) -> AxisArray:
         return await self.__acall__()
 
-    def __next__(self):
+    def __next__(self) -> AxisArray:
         return self.__call__()
 
 
@@ -251,10 +251,13 @@ class CounterProducer(BaseStatefulProducer[CounterSettings, AxisArray, CounterSt
     # TODO: Adapt this to use ezmsg.util.rate?
 
     @classmethod
-    def get_message_type(cls, dir: str) -> typing.Type[typing.Optional[AxisArray]]:
+    def get_message_type(cls, dir: str) -> type[typing.Optional[AxisArray]]:
         if dir == "in":
             return typing.Optional[AxisArray]
-        return AxisArray
+        elif dir == "out":
+            return AxisArray
+        else:
+            raise ValueError(f"Invalid direction: {dir}. Use 'in' or 'out'.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -492,11 +495,11 @@ class RandomTransformer(BaseTransformer[RandomGeneratorSettings, AxisArray, Axis
     ):
         super().__init__(*args, settings=settings, **kwargs)
 
-    def _process(self, msg: AxisArray) -> AxisArray:
+    def _process(self, message: AxisArray) -> AxisArray:
         random_data = np.random.normal(
-            size=msg.shape, loc=self.settings.loc, scale=self.settings.scale
+            size=message.shape, loc=self.settings.loc, scale=self.settings.scale
         )
-        return replace(msg, data=random_data)
+        return replace(message, data=random_data)
 
 
 class RandomGenerator(

--- a/src/ezmsg/sigproc/transpose.py
+++ b/src/ezmsg/sigproc/transpose.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 import numpy as np
 import ezmsg.core as ez
 from ezmsg.util.messages.axisarray import (
@@ -20,7 +21,7 @@ class TransposeSettings(ez.Settings):
       axes:
     """
 
-    axes: tuple[int | str | type(...), ...] | None = None
+    axes: tuple[int | str | EllipsisType, ...] | None = None
     order: str | None = None
 
 
@@ -125,6 +126,6 @@ class Transpose(
 
 
 def transpose(
-    axes: tuple[int | str | type(...), ...] | None = None, order: str | None = None
+    axes: tuple[int | str | EllipsisType, ...] | None = None, order: str | None = None
 ) -> TransposeTransformer:
     return TransposeTransformer(TransposeSettings(axes=axes, order=order))

--- a/src/ezmsg/sigproc/util/message.py
+++ b/src/ezmsg/sigproc/util/message.py
@@ -24,3 +24,8 @@ class SampleMessage:
 
     sample: AxisArray
     """The data sampled around the trigger."""
+
+
+def is_sample_message(message: typing.Any) -> typing.TypeGuard[SampleMessage]:
+    """Check if the message is a SampleMessage."""
+    return hasattr(message, "trigger")

--- a/src/ezmsg/sigproc/util/typeresolution.py
+++ b/src/ezmsg/sigproc/util/typeresolution.py
@@ -1,14 +1,46 @@
 from types import UnionType
 import typing
+from typing_extensions import get_original_bases
+
+
+def resolve_typevar(cls: type, target_typevar: typing.TypeVar) -> type:
+    """
+    Resolve the concrete type bound to a TypeVar in a class hierarchy.
+    This function traverses the method resolution order (MRO) of the class
+    and checks the original bases of each class in the MRO for the TypeVar.
+    If the TypeVar is found, it returns the concrete type bound to it.
+    If the TypeVar is not found, it raises a TypeError.
+    Args:
+        cls (type): The class to inspect.
+        target_typevar (typing.TypeVar): The TypeVar to resolve.
+    Returns:
+        type: The concrete type bound to the TypeVar.
+    """
+    for base in cls.__mro__:
+        orig_bases = get_original_bases(base)
+        for orig_base in orig_bases:
+            origin = typing.get_origin(orig_base)
+            if origin is None:
+                continue
+            params = getattr(origin, "__parameters__", ())
+            if not params:
+                continue
+            if target_typevar in params:
+                index = params.index(target_typevar)
+                args = typing.get_args(orig_base)
+                try:
+                    return args[index]
+                except IndexError:
+                    pass
+    raise TypeError(f"Could not resolve {target_typevar} in {cls}")
 
 
 TypeLike = typing.Union[typing.Type[typing.Any], typing.Any, type(None), None]
 
 
-def _check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:
+def check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:
     """
     Check if two types are compatible for message passing.
-
     Returns True if:
     - Both are None/NoneType
     - Either is typing.Any
@@ -17,11 +49,9 @@ def _check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:
         - type1 is None/NoneType and type2 is typing.Optional, or
         - type1 is subtype of the non-None inner type of type2 if type2 is Optional
     - type1 is a Union/Optional type and all inner types are compatible with type2
-
     Args:
         type1: First type to compare
         type2: Second type to compare
-
     Returns:
         bool: True if the types are compatible, False otherwise
     """
@@ -38,7 +68,7 @@ def _check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:
     # Handle if type1 is Optional/Union type
     if typing.get_origin(type1) in {typing.Union, UnionType}:
         return all(
-            _check_message_type_compatibility(inner_type, type2)
+            check_message_type_compatibility(inner_type, type2)
             for inner_type in typing.get_args(type1)
         )
 

--- a/src/ezmsg/sigproc/util/typeresolution.py
+++ b/src/ezmsg/sigproc/util/typeresolution.py
@@ -35,7 +35,7 @@ def resolve_typevar(cls: type, target_typevar: typing.TypeVar) -> type:
     raise TypeError(f"Could not resolve {target_typevar} in {cls}")
 
 
-TypeLike = typing.Union[typing.Type[typing.Any], typing.Any, type(None), None]
+TypeLike = typing.Union[type[typing.Any], typing.Any, type(None), None]
 
 
 def check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:

--- a/src/ezmsg/sigproc/util/typeresolution.py
+++ b/src/ezmsg/sigproc/util/typeresolution.py
@@ -1,0 +1,53 @@
+from types import UnionType
+import typing
+
+
+TypeLike = typing.Union[typing.Type[typing.Any], typing.Any, type(None), None]
+
+
+def _check_message_type_compatibility(type1: TypeLike, type2: TypeLike) -> bool:
+    """
+    Check if two types are compatible for message passing.
+
+    Returns True if:
+    - Both are None/NoneType
+    - Either is typing.Any
+    - type1 is a subclass of type2, which includes
+        - type1 and type2 are concrete types and type1 is a subclass of type2
+        - type1 is None/NoneType and type2 is typing.Optional, or
+        - type1 is subtype of the non-None inner type of type2 if type2 is Optional
+    - type1 is a Union/Optional type and all inner types are compatible with type2
+
+    Args:
+        type1: First type to compare
+        type2: Second type to compare
+
+    Returns:
+        bool: True if the types are compatible, False otherwise
+    """
+    # If either is Any, they are compatible
+    if type1 is typing.Any or type2 is typing.Any:
+        return True
+
+    # Handle None as NoneType
+    if type1 is None:
+        type1 = type(None)
+    if type2 is None:
+        type2 = type(None)
+
+    # Handle if type1 is Optional/Union type
+    if typing.get_origin(type1) in {typing.Union, UnionType}:
+        return all(
+            _check_message_type_compatibility(inner_type, type2)
+            for inner_type in typing.get_args(type1)
+        )
+
+    # Regular issubclass check. Handles cases like:
+    # - type1 is a subclass of concrete type2
+    # - type1 is a subclass of the inner type of type2 if type2 is Optional
+    # - type1 is a subclass of one of the inner types of type2 if type2 is Union
+    # - type1 is NoneType and type2 is Optional or Union[None, ...] or Union[NoneType, ...]
+    try:
+        return issubclass(type1, type2)
+    except TypeError:
+        return False

--- a/src/ezmsg/sigproc/window.py
+++ b/src/ezmsg/sigproc/window.py
@@ -64,7 +64,7 @@ class WindowTransformer(
     can be difficult. Please read the argument descriptions carefully.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         """
 
         Args:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -37,7 +37,7 @@ class MockSettings:
     param2: str = "test"
 
 
-@processor_state()
+@processor_state
 class MockState:
     iterations: int = 0
     hash: int = -1
@@ -373,16 +373,16 @@ class TestHelperFunctions:
         )
 
         # Test with producers (should throw)
-        with pytest.raises(TypeError, match="Could not resolve ~MessageInType"):
+        with pytest.raises(TypeError, match="Could not resolve MessageInType"):
             _get_base_processor_message_in_type(MockProducer)
-        with pytest.raises(TypeError, match="Could not resolve ~MessageInType"):
+        with pytest.raises(TypeError, match="Could not resolve MessageInType"):
             _get_base_processor_message_in_type(MockStatefulProducer)
 
         # Test with no message in type should raise exception
         class NoMessageInTypeClass:
             pass
 
-        with pytest.raises(TypeError, match="Could not resolve ~MessageInType"):
+        with pytest.raises(TypeError, match="Could not resolve MessageInType"):
             _get_base_processor_message_in_type(NoMessageInTypeClass)
 
     def test_get_base_processor_message_out_type(self):
@@ -429,7 +429,7 @@ class TestHelperFunctions:
         class NoMessageOutTypeClass:
             pass
 
-        with pytest.raises(TypeError, match="Could not resolve ~MessageOutType"):
+        with pytest.raises(TypeError, match="Could not resolve MessageOutType"):
             _get_base_processor_message_out_type(NoMessageOutTypeClass)
 
     # Test _unify_settings function through the MockProcessor class __init__
@@ -477,6 +477,10 @@ class TestHelperFunctions:
             _get_base_processor_state_type(ChebyshevFilterTransformer)
             == FilterByDesignState
         )
+        assert (
+            _get_base_processor_state_type(ValidMultipleCompositeProcessor)
+            == dict[str, Any]
+        )
 
         # Test with class that doesn't have state type
         with pytest.raises(Exception, match="Could not resolve state type"):
@@ -489,8 +493,6 @@ class TestHelperFunctions:
             _get_base_processor_state_type(MockConsumer)
         with pytest.raises(Exception, match="Could not resolve state type"):
             _get_base_processor_state_type(MockTransformer)
-        with pytest.raises(Exception, match="Could not resolve state type"):
-            _get_base_processor_state_type(ValidMultipleCompositeProcessor)
 
     def test_get_processor_message_type(self):
         processor = MockProcessor(MockSettings())
@@ -516,7 +518,7 @@ class TestHelperFunctions:
         assert _get_processor_message_type(deep_transformer, "in") == MockMessageA
         assert _get_processor_message_type(deep_transformer, "out") == MockMessageC
 
-        # Test with invalid direction (currently not supported)
+        # Test with invalid direction
         with pytest.raises(ValueError, match="Invalid direction"):
             _get_processor_message_type(processor, "invalid")
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,0 +1,851 @@
+import dataclasses
+import pickle
+import pytest
+from types import NoneType
+import typing
+from unittest.mock import MagicMock
+
+from ezmsg.sigproc.base import (
+    _get_state_type,
+    _get_processor_message_type,
+    _check_message_type_compatibility,
+    processor_state,
+    BaseProcessor,
+    BaseProducer,
+    BaseConsumer,
+    BaseTransformer,
+    BaseStatefulProcessor,
+    BaseStatefulProducer,
+    BaseStatefulConsumer,
+    BaseStatefulTransformer,
+    BaseAdaptiveTransformer,
+    BaseAsyncTransformer,
+    CompositeProcessor,
+    SampleMessage,
+)
+
+# -- Mock Classes for Testing --
+
+
+@dataclasses.dataclass
+class MockSettings:
+    param1: int = 10
+    param2: str = "test"
+
+
+@processor_state()
+class MockState:
+    iterations: int = 0
+    hash: int = -1
+
+
+# Simple mock message types for testing type compatibility
+class MockMessageA:
+    pass
+
+
+class MockMessageB(MockMessageA):
+    pass
+
+
+class MockMessageC:
+    pass
+
+
+# Mock processors for testing
+class MockProcessor(BaseProcessor[MockSettings, MockMessageA, MockMessageB]):
+    def _process(self, message: MockMessageA) -> MockMessageB:
+        return MockMessageB()
+
+
+class DeepMockProcessor(MockProcessor):
+    def _process(self, message: MockMessageA) -> MockMessageB:
+        return MockMessageB()
+
+
+class MockProducer(BaseProducer[MockSettings, MockMessageA]):
+    async def _produce(self) -> MockMessageA:
+        return MockMessageA()
+
+
+class MockConsumer(BaseConsumer[MockSettings, MockMessageB]):
+    def _process(self, message: MockMessageB) -> None:
+        pass
+
+
+class MockTransformer(BaseTransformer[MockSettings, MockMessageA, MockMessageC]):
+    def _process(self, message: MockMessageA) -> MockMessageC:
+        return MockMessageC()
+
+
+class DeepMockTransformer(MockTransformer):
+    pass
+
+
+class DeeperMockTransformer(DeepMockTransformer):
+    pass
+
+
+class MockStatefulProcessor(
+    BaseStatefulProcessor[MockSettings, MockMessageA, MockMessageB, MockState]
+):
+    def _reset_state(self, message: MockMessageA) -> None:
+        self._state.iterations = 0
+
+    def _process(self, message: MockMessageA) -> MockMessageB:
+        self._state.iterations += 1
+        return MockMessageB()
+
+
+class DeepMockStatefulProcessor(MockStatefulProcessor):
+    pass
+
+
+class MockStatefulProducer(BaseStatefulProducer[MockSettings, MockMessageA, MockState]):
+    def _reset_state(self) -> None:
+        self._state.iterations = 0
+
+    async def _produce(self) -> MockMessageA:
+        self._state.iterations += 1
+        return MockMessageA()
+
+
+class MockStatefulConsumer(BaseStatefulConsumer[MockSettings, MockMessageB, MockState]):
+    def _reset_state(self, message: MockMessageB) -> None:
+        self._state.iterations = 0
+
+    def _process(self, message: MockMessageB) -> None:
+        self._state.iterations += 1
+
+
+class MockStatefulTransformer(
+    BaseStatefulTransformer[MockSettings, MockMessageA, MockMessageC, MockState]
+):
+    def _reset_state(self, message: MockMessageA) -> None:
+        self._state.iterations = 0
+
+    def _process(self, message: MockMessageA) -> MockMessageC:
+        self._state.iterations += 1
+        return MockMessageC()
+
+
+class MockAdaptiveTransformer(
+    BaseAdaptiveTransformer[MockSettings, MockMessageA, MockMessageB, MockState]
+):
+    def _reset_state(self, message: MockMessageA) -> None:
+        self._state.iterations = 0
+
+    def _process(self, message: MockMessageA) -> MockMessageB:
+        self._state.iterations += 1
+        return MockMessageB()
+
+    def partial_fit(self, message: SampleMessage) -> None:
+        self._state.iterations += 1
+
+
+class MockAsyncTransformer(
+    BaseAsyncTransformer[MockSettings, MockMessageA, MockMessageB, MockState]
+):
+    def _reset_state(self, message: MockMessageA) -> None:
+        self._state.iterations = 0
+
+    async def _aprocess(self, message: MockMessageA) -> MockMessageB:
+        self._state.iterations += 1
+        return MockMessageB()
+
+
+# Mock CompositeProcessor examples
+class ValidSingleCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageB]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {"processor": MockProcessor(settings=settings)}
+
+
+class ValidMultipleCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageB]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "processor": MockProcessor(settings=settings),
+            "stateful_processor": MockStatefulProcessor(settings=settings),
+        }
+
+
+class EmptyCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageB]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {}
+
+
+class InvalidOutputCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageB]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {"transformer": MockTransformer(settings=settings)}
+
+
+class InvalidInputCompositeProcessor(
+    CompositeProcessor[MockSettings, None, MockMessageC]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {"transformer": MockTransformer(settings=settings)}
+
+
+class InvalidProducerNotFirstCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageA]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "processor": MockProcessor(settings=settings),
+            "producer": MockProducer(settings=settings),
+        }
+
+
+class InvalidConsumerNotLastCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageB, MockMessageC]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "consumer": MockConsumer(settings=settings),
+            "transformer": MockTransformer(settings=settings),
+        }
+
+
+class TypeMismatchCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, None]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "transformer": MockTransformer(settings=settings),
+            "consumer": MockConsumer(settings=settings),
+        }
+
+
+class ChainedCompositeProcessor(CompositeProcessor[MockSettings, MockMessageA, None]):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "processor": MockProcessor(settings=settings),
+            "stateful_consumer": MockStatefulConsumer(settings=settings),
+        }
+
+
+class ChainedWithProducerCompositeProcessor(
+    CompositeProcessor[MockSettings, NoneType, MockMessageC]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "stateful_producer": MockStatefulProducer(settings=settings),
+            "stateful_transformer": MockStatefulTransformer(settings=settings),
+        }
+
+
+class ChainedCompositeProcessorWithDeepProcessors(
+    CompositeProcessor[MockSettings, NoneType, MockMessageC]
+):
+    @staticmethod
+    def _initialize_processors(settings: MockSettings) -> dict[str, typing.Any]:
+        return {
+            "stateful_producer": MockStatefulProducer(settings=settings),
+            "deep_processor": DeepMockProcessor(settings=settings),
+            "deeper_transformer": DeeperMockTransformer(settings=settings),
+        }
+
+
+def mock_generator() -> typing.Generator[MockMessageA, MockMessageA, None]:
+    """A mock generator function for testing purposes."""
+    yield MockMessageA()
+
+
+class MockGeneratorCompositeProcessor(
+    CompositeProcessor[MockSettings, MockMessageA, MockMessageB]
+):
+    @staticmethod
+    def _initialize_processors(settings):
+        return {
+            "generator": mock_generator(),
+            "stateful_processor": MockStatefulProcessor(settings=settings),
+        }
+
+
+# -- Tests for Helper Functions --
+
+
+class TestHelperFunctions:
+    def test_processor_state_decorator(self):
+        # Test that processor_state creates a dataclass with the right properties
+        state = MockState()
+        assert state.iterations == 0
+        assert state.hash == -1
+
+        # Test that we can modify it (not frozen)
+        state.iterations = 5
+        assert state.iterations == 5
+
+        # Test hash functionality
+        state1 = MockState()
+        state2 = MockState()
+        assert hash(state1) == hash(state2)
+
+        state1.iterations = 10
+        assert hash(state1) != hash(state2)
+
+    # Test _unify_settings function through the MockProcessor class __init__
+    def test_unify_settings_with_provided_settings(self):
+        settings = MockSettings(param1=20)
+        obj = MockProcessor(settings=settings)
+        assert obj.settings.param1 == 20
+        assert obj.settings.param2 == "test"
+
+    def test_unify_settings_with_settings_arg(self):
+        obj = MockProcessor(MockSettings(param1=30, param2="new"))
+        assert obj.settings.param1 == 30
+        assert obj.settings.param2 == "new"
+
+    def test_unify_settings_with_args(self):
+        obj = MockProcessor(40, "newer")
+        assert obj.settings.param1 == 40
+        assert obj.settings.param2 == "newer"
+
+    def test_unify_settings_with_kwargs(self):
+        obj = MockProcessor(param1=50)
+        assert obj.settings.param1 == 50
+        assert obj.settings.param2 == "test"
+
+    def test_unify_settings_with_args_kwargs(self):
+        obj = MockProcessor(60, param2="newest")
+        assert obj.settings.param1 == 60
+        assert obj.settings.param2 == "newest"
+
+    def test_unify_settings_with_default(self):
+        obj = MockProcessor()
+        assert obj.settings.param1 == 10
+        assert obj.settings.param2 == "test"
+
+    def test_get_state_type(self):
+        # Test with class that has state type
+        assert _get_state_type(MockStatefulProcessor) == MockState
+        assert _get_state_type(DeepMockStatefulProcessor) == MockState
+        assert _get_state_type(MockStatefulProducer) == MockState
+        assert _get_state_type(MockStatefulConsumer) == MockState
+        assert _get_state_type(MockStatefulTransformer) == MockState
+        assert _get_state_type(MockAdaptiveTransformer) == MockState
+        assert _get_state_type(MockAsyncTransformer) == MockState
+
+        # Test with class that doesn't have state type
+        assert _get_state_type(MockProcessor) is None
+        assert _get_state_type(DeepMockProcessor) is None
+        assert _get_state_type(MockProducer) is None
+        assert _get_state_type(MockConsumer) is None
+        assert _get_state_type(MockTransformer) is None
+        assert _get_state_type(ValidMultipleCompositeProcessor) is None
+
+    def test_get_processor_message_type(self):
+        processor = MockProcessor(MockSettings())
+        producer = MockProducer(MockSettings())
+        consumer = MockConsumer(MockSettings())
+        deep_transformer = DeeperMockTransformer(MockSettings())
+
+        # Test getting input type
+        assert _get_processor_message_type(processor, "in") == MockMessageA
+
+        # Test getting output type
+        assert _get_processor_message_type(processor, "out") == MockMessageB
+
+        # Test with producer
+        assert _get_processor_message_type(producer, "in") is None
+        assert _get_processor_message_type(producer, "out") == MockMessageA
+
+        # Test with consumer
+        assert _get_processor_message_type(consumer, "in") == MockMessageB
+        assert _get_processor_message_type(consumer, "out") is None
+
+        # Test with deep subclass (transformer)
+        assert _get_processor_message_type(deep_transformer, "in") == MockMessageA
+        assert _get_processor_message_type(deep_transformer, "out") == MockMessageC
+
+        # # Test with invalid direction (currently not supported)
+        # with pytest.raises(ValueError, match="Invalid direction"):
+        #     _get_processor_message_type(processor, "invalid")
+
+    def test_check_message_type_compatibility(self):
+        # Test compatible types (subclass)
+        assert _check_message_type_compatibility(MockMessageB, MockMessageA)
+
+        # Test incompatible types
+        assert not _check_message_type_compatibility(MockMessageC, MockMessageA)
+        assert not _check_message_type_compatibility(MockMessageA, MockMessageB)
+        assert not _check_message_type_compatibility(None, MockMessageA)
+        assert not _check_message_type_compatibility(MockMessageA, None)
+        assert not _check_message_type_compatibility(NoneType, MockMessageA)
+        assert not _check_message_type_compatibility(MockMessageA, NoneType)
+
+        # Test with None and Any
+        assert _check_message_type_compatibility(None, None)
+        assert _check_message_type_compatibility(
+            NoneType, None
+        )  # currently not supported
+        assert _check_message_type_compatibility(
+            None, NoneType
+        )  # currently not supported
+        assert _check_message_type_compatibility(MockMessageA, typing.Any)
+        assert _check_message_type_compatibility(typing.Any, MockMessageA)
+        assert _check_message_type_compatibility(None, typing.Any)
+        assert _check_message_type_compatibility(typing.Any, None)
+
+        # Test with Optional types
+        assert _check_message_type_compatibility(
+            MockMessageA, typing.Optional[MockMessageA]
+        )
+        assert _check_message_type_compatibility(
+            MockMessageB, typing.Optional[MockMessageA]
+        )
+        assert _check_message_type_compatibility(None, typing.Optional[MockMessageA])
+        assert _check_message_type_compatibility(
+            NoneType, typing.Optional[MockMessageA]
+        )
+
+        # Test with incompatible Types and Optional
+        assert not _check_message_type_compatibility(
+            MockMessageA, typing.Optional[MockMessageB]
+        )
+        assert not _check_message_type_compatibility(
+            MockMessageC, typing.Optional[MockMessageA]
+        )
+
+
+# -- Tests for BaseProcessor and derived classes --
+
+
+class TestBaseProcessor:
+    def test_initialization(self):
+        processor = MockProcessor(param1=20)
+        assert processor.settings.param1 == 20
+        assert processor.settings.param2 == "test"
+
+    def test_get_settings_type(self):
+        assert MockProcessor.get_settings_type() == MockSettings
+
+    def test_get_message_type(self):
+        assert MockProcessor.get_message_type("in") == MockMessageA
+        assert MockProcessor.get_message_type("out") == MockMessageB
+
+    def test_call_methods(self):
+        processor = MockProcessor()
+        result = processor(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    @pytest.mark.asyncio
+    async def test_acall_methods(self):
+        processor = MockProcessor()
+        result = await processor.__acall__(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    def test_send_alias(self):
+        processor = MockProcessor()
+        result = processor.send(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    @pytest.mark.asyncio
+    async def test_asend_alias(self):
+        processor = MockProcessor()
+        result = await processor.asend(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    # # currently does not throw
+    # def test_invalid_call(self):
+    #     processor = MockProcessor()
+    #     with pytest.raises(TypeError):
+    #         processor(MockMessageC())
+
+
+class TestBaseConsumer:
+    def test_initialization(self):
+        consumer = MockConsumer(param1=20)
+        assert consumer.settings.param1 == 20
+        assert consumer.settings.param2 == "test"
+
+    def test_get_message_type(self):
+        assert MockConsumer.get_message_type("in") == MockMessageB
+        assert MockConsumer.get_message_type("out") is None
+
+    def test_call_method(self):
+        consumer = MockConsumer()
+        # Should not raise an exception
+        consumer(MockMessageB())
+
+    @pytest.mark.asyncio
+    async def test_acall_method(self):
+        consumer = MockConsumer()
+        # Should not raise an exception
+        await consumer.__acall__(MockMessageB())
+
+
+class TestBaseTransformer:
+    def test_call_method(self):
+        transformer = MockTransformer()
+        result = transformer(MockMessageA())
+        assert isinstance(result, MockMessageC)
+
+    @pytest.mark.asyncio
+    async def test_acall_method(self):
+        transformer = MockTransformer()
+        result = await transformer.__acall__(MockMessageA())
+        assert isinstance(result, MockMessageC)
+
+
+# -- Tests for BaseProducer --
+
+
+class TestBaseProducer:
+    def test_initialization(self):
+        producer = MockProducer(param1=20)
+        assert producer.settings.param1 == 20
+        assert producer.settings.param2 == "test"
+
+    def test_get_settings_type(self):
+        assert MockProducer.get_settings_type() == MockSettings
+
+    def test_get_message_type(self):
+        assert MockProducer.get_message_type("in") is None
+        assert MockProducer.get_message_type("out") == MockMessageA
+
+    def test_call_method(self):
+        producer = MockProducer()
+        result = producer()
+        assert isinstance(result, MockMessageA)
+
+    @pytest.mark.asyncio
+    async def test_acall_method(self):
+        producer = MockProducer()
+        result = await producer.__acall__()
+        assert isinstance(result, MockMessageA)
+
+    def test_iterator_interface(self):
+        producer = MockProducer()
+        result = next(producer)
+        assert isinstance(result, MockMessageA)
+
+    @pytest.mark.asyncio
+    async def test_async_iterator_interface(self):
+        producer = MockProducer()
+        result = await producer.__anext__()
+        assert isinstance(result, MockMessageA)
+
+
+# -- Tests for BaseStatefulProcessor and derived classes --
+
+
+class TestBaseStatefulProcessor:
+    def test_initialization(self):
+        processor = MockStatefulProcessor(param1=20)
+        assert processor.settings.param1 == 20
+        assert processor._hash == -1
+        assert processor.state.iterations == 0
+
+    def test_state_property(self):
+        processor = MockStatefulProcessor()
+        assert processor.state.iterations == 0
+
+        # Modify state
+        processor.state.iterations = 5
+        assert processor.state.iterations == 5
+
+    def test_state_setter_with_state_object(self):
+        processor = MockStatefulProcessor()
+        new_state = MockState()
+        new_state.iterations = 10
+        processor.state = new_state
+        assert processor.state.iterations == 10
+
+    def test_state_setter_with_bytes(self):
+        processor = MockStatefulProcessor()
+        new_state = MockState()
+        new_state.iterations = 15
+        serialized = pickle.dumps(new_state)
+        processor.state = serialized
+        assert processor.state.iterations == 15
+
+    def test_hash_message_default(self):
+        processor = MockStatefulProcessor()
+        assert processor._hash_message(MockMessageA()) == 0
+
+    def test_state_reset_on_first_call(self):
+        processor = MockStatefulProcessor()
+        assert processor._hash == -1
+
+        # First call should trigger state reset
+        processor(MockMessageA())
+        assert processor._hash == 0
+        assert processor.state.iterations == 1
+
+    def test_stateful_op(self):
+        processor = MockStatefulProcessor()
+        state = (MockState(), -1)
+        new_state, result = processor.stateful_op(state, MockMessageA())
+        assert isinstance(result, MockMessageB)
+        assert new_state[0].iterations == 1
+        assert new_state[1] == 0  # hash updated
+
+
+class TestBaseStatefulConsumer:
+    def test_stateful_op(self):
+        consumer = MockStatefulConsumer()
+        state = (MockState(), 0)
+        new_state, result = consumer.stateful_op(state, MockMessageB())
+        assert result is None
+        assert new_state[0].iterations == 1
+
+
+class TestBaseStatefulTransformer:
+    def test_stateful_op(self):
+        transformer = MockStatefulTransformer()
+        state = (MockState(), 0)
+        new_state, result = transformer.stateful_op(state, MockMessageA())
+        assert isinstance(result, MockMessageC)
+        assert new_state[0].iterations == 1
+
+
+# Mock SampleMessage for testing BaseAdaptiveTransformer
+def mock_sample_message():
+    sample_message = MagicMock(spec=SampleMessage)
+    return sample_message
+
+
+class TestBaseAdaptiveTransformer:
+    def test_partial_fit(self):
+        transformer = MockAdaptiveTransformer()
+        transformer.partial_fit(mock_sample_message())
+        assert transformer.state.iterations == 1
+
+    @pytest.mark.asyncio
+    async def test_apartial_fit(self):
+        transformer = MockAdaptiveTransformer()
+        await transformer.apartial_fit(mock_sample_message())
+        assert transformer.state.iterations == 1
+
+    def test_call_with_sample_message(self):
+        transformer = MockAdaptiveTransformer()
+        # Create a sample message with a trigger attribute
+        sample_msg = mock_sample_message()
+        setattr(sample_msg, "trigger", None)
+        result = transformer(sample_msg)
+        assert result is None  # partial_fit returns None
+        assert transformer.state.iterations == 1
+
+
+class TestBaseAsyncTransformer:
+    @pytest.mark.asyncio
+    async def test_acall_method(self):
+        transformer = MockAsyncTransformer()
+        result = await transformer.__acall__(MockMessageA())
+        assert isinstance(result, MockMessageB)
+        assert transformer.state.iterations == 1
+
+    def test_call_method(self):
+        transformer = MockAsyncTransformer()
+        result = transformer(MockMessageA())
+        assert isinstance(result, MockMessageB)
+        assert transformer.state.iterations == 1
+
+
+# -- Test for BaseStatefulProducer --
+
+
+class TestBaseStatefulProducer:
+    def test_initialization(self):
+        producer = MockStatefulProducer(param1=20)
+        assert producer.settings.param1 == 20
+        assert producer._hash == -1
+        assert producer.state.iterations == 0
+
+    @pytest.mark.asyncio
+    async def test_state_reset_on_first_call(self):
+        producer = MockStatefulProducer()
+        assert producer._hash == -1
+
+        # First call should trigger state reset
+        result = await producer.__acall__()
+        assert producer._hash == 0
+        assert producer.state.iterations == 1
+        assert isinstance(result, MockMessageA)
+
+    def test_stateful_op(self):
+        producer = MockStatefulProducer()
+        state = (MockState(), 0)
+        new_state, result = producer.stateful_op(state)
+        assert isinstance(result, MockMessageA)
+        assert new_state[0].iterations == 1
+
+
+# -- Tests for CompositeProcessor --
+
+
+class TestCompositeProcessor:
+    def test_valid_single_processor_chain(self):
+        processor = ValidSingleCompositeProcessor()
+        result = processor(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    def test_valid_multiple_processor_chain(self):
+        processor = ValidMultipleCompositeProcessor()
+        result = processor(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    def test_empty_processor_chain(self):
+        with pytest.raises(ValueError, match="requires at least one processor"):
+            EmptyCompositeProcessor()
+
+    def test_invalid_output_type(self):
+        with pytest.raises(TypeError, match="Output type mismatch"):
+            InvalidOutputCompositeProcessor()
+
+    def test_invalid_input_type(self):
+        with pytest.raises(TypeError, match="Input type mismatch"):
+            InvalidInputCompositeProcessor()
+
+    def test_invalid_producer_not_first(self):
+        with pytest.raises(
+            TypeError, match="Message type mismatch between processors 0 and 1"
+        ):
+            InvalidProducerNotFirstCompositeProcessor()
+
+    def test_invalid_consumer_not_last(self):
+        with pytest.raises(
+            TypeError, match="Message type mismatch between processors 0 and 1"
+        ):
+            InvalidConsumerNotLastCompositeProcessor()
+
+    def test_type_mismatch_between_processors(self):
+        # Currently throws wrong error due to issue with None/NoneType
+        with pytest.raises(
+            TypeError, match="Message type mismatch between processors 0 and 1"
+        ):
+            TypeMismatchCompositeProcessor()
+
+    def test_chained_processors(self):
+        # should not throw - currently does
+        processor = ChainedCompositeProcessor()
+        result = processor(MockMessageA())
+        assert isinstance(result, NoneType)
+
+    def test_chained_processors_with_producer_first(self):
+        # should not throw - currently does
+        processor = ChainedWithProducerCompositeProcessor()
+        result = processor(None)
+        assert isinstance(result, MockMessageC)
+
+    def test_chained_processors_with_deep_classes(self):
+        # should not throw - currently does
+        processor = ChainedCompositeProcessorWithDeepProcessors()
+        result = processor(None)
+        assert isinstance(result, MockMessageC)
+
+    def test_composite_processor_with_generator_sync(self):
+        processor = MockGeneratorCompositeProcessor()
+        # Attempt to use the sync processing interface and assert it raises an error
+        with pytest.raises(
+            Exception, match="'generator' object has no attribute '__call__'"
+        ):
+            processor._process(MockMessageA())
+
+    @pytest.mark.asyncio
+    async def test_composite_processor_with_generator_async(self):
+        processor = MockGeneratorCompositeProcessor()
+        # Attempt to use the async processing interface and assert it raises an error
+        with pytest.raises(
+            Exception, match="'generator' object has no attribute '__acall__'"
+        ):
+            await processor._aprocess(MockMessageA())
+
+    def test_state_property(self):
+        processor1 = ValidMultipleCompositeProcessor()
+        processor2 = ChainedWithProducerCompositeProcessor()
+        processor3 = ChainedCompositeProcessorWithDeepProcessors()
+        processor4 = MockGeneratorCompositeProcessor()
+
+        state1 = processor1.state
+        assert "processor" not in state1
+        assert "stateful_processor" in state1
+
+        state2 = processor2.state
+        assert "stateful_producer" in state2
+        assert "stateful_transformer" in state2
+
+        state3 = processor3.state
+        assert "stateful_producer" in state3
+        assert "deep_processor" not in state3
+        assert "deeper_transformer" not in state3
+
+        state4 = processor4.state
+        assert "generator" not in state4
+        assert "stateful_processor" in state4
+
+    def test_state_setter(self):
+        processor = ChainedWithProducerCompositeProcessor()
+
+        # Create new states
+        state1 = MockState()
+        state1.iterations = 5
+        state2 = MockState()
+        state2.iterations = 10
+
+        # Set composite state
+        processor.state = {"stateful_producer": state1, "stateful_transformer": state2}
+
+        assert processor._procs["stateful_producer"].state.iterations == 5
+        assert processor._procs["stateful_transformer"].state.iterations == 10
+
+    def test_state_setter_with_bytes(self):
+        processor = ChainedWithProducerCompositeProcessor()
+
+        # Create new states
+        state1 = MockState()
+        state1.iterations = 15
+        state2 = MockState()
+        state2.iterations = 20
+
+        # Serialize composite state
+        serialized = pickle.dumps(
+            {"stateful_producer": state1, "stateful_transformer": state2}
+        )
+
+        processor.state = serialized
+
+        assert processor._procs["stateful_producer"].state.iterations == 15
+        assert processor._procs["stateful_transformer"].state.iterations == 20
+
+    @pytest.mark.asyncio
+    async def test_aprocess_method(self):
+        processor = ValidMultipleCompositeProcessor()
+        result = await processor._aprocess(MockMessageA())
+        assert isinstance(result, MockMessageB)
+
+    def test_stateful_op(self):
+        processor = ValidMultipleCompositeProcessor()
+        state = {"processor": (MockState(), 2), "stateful_processor": (MockState(), 3)}
+        new_state, result = processor.stateful_op(state, MockMessageA())
+        assert isinstance(result, MockMessageB)
+        # Do we really want to keep the 'state' of a stateless processor?
+        # State of processor 1 not changed from default values
+        assert new_state["processor"][0].iterations == 0
+        assert new_state["processor"][0].hash == -1
+        assert hasattr(processor._procs["processor"], "_state") is False
+        # State of processor 2 updated
+        assert new_state["stateful_processor"][0].iterations == 1
+        assert new_state["stateful_processor"][0].hash == -1
+        assert processor._procs["stateful_processor"].state.iterations == 1
+        # Hash not set to 3 as expected as processor is called after setting the hash
+        # Hash set to 0 via the _reset_state method.
+        assert processor._procs["stateful_processor"]._hash == 0

--- a/tests/unit/test_synth.py
+++ b/tests/unit/test_synth.py
@@ -15,7 +15,7 @@ from ezmsg.sigproc.synth import (
 
 
 # TEST CLOCK
-@pytest.mark.parametrize("dispatch_rate", [None, 2.0, 20.0])
+@pytest.mark.parametrize("dispatch_rate", [None, 1.0, 2.0, 5.0, 10.0, 20.0])
 def test_clock_gen(dispatch_rate: float | None):
     run_time = 1.0
     n_target = int(np.ceil(dispatch_rate * run_time)) if dispatch_rate else 100

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,121 @@
+from types import NoneType
+from typing import Any, Optional, Union
+
+from ezmsg.sigproc.util.typeresolution import check_message_type_compatibility
+
+
+# Simple mock message types for testing type compatibility
+class MockMessageA:
+    pass
+
+
+class MockMessageB(MockMessageA):
+    pass
+
+
+class MockMessageC:
+    pass
+
+
+class TestCheckMessageTypeCompatibility:
+    """
+    Unit tests for the check_message_type_compatibility function.
+    """
+
+    def test_concrete_subclass_compatibility(self):
+        assert check_message_type_compatibility(MockMessageB, MockMessageA)
+
+        # Test incompatible types
+        assert not check_message_type_compatibility(MockMessageC, MockMessageA)
+        assert not check_message_type_compatibility(MockMessageA, MockMessageB)
+        assert not check_message_type_compatibility(None, MockMessageA)
+        assert not check_message_type_compatibility(MockMessageA, None)
+        assert not check_message_type_compatibility(NoneType, MockMessageA)
+        assert not check_message_type_compatibility(MockMessageA, NoneType)
+
+    def test_none_and_any_compatibility(self):
+        assert check_message_type_compatibility(None, None)
+        assert check_message_type_compatibility(NoneType, None)
+        assert check_message_type_compatibility(None, NoneType)
+        assert check_message_type_compatibility(MockMessageA, Any)
+        assert check_message_type_compatibility(Any, MockMessageA)
+        assert check_message_type_compatibility(None, Any)
+        assert check_message_type_compatibility(Any, None)
+
+    def test_optional_compatibility(self):
+        assert check_message_type_compatibility(MockMessageA, Optional[MockMessageA])
+        assert check_message_type_compatibility(MockMessageB, Optional[MockMessageA])
+        assert check_message_type_compatibility(None, Optional[MockMessageA])
+        assert check_message_type_compatibility(NoneType, Optional[MockMessageA])
+        assert check_message_type_compatibility(
+            Optional[MockMessageA], Optional[MockMessageA]
+        )
+        assert not check_message_type_compatibility(Optional[MockMessageA], None)
+        assert not check_message_type_compatibility(Optional[MockMessageA], NoneType)
+        assert not check_message_type_compatibility(
+            Optional[MockMessageA], MockMessageA
+        )
+        assert not check_message_type_compatibility(
+            MockMessageA, Optional[MockMessageB]
+        )
+        assert not check_message_type_compatibility(
+            MockMessageC, Optional[MockMessageA]
+        )
+
+    def test_union_compatibility(self):
+        assert check_message_type_compatibility(MockMessageA, Union[MockMessageA, int])
+        assert check_message_type_compatibility(MockMessageB, Union[MockMessageA, int])
+        assert check_message_type_compatibility(None, Union[MockMessageA, None])
+        assert check_message_type_compatibility(NoneType, Union[MockMessageA, None])
+        assert check_message_type_compatibility(
+            Union[MockMessageA, int], Union[MockMessageA, int]
+        )
+        assert check_message_type_compatibility(
+            Union[MockMessageA, None], Optional[MockMessageA]
+        )
+        assert check_message_type_compatibility(
+            Optional[MockMessageA], Union[MockMessageA, None]
+        )
+        assert check_message_type_compatibility(
+            Union[MockMessageB, int], Union[MockMessageA, int, MockMessageC]
+        )
+        assert not check_message_type_compatibility(Union[MockMessageA, None], None)
+        assert not check_message_type_compatibility(Union[MockMessageA, None], NoneType)
+        assert not check_message_type_compatibility(
+            Union[MockMessageA, int], MockMessageA
+        )
+        assert not check_message_type_compatibility(
+            Union[MockMessageA, int, MockMessageC], Union[MockMessageA, int]
+        )
+        assert not check_message_type_compatibility(
+            MockMessageC, Union[MockMessageA, int]
+        )
+
+    def test_union_operator_compatibility(self):
+        assert check_message_type_compatibility(MockMessageA, MockMessageA | int)
+        assert check_message_type_compatibility(MockMessageB, MockMessageA | int)
+        assert check_message_type_compatibility(None, MockMessageA | None)
+        assert check_message_type_compatibility(NoneType, MockMessageA | None)
+        assert check_message_type_compatibility(MockMessageA | int, MockMessageA | int)
+        assert check_message_type_compatibility(
+            MockMessageB | bool, Union[MockMessageA, int]
+        )
+        assert check_message_type_compatibility(
+            Union[MockMessageB, bool], MockMessageA | int
+        )
+        assert check_message_type_compatibility(
+            MockMessageA | None, Optional[MockMessageA]
+        )
+        assert check_message_type_compatibility(
+            Optional[MockMessageA], MockMessageA | None
+        )
+        assert check_message_type_compatibility(
+            MockMessageB | int, MockMessageA | int | MockMessageC
+        )
+        assert not check_message_type_compatibility(MockMessageA | None, None)
+        assert not check_message_type_compatibility(MockMessageA | None, NoneType)
+        assert not check_message_type_compatibility(MockMessageA | int, MockMessageA)
+        assert not check_message_type_compatibility(
+            MockMessageA | int | MockMessageC, MockMessageA | int
+        )
+        assert not check_message_type_compatibility(MockMessageC, MockMessageA | int)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10.15"
 
 [[package]]
@@ -124,7 +125,6 @@ wheels = [
 
 [[package]]
 name = "ezmsg-sigproc"
-version = "1.7.2.dev118+gca2df2c.d20250413"
 source = { editable = "." }
 dependencies = [
     { name = "array-api-compat" },
@@ -166,6 +166,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "sparse", specifier = ">=0.15.4" },
 ]
+provides-extras = ["test"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

Intended to replace Preston's [PR#79](https://github.com/ezmsg-org/ezmsg-sigproc/pull/79) by satisfying his concerns and Chad's.

Changes
1. Add unit testing of base.py,
2. Make type resolution methods (eg. `get_state_type`) more robust,
3. Fix logic around checking message type compatibility in composite processors - allow use of None in `check_message_type_compatibility` function and correct direction of subclass requirement in `validate_processor_chain`.
4. Fix pyright errors in `base.py` (and minor fixes in other files).
5. Add `BaseProcessorUnit` class (as per Preston's work) for correct subclassing of Processor Units.
6. Implement `CompositeProducer` to avoid class type checking on the hot path and move it to initialisation. The following classes are now subclassed from `CompositeProducer` and renamed:
    -  `OscillatorTransformer` -> `OscillatorProducer`
    - `WhiteNoiseTransformer` -> `WhiteNoiseProducer`
    - `PinkNoiseTransformer` -> `PinkNoiseProducer`
Thus, we also have the following name change `BaseCounterFirstTransformerUnit` -> `BaseCounterFirstProducerUnit` and this is subclassed from `BaseProducerUnit` instead. Its subclasses `Oscillator`, `WhiteNoise`, `PinkNoise` behave as before.
7. Update documentation of the class hierarchy in `docs/ProcessorsBase.md`.
8. Allow generators to be used in async context within `CompositeProcessor`/`CompositeProducer` and prime the generator if it isn't at initialisation. 

## Reason for change
Motivated by Chad's refactor (explained [here](https://github.com/ezmsg-org/ezmsg-sigproc/blob/70-use-protocols-for-axisarray-transformers/docs/ProcessorsBase.md)), moving to class-based signal processors. Intent was to make robust for release. Creating a test suite identified certain issues:
- current type resolution logic uses `__orig_bases__` attribute, which is not officially documented (and thus subject to no guarantees of behaviour change) and does not necessarily exist for each class. It is also inconsistent about finding generic type parameter args for second or later parent classes. It is thus not robust to processor classes whose inheritance order does not put a processor abstract base class (ABC) in the first base class position. Should replace with `typing.get_original_bases`. Moreover, the logic is not robust to a processor base class being constructed with a different order of generic typevars - current logic assumes `SettingsType` will be put first and `StateType` last for example. 
- message type compatibility in a composite processor fails when explicit generic type parameter is replaced by None (as in the case of consumers). Additionally, the last processor should return a subclass of the specified `MessageOutType` of the `CompositeProcessor`, not the other way around. 
- synchronous generators will fail if called in asynchronous context. Additionally, if a generator is not primed (sent to first yield at initialisation), methods such as `_process` will fail when calling `asend`. 
- typeright errors coming from type hinting issues. Main issue being subclasses defined in a way that makes them incompatible with the parent class. This is the motivation for the `BaseProcessorUnit` addition. 
- repeated use of `isinstance` in the `_process` method of `CompositeProcessor`. When used offline, this can add up to an expensive amount of processing time. This motivated the implementation of `CompositeProducer` to compute the isinstance check at initialisation. 

## Type of change
This is a mix of logic fixes, new features and code improvements. Intent was to keep current implementation behaving as before.

Changes in behaviour:
1. `CompositeProcessor`/`CompositeProducer`:
    a) Chains of processors that start with a producer should use the `CompositeProducer` class. A producer inside a `CompositeProcessor` will throw a `TypeError`. 
    b) Similarly, a `CompositeProducer` will throw if the first processor is not a producer.
    c) Both `CompositeProcessor` and `CompositeProducer` throw a `TypeError` when `_initialize_processors` returns a dictionary of processors that has a producer not in first position or a consumer not in last (even if message types are compatible).
    d) Both `CompositeProcessor` and `CompositeProducer` throw a `KeyError` when attempting to set the state of the composite chain with a processor name key that doesn't exist in the chain (in `self._procs`).
    e) Setting the state of a `CompositeProcessor`/`CompositeProducer` will no longer impart a state attribute to stateless processors.
2. Changes to concrete signal processing classes built with `CounterProducer`. Name changes:
    -  `OscillatorTransformer` -> `OscillatorProducer`
    - `WhiteNoiseTransformer` -> `WhiteNoiseProducer`
    - `PinkNoiseTransformer` -> `PinkNoiseProducer`
    - `BaseCounterFirstTransformerUnit` -> `BaseCounterFirstProducerUnit`
The first four are now CompositeProducers and the last is a generic subclass of `BaseProducerUnit`. This means the following units are now concrete implementations of `BaseProducerUnit`: `Oscillator`, `WhiteNoise`, and `PinkNoise`. Access the internal processor with `.producer` rather than `.processor`.
3. `BaseProducerUnit` filters out None outputs just like `BaseTransformerUnit`.
4. `SlicerState` attribute `slice` has been renamed `slice_` as it conflicts with the built-in `slice` object/method.

## Main change details
1. `tests/unit/test_base.py`: added test suite for all base processor classes and helper functions in `base.py`,
2. `tests/unit/test_util.py`: added unit tests for `check_message_type_compatibility`.
3. `src/ezmsg/sigproc/util/typeresolution.py`: added functions `resolve_typevar` for more robust type resolution. Moved utility function `check_message_type_compatibility` here. 
4. `src/ezmsg/sigproc/util/asio.py`: added `SyncToAsyncGeneratorWrapper` decorator class for synchronous generators. This decorator adds async versions of generator internals (`__anext__`, `asend`, `aclose`, `aiter`) by running calls in an asyncio thread. It also primes the generator if not done at definition.
5. `src/ezmsg/sigproc/base.py`: 
    - Added helper functions to resolve generic type args: `get_base_processor_settings_type`, `get_base_processor_state_type`, `get_base_processor_message_in_type`, `get_base_processor_message_out_type`, `get_base_producer_type`, `get_base_consumer_type`, `get_base_transformer_type`, `get_base_adaptive_transformer_type`.
    - Refactored stateful classes to inherit from mixin generic ABC `Stateful` (solves issue of composite chain classes failing to properly subclass `BaseStatefulProcessor` or `BaseStatefulProducer`.
    - Refactored composite processor ABCs to inherit from mixin generic ABC `CompositeStateful` to reduce code duplication and implemented `CompositeProducer`. 
    - Added `BaseProcessorUnit` for more correct subclassing of units. 
    - Wrapped generators with `SyncToAsyncGeneratorWrapper` when included in one of the composite chain classes. 
    - Various type hinting fixes, function logic improvements, enhanced error messages.
6. Other files:
    - various code improvements
    - name changes explained in points 2 and 3 of the previous section. 

## How Has This Been Tested?
All ezmsg-sigproc tests pass. Passes formatter and linter checks. All new tests pass (many fail in the first commit - fixed in all following commits).