### PR TITLE
Gaussian Smoothing Filter (redo of #95)

### DIFF
--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -7,20 +7,15 @@ from .filter import (
     FilterBaseSettings,
     BACoeffs,
     FilterByDesignTransformer,
-    BaseFilterByDesignTransformerUnit
+    BaseFilterByDesignTransformerUnit,
 )
 
-class GaussianSmoothingSettings(FilterBaseSettings):
 
+class GaussianSmoothingSettings(FilterBaseSettings):
     sigma: float | None = 1.0
     """
     sigma : float
         Standard deviation of the Gaussian kernel.
-    """
-
-    # dimensions: int | None = 1
-    """
-    Kernel dimension. Either 1D, 2D, or 3D.
     """
 
     width: int | None = 4
@@ -28,21 +23,20 @@ class GaussianSmoothingSettings(FilterBaseSettings):
     width : int
         Number of standard deviations covered by the kernel window if kernel_size is not provided.
     """
-    
+
     kernel_size: int | None = None
     """
     kernel_size : int | None
         Length of the kernel in samples. If provided, overrides automatic calculation.
     """
 
+
 def gaussian_smoothing_filter_design(
     sigma: float = 1.0,
-    #dims: int = 1,
     width: int = 4,
     kernel_size: int | None = None,
-    coef_type: str = "ba"
+    coef_type: str = "ba",
 ) -> BACoeffs | None:
-    
     # Parameter checks
     if sigma <= 0:
         raise ValueError(f"sigma must be positive. Received: {sigma}")
@@ -66,22 +60,25 @@ def gaussian_smoothing_filter_design(
             "The kernel may be truncated."
         )
 
-    kernel_sequence = np.arange(-(kernel_size // 2), (kernel_size // 2) + 1) # default spacing of 1.0 -> change to np.linspace to adjust spacing <1.0
-    
-    b = np.exp(-1/2 * (kernel_sequence**2) / (sigma**2))
+    kernel_sequence = np.arange(
+        -(kernel_size // 2), (kernel_size // 2) + 1
+    )  # default spacing of 1.0 -> change to np.linspace to adjust spacing <1.0
+
+    b = np.exp(-1 / 2 * (kernel_sequence**2) / (sigma**2))
     b /= np.sum(b)
 
-    a = np.array([1.0]) # default for gaussian window
+    a = np.array([1.0])  # default for gaussian window
 
     if coef_type == "ba":
         return (b, a)  # Return as tuple, not BACoeffs(b=b, a=a)
     return (np.array([1.0]), np.array([1.0]))  # Return as tuple for non-ba case
 
+
 class GaussianSmoothingFilterTransformer(
     FilterByDesignTransformer[GaussianSmoothingSettings, BACoeffs]
 ):
     def get_design_function(
-            self,
+        self,
     ) -> Callable[[float], BACoeffs]:
         # Create a wrapper function that ignores fs parameter since gaussian smoothing doesn't need it
         def design_wrapper(fs: float) -> BACoeffs:
@@ -89,34 +86,35 @@ class GaussianSmoothingFilterTransformer(
                 sigma=self.settings.sigma,
                 width=self.settings.width,
                 kernel_size=self.settings.kernel_size,
-                coef_type=self.settings.coef_type
+                coef_type=self.settings.coef_type,
             )
+
         return design_wrapper
-    
+
 
 class GaussianSmoothingFilter(
     BaseFilterByDesignTransformerUnit[
         GaussianSmoothingSettings, GaussianSmoothingFilterTransformer
-        ]
+    ]
 ):
     SETTINGS = GaussianSmoothingSettings
 
+
 def gaussian_smoothing_filter(
-    axis:str | None,
+    axis: str | None,
     sigma: float = 1.0,
-    #dims: int = 1,
+    # dims: int = 1,
     width: int = 4,
     kernel_size: int | None = None,
     coef_type: str = "ba",
 ) -> GaussianSmoothingFilterTransformer:
-    
     return GaussianSmoothingFilterTransformer(
         GaussianSmoothingSettings(
             axis=axis,
             sigma=sigma,
-            #dims=dims,
+            # dims=dims,
             width=width,
             kernel_size=kernel_size,
-            coef_type=coef_type
+            coef_type=coef_type,
         )
     )

--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -1,16 +1,16 @@
-import functools
 from typing import Callable
+import warnings
 
 import numpy as np
 
 from .filter import (
-    FilterSettings,
+    FilterBaseSettings,
     BACoeffs,
     FilterByDesignTransformer,
     BaseFilterByDesignTransformerUnit
 )
 
-class GaussianSmoothingSettings(FilterSettings):
+class GaussianSmoothingSettings(FilterBaseSettings):
 
     sigma: float | None = 1.0
     """
@@ -43,31 +43,55 @@ def gaussian_smoothing_filter_design(
     coef_type: str = "ba"
 ) -> BACoeffs | None:
     
-    if kernel_size is None:
+    # Parameter checks
+    if sigma <= 0:
+        raise ValueError(f"sigma must be positive. Received: {sigma}")
+
+    if width <= 0:
+        raise ValueError(f"width must be positive. Received: {width}")
+
+    if kernel_size is not None:
+        if kernel_size < 1:
+            raise ValueError(f"kernel_size must be >= 1. Received: {kernel_size}")
+    else:
         kernel_size = int(2 * width * sigma + 1)
+
+    # Warn if kernel_size is smaller than recommended but don't fail
+    expected_kernel_size = int(2 * width * sigma + 1)
+    if kernel_size < expected_kernel_size:
+        ## TODO: Either add a warning or determine appropriate kernel size and raise an error
+        warnings.warn(
+            f"Provided kernel_size {kernel_size} is smaller than recommended "
+            f"size {expected_kernel_size} for sigma={sigma} and width={width}. "
+            "The kernel may be truncated."
+        )
+
     kernel_sequence = np.arange(-(kernel_size // 2), (kernel_size // 2) + 1) # default spacing of 1.0 -> change to np.linspace to adjust spacing <1.0
     
     b = np.exp(-1/2 * (kernel_sequence**2) / (sigma**2))
     b /= np.sum(b)
 
-    a = [1.0] # default for gaussian window
+    a = np.array([1.0]) # default for gaussian window
 
     if coef_type == "ba":
-        return BACoeffs(b=b, a=a)
-    return BACoeffs(b=1.0, a=1.0)
+        return (b, a)  # Return as tuple, not BACoeffs(b=b, a=a)
+    return (np.array([1.0]), np.array([1.0]))  # Return as tuple for non-ba case
 
 class GaussianSmoothingFilterTransformer(
     FilterByDesignTransformer[GaussianSmoothingSettings, BACoeffs]
 ):
     def get_design_function(
             self,
-    ) -> Callable[[int], BACoeffs]:
-        return functools.partial(
-            gaussian_smoothing_filter_design,
-            sigma = self.settings.sigma,
-            width = self.settings.width,
-            coef_type = self.settings.coef_type
-        )
+    ) -> Callable[[float], BACoeffs]:
+        # Create a wrapper function that ignores fs parameter since gaussian smoothing doesn't need it
+        def design_wrapper(fs: float) -> BACoeffs:
+            return gaussian_smoothing_filter_design(
+                sigma=self.settings.sigma,
+                width=self.settings.width,
+                kernel_size=self.settings.kernel_size,
+                coef_type=self.settings.coef_type
+            )
+        return design_wrapper
     
 
 class GaussianSmoothingFilter(

--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -59,14 +59,11 @@ def gaussian_smoothing_filter_design(
             "The kernel may be truncated."
         )
 
-    kernel_sequence = np.arange(
-        -(kernel_size // 2), (kernel_size // 2) + 1
-    )  # default spacing of 1.0 -> change to np.linspace to adjust spacing <1.0
+    from scipy.signal.windows import gaussian
 
-    b = np.exp(-1 / 2 * (kernel_sequence**2) / (sigma**2))
-    b /= np.sum(b)
-
-    a = np.array([1.0])  # default for gaussian window
+    b = gaussian(kernel_size, std=sigma)
+    b /= np.sum(b)  # Ensure normalization
+    a = np.array([1.0])
 
     return b, a
 

--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -1,0 +1,98 @@
+import functools
+from typing import Callable
+
+import numpy as np
+
+from .filter import (
+    FilterSettings,
+    BACoeffs,
+    FilterByDesignTransformer,
+    BaseFilterByDesignTransformerUnit
+)
+
+class GaussianSmoothingSettings(FilterSettings):
+
+    sigma: float | None = 1.0
+    """
+    sigma : float
+        Standard deviation of the Gaussian kernel.
+    """
+
+    # dimensions: int | None = 1
+    """
+    Kernel dimension. Either 1D, 2D, or 3D.
+    """
+
+    width: int | None = 4
+    """
+    width : int
+        Number of standard deviations covered by the kernel window if kernel_size is not provided.
+    """
+    
+    kernel_size: int | None = None
+    """
+    kernel_size : int | None
+        Length of the kernel in samples. If provided, overrides automatic calculation.
+    """
+
+def gaussian_smoothing_filter_design(
+    sigma: float = 1.0,
+    #dims: int = 1,
+    width: int = 4,
+    kernel_size: int | None = None,
+    coef_type: str = "ba"
+) -> BACoeffs | None:
+    
+    if kernel_size is None:
+        kernel_size = int(2 * width * sigma + 1)
+    kernel_sequence = np.arange(-(kernel_size // 2), (kernel_size // 2) + 1) # default spacing of 1.0 -> change to np.linspace to adjust spacing <1.0
+    
+    b = np.exp(-1/2 * (kernel_sequence**2) / (sigma**2))
+    b /= np.sum(b)
+
+    a = [1.0] # default for gaussian window
+
+    if coef_type == "ba":
+        return BACoeffs(b=b, a=a)
+    return BACoeffs(b=1.0, a=1.0)
+
+class GaussianSmoothingFilterTransformer(
+    FilterByDesignTransformer[GaussianSmoothingSettings, BACoeffs]
+):
+    def get_design_function(
+            self,
+    ) -> Callable[[int], BACoeffs]:
+        return functools.partial(
+            gaussian_smoothing_filter_design,
+            sigma = self.settings.sigma,
+            width = self.settings.width,
+            coef_type = self.settings.coef_type
+        )
+    
+
+class GaussianSmoothingFilter(
+    BaseFilterByDesignTransformerUnit[
+        GaussianSmoothingSettings, GaussianSmoothingFilterTransformer
+        ]
+):
+    SETTINGS = GaussianSmoothingSettings
+
+def gaussian_smoothing_filter(
+    axis:str | None,
+    sigma: float = 1.0,
+    #dims: int = 1,
+    width: int = 4,
+    kernel_size: int | None = None,
+    coef_type: str = "ba",
+) -> GaussianSmoothingFilterTransformer:
+    
+    return GaussianSmoothingFilterTransformer(
+        GaussianSmoothingSettings(
+            axis=axis,
+            sigma=sigma,
+            #dims=dims,
+            width=width,
+            kernel_size=kernel_size,
+            coef_type=coef_type
+        )
+    )

--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -35,7 +35,6 @@ def gaussian_smoothing_filter_design(
     sigma: float = 1.0,
     width: int = 4,
     kernel_size: int | None = None,
-    coef_type: str = "ba",
 ) -> BACoeffs | None:
     # Parameter checks
     if sigma <= 0:
@@ -69,9 +68,7 @@ def gaussian_smoothing_filter_design(
 
     a = np.array([1.0])  # default for gaussian window
 
-    if coef_type == "ba":
-        return (b, a)  # Return as tuple, not BACoeffs(b=b, a=a)
-    return (np.array([1.0]), np.array([1.0]))  # Return as tuple for non-ba case
+    return b, a
 
 
 class GaussianSmoothingFilterTransformer(
@@ -86,7 +83,6 @@ class GaussianSmoothingFilterTransformer(
                 sigma=self.settings.sigma,
                 width=self.settings.width,
                 kernel_size=self.settings.kernel_size,
-                coef_type=self.settings.coef_type,
             )
 
         return design_wrapper

--- a/src/ezmsg/sigproc/gaussiansmoothing.py
+++ b/src/ezmsg/sigproc/gaussiansmoothing.py
@@ -98,23 +98,3 @@ class GaussianSmoothingFilter(
     ]
 ):
     SETTINGS = GaussianSmoothingSettings
-
-
-def gaussian_smoothing_filter(
-    axis: str | None,
-    sigma: float = 1.0,
-    # dims: int = 1,
-    width: int = 4,
-    kernel_size: int | None = None,
-    coef_type: str = "ba",
-) -> GaussianSmoothingFilterTransformer:
-    return GaussianSmoothingFilterTransformer(
-        GaussianSmoothingSettings(
-            axis=axis,
-            sigma=sigma,
-            # dims=dims,
-            width=width,
-            kernel_size=kernel_size,
-            coef_type=coef_type,
-        )
-    )

--- a/tests/unit/test_gaussian_smoothing_filter.py
+++ b/tests/unit/test_gaussian_smoothing_filter.py
@@ -3,56 +3,55 @@ import pytest
 from ezmsg.util.messages.axisarray import AxisArray
 
 from ezmsg.sigproc.gaussiansmoothing import (
-    gaussian_smoothing_filter,
     gaussian_smoothing_filter_design,
     GaussianSmoothingSettings,
     GaussianSmoothingFilterTransformer,
 )
 
 
-def test_gaussian_smoothing_filter_function():
+@pytest.mark.parametrize(
+    "axis,sigma,width,kernel_size,coef_type",
+    [
+        ("time", 1.5, 5, None, "ba"),
+        ("time", 2.0, 4, 21, "ba"),
+    ],
+)
+def test_gaussian_smoothing_filter_function(axis, sigma, width, kernel_size, coef_type):
     """Test the gaussian_smoothing_filter convenience function."""
-    # Test basic usage
-    transformer = gaussian_smoothing_filter(
-        axis="time", sigma=1.5, width=5, kernel_size=None, coef_type="ba"
+    transformer = GaussianSmoothingFilterTransformer(
+        axis=axis,
+        sigma=sigma,
+        width=width,
+        kernel_size=kernel_size,
+        coef_type=coef_type,
     )
 
     assert isinstance(transformer, GaussianSmoothingFilterTransformer)
-    assert transformer.settings.axis == "time"
-    assert transformer.settings.sigma == 1.5
-    assert transformer.settings.width == 5
-    assert transformer.settings.kernel_size is None
-    assert transformer.settings.coef_type == "ba"
-
-    # Test with custom kernel_size
-    transformer_custom = gaussian_smoothing_filter(
-        axis="time", sigma=2.0, width=4, kernel_size=21, coef_type="ba"
-    )
-
-    assert transformer_custom.settings.axis == "time"
-    assert transformer_custom.settings.sigma == 2.0
-    assert transformer_custom.settings.width == 4
-    assert transformer_custom.settings.kernel_size == 21
-    assert transformer_custom.settings.coef_type == "ba"
+    assert transformer.settings.axis == axis
+    assert transformer.settings.sigma == sigma
+    assert transformer.settings.width == width
+    assert transformer.settings.kernel_size == kernel_size
+    assert transformer.settings.coef_type == coef_type
 
 
-def test_gaussian_smoothing_settings():
-    """Test the GaussianSmoothingSettings class."""
-    # Test default settings
+def test_gaussian_smoothing_settings_defaults():
+    """Test the GaussianSmoothingSettings class with default values."""
     settings = GaussianSmoothingSettings()
     assert settings.sigma == 1.0
     assert settings.width == 4
     assert settings.kernel_size is None
     assert settings.coef_type == "ba"
 
-    # Test custom settings
-    settings_custom = GaussianSmoothingSettings(
+
+def test_gaussian_smoothing_settings_custom():
+    """Test the GaussianSmoothingSettings class with custom values."""
+    settings = GaussianSmoothingSettings(
         sigma=2.5, width=6, kernel_size=21, coef_type="ba"
     )
-    assert settings_custom.sigma == 2.5
-    assert settings_custom.width == 6
-    assert settings_custom.kernel_size == 21
-    assert settings_custom.coef_type == "ba"
+    assert settings.sigma == 2.5
+    assert settings.width == 6
+    assert settings.kernel_size == 21
+    assert settings.coef_type == "ba"
 
 
 @pytest.mark.parametrize(
@@ -221,7 +220,7 @@ def test_gaussian_smoothing_update_settings():
     original_variance = _calc_smoothing_effect(msg_in)
 
     # Initialize filter with small sigma (minimal smoothing)
-    proc = gaussian_smoothing_filter(
+    proc = GaussianSmoothingFilterTransformer(
         axis="time",
         sigma=0.5,
         width=4,

--- a/tests/unit/test_gaussian_smoothing_filter.py
+++ b/tests/unit/test_gaussian_smoothing_filter.py
@@ -10,20 +10,19 @@ from ezmsg.sigproc.gaussiansmoothing import (
 
 
 @pytest.mark.parametrize(
-    "axis,sigma,width,kernel_size,coef_type",
+    "axis,sigma,width,kernel_size",
     [
-        ("time", 1.5, 5, None, "ba"),
-        ("time", 2.0, 4, 21, "ba"),
+        ("time", 1.5, 5, None),
+        ("time", 2.0, 4, 21),
     ],
 )
-def test_gaussian_smoothing_filter_function(axis, sigma, width, kernel_size, coef_type):
+def test_gaussian_smoothing_filter_function(axis, sigma, width, kernel_size):
     """Test the gaussian_smoothing_filter convenience function."""
     transformer = GaussianSmoothingFilterTransformer(
         axis=axis,
         sigma=sigma,
         width=width,
         kernel_size=kernel_size,
-        coef_type=coef_type,
     )
 
     assert isinstance(transformer, GaussianSmoothingFilterTransformer)
@@ -31,7 +30,6 @@ def test_gaussian_smoothing_filter_function(axis, sigma, width, kernel_size, coe
     assert transformer.settings.sigma == sigma
     assert transformer.settings.width == width
     assert transformer.settings.kernel_size == kernel_size
-    assert transformer.settings.coef_type == coef_type
 
 
 def test_gaussian_smoothing_settings_defaults():
@@ -40,36 +38,35 @@ def test_gaussian_smoothing_settings_defaults():
     assert settings.sigma == 1.0
     assert settings.width == 4
     assert settings.kernel_size is None
-    assert settings.coef_type == "ba"
 
 
 def test_gaussian_smoothing_settings_custom():
     """Test the GaussianSmoothingSettings class with custom values."""
     settings = GaussianSmoothingSettings(
-        sigma=2.5, width=6, kernel_size=21, coef_type="ba"
+        sigma=2.5,
+        width=6,
+        kernel_size=21,
     )
     assert settings.sigma == 2.5
     assert settings.width == 6
     assert settings.kernel_size == 21
-    assert settings.coef_type == "ba"
 
 
 @pytest.mark.parametrize(
-    "sigma,width,kernel_size,coef_type",
+    "sigma,width,kernel_size",
     [
-        (1.0, 4, None, "ba"),
-        (2.0, 6, None, "ba"),
-        (1.5, 5, 11, "ba"),
-        (1.5, 5, 17, "ba"),  # Fixed kernel_size to be >= expected
-        (3.0, 2, None, "sos"),
+        (1.0, 4, None),
+        (2.0, 6, None),
+        (1.5, 5, 11),
+        (1.5, 5, 17),  # Fixed kernel_size to be >= expected
     ],
 )
-def test_gaussian_smoothing_filter_design_parameters(
-    sigma, width, kernel_size, coef_type
-):
+def test_gaussian_smoothing_filter_design_parameters(sigma, width, kernel_size):
     """Test gaussian smoothing filter design across multiple parameter configurations."""
     coefs = gaussian_smoothing_filter_design(
-        sigma=sigma, width=width, kernel_size=kernel_size, coef_type=coef_type
+        sigma=sigma,
+        width=width,
+        kernel_size=kernel_size,
     )
     assert coefs is not None
     assert isinstance(coefs, tuple)
@@ -84,13 +81,10 @@ def test_gaussian_smoothing_filter_design_parameters(
     assert b[len(b) // 2] == np.max(b)  # center of kernel is peak
     assert len(a) == 1 and a[0] == 1.0  # default for gaussian window
 
-    if coef_type == "ba":
-        expected_kernel_size = (
-            int(2 * width * sigma + 1) if kernel_size is None else kernel_size
-        )
-        assert len(b) == expected_kernel_size
-    else:
-        assert len(b) == 1
+    expected_kernel_size = (
+        int(2 * width * sigma + 1) if kernel_size is None else kernel_size
+    )
+    assert len(b) == expected_kernel_size
 
 
 def test_gaussian_smoothing_kernel_properties():

--- a/tests/unit/test_gaussian_smoothing_filter.py
+++ b/tests/unit/test_gaussian_smoothing_filter.py
@@ -1,0 +1,273 @@
+import numpy as np
+from scipy.ndimage import gaussian_filter1d
+import pytest
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.gaussiansmoothing import (
+    gaussian_smoothing_filter,
+    gaussian_smoothing_filter_design,
+    GaussianSmoothingSettings,
+    GaussianSmoothingFilterTransformer,
+    GaussianSmoothingFilter,
+)
+
+
+def test_gaussian_smoothing_filter_function():
+    """Test the gaussian_smoothing_filter convenience function."""
+    # Test basic usage
+    transformer = gaussian_smoothing_filter(
+        axis="time",
+        sigma=1.5,
+        width=5,
+        kernel_size=None,
+        coef_type="ba"
+    )
+    
+    assert isinstance(transformer, GaussianSmoothingFilterTransformer)
+    assert transformer.settings.axis == "time"
+    assert transformer.settings.sigma == 1.5
+    assert transformer.settings.width == 5
+    assert transformer.settings.kernel_size is None
+    assert transformer.settings.coef_type == "ba"
+    
+    # Test with custom kernel_size
+    transformer_custom = gaussian_smoothing_filter(
+        axis="time",
+        sigma=2.0,
+        width=4,
+        kernel_size=21,
+        coef_type="ba"
+    )
+    
+    assert transformer_custom.settings.axis == "time"
+    assert transformer_custom.settings.sigma == 2.0
+    assert transformer_custom.settings.width == 4
+    assert transformer_custom.settings.kernel_size == 21
+    assert transformer_custom.settings.coef_type == "ba"
+
+
+def test_gaussian_smoothing_settings():
+    """Test the GaussianSmoothingSettings class."""
+    # Test default settings
+    settings = GaussianSmoothingSettings()
+    assert settings.sigma == 1.0
+    assert settings.width == 4
+    assert settings.kernel_size is None
+    assert settings.coef_type == "ba"
+    
+    # Test custom settings
+    settings_custom = GaussianSmoothingSettings(
+        sigma=2.5,
+        width=6,
+        kernel_size=21,
+        coef_type="ba"
+    )
+    assert settings_custom.sigma == 2.5
+    assert settings_custom.width == 6
+    assert settings_custom.kernel_size == 21
+    assert settings_custom.coef_type == "ba"
+
+
+@pytest.mark.parametrize("sigma,width,kernel_size,coef_type", [
+    (1.0, 4, None, "ba"),
+    (2.0, 6, None, "ba"),
+    (1.5, 5, 11, "ba"),
+    (1.5, 5, 17, "ba"),  # Fixed kernel_size to be >= expected
+    (3.0, 2, None, "sos"),
+])
+def test_gaussian_smoothing_filter_design_parameters(sigma, width, kernel_size, coef_type):
+    """Test gaussian smoothing filter design across multiple parameter configurations."""
+    coefs = gaussian_smoothing_filter_design(sigma=sigma, width=width, kernel_size=kernel_size, coef_type=coef_type)
+    assert coefs is not None
+    assert isinstance(coefs, tuple)
+    assert len(coefs) == 2  # b and a coefficients
+    
+    b, a = coefs
+    assert b is not None and a is not None
+    assert isinstance(b, np.ndarray) and isinstance(a, np.ndarray)
+    assert np.all(b >= 0) # positive
+    assert np.allclose(b, b[::-1]) # symmetric
+    assert np.isclose(np.sum(b), 1.0) # normalized
+    assert b[len(b)//2] == np.max(b)  # center of kernel is peak
+    assert len(a) == 1 and a[0] == 1.0 # default for gaussian window
+
+    if coef_type == "ba":
+        expected_kernel_size = int(2 * width * sigma + 1) if kernel_size is None else kernel_size
+        assert len(b) == expected_kernel_size
+    else:
+        assert len(b) == 1
+
+
+def test_gaussian_smoothing_kernel_properties():
+    """Test that larger sigma creates wider kernel"""
+    coefs_small = gaussian_smoothing_filter_design(sigma=1.0)
+    b_small, _ = coefs_small
+    coefs_large = gaussian_smoothing_filter_design(sigma=3.0)
+    b_large, _ = coefs_large
+
+    assert len(b_large) >= len(b_small) # wider kernel
+    assert b_large[len(b_large)//2] < b_small[len(b_small)//2] # lower peak
+
+
+@pytest.mark.parametrize("sigma", [0.0, -1.0])
+@pytest.mark.parametrize("width", [0.0, -1.0])
+@pytest.mark.parametrize("kernel_size", [0, -1])
+def test_gaussian_smoothing_filter_design_invalid_inputs(sigma, width, kernel_size):
+    """Test the gaussian smoothing filter design function with invalid inputs."""
+    with pytest.raises(ValueError):
+        gaussian_smoothing_filter_design(sigma=sigma)
+    with pytest.raises(ValueError):
+        gaussian_smoothing_filter_design(width=width)
+    with pytest.raises(ValueError):
+        gaussian_smoothing_filter_design(kernel_size=kernel_size)
+
+
+@pytest.mark.parametrize("data_shape", [(100,), (1, 100), (100, 2), (100, 2, 3)])
+def test_gaussian_smoothing_filter_process(data_shape):
+    """Test gaussian smoothing filter with different data shapes."""
+    # Create test data
+    data = np.arange(np.prod(data_shape)).reshape(data_shape)
+    
+    # Create appropriate dims and axes based on shape
+    if len(data_shape) == 1:
+        dims = ["time"]
+        axes = {
+            "time": AxisArray.TimeAxis(fs=100.0, offset=0)
+        }
+    elif len(data_shape) == 2:
+        dims = ["time", "ch"]
+        axes = {
+            "time": AxisArray.TimeAxis(fs=100.0, offset=0),
+            "ch": AxisArray.CoordinateAxis(
+                data=np.arange(data_shape[1]).astype(str), dims=["ch"]
+            )
+        }
+    else:
+        dims = ["freq", "time", "ch"]
+        axes = {
+            "freq": AxisArray.LinearAxis(unit="Hz", offset=0.0, gain=1.0),
+            "time": AxisArray.TimeAxis(fs=100.0, offset=0),
+            "ch": AxisArray.CoordinateAxis(
+                data=np.arange(data_shape[2]).astype(str), dims=["ch"]
+            )
+        }
+    
+    msg = AxisArray(data=data, dims=dims, axes=axes, key="test_gaussian_smoothing")
+
+    # Instantiate transformer (not unit)
+    transformer = GaussianSmoothingFilterTransformer(
+        settings=GaussianSmoothingSettings(
+            axis="time",
+            sigma=2.0,
+            width=4
+        )
+    )
+    
+    # Process message using __call__ method
+    output_msg = transformer(msg)
+
+    # Assertions
+    assert isinstance(output_msg, AxisArray)
+    assert output_msg.data.shape == data.shape
+    assert np.isfinite(output_msg.data).all()
+
+
+def test_gaussian_smoothing_edge_cases():
+    """Test edge cases for gaussian smoothing filter."""
+    # Test with very small sigma
+    coefs_small = gaussian_smoothing_filter_design(sigma=0.01)
+    b_small, a_small = coefs_small
+    assert len(b_small) > 0
+    assert np.isclose(np.sum(b_small), 1.0)
+    
+    # Test with very large sigma
+    coefs_large = gaussian_smoothing_filter_design(sigma=100.0)
+    b_large, a_large = coefs_large
+    assert len(b_large) > 0
+    assert np.isclose(np.sum(b_large), 1.0)
+    
+    # Test with very small width
+    coefs_narrow = gaussian_smoothing_filter_design(width=1)
+    b_narrow, a_narrow = coefs_narrow
+    assert len(b_narrow) > 0
+    
+    # Test with very large width
+    coefs_wide = gaussian_smoothing_filter_design(width=100)
+    b_wide, a_wide = coefs_wide
+    assert len(b_wide) > len(b_narrow)  # Wider kernel
+
+
+def test_gaussian_smoothing_update_settings():
+    """Test the update_settings functionality of the Gaussian smoothing filter."""
+    # Setup parameters
+    fs = 200.0
+    dur = 1.0
+    n_times = int(dur * fs)
+    n_chans = 2
+
+    # Create input data with high frequency noise
+    t = np.arange(n_times) / fs
+    # Create a signal with both low and high frequency components
+    signal = np.sin(2 * np.pi * 5 * t) + 0.5 * np.sin(2 * np.pi * 50 * t)
+    in_dat = np.vstack([signal, signal + np.random.randn(n_times) * 0.1]).T
+
+    # Create message
+    msg_in = AxisArray(
+        data=in_dat,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.TimeAxis(fs=fs, offset=0),
+            "ch": AxisArray.CoordinateAxis(
+                data=np.arange(n_chans).astype(str), dims=["ch"]
+            ),
+        },
+        key="test_gaussian_smoothing_update_settings",
+    )
+
+    def _calc_smoothing_effect(msg):
+        """Calculate the smoothing effect by comparing variance."""
+        return np.var(msg.data, axis=0)
+
+    original_variance = _calc_smoothing_effect(msg_in)
+
+    # Initialize filter with small sigma (minimal smoothing)
+    proc = gaussian_smoothing_filter(
+        axis="time",
+        sigma=0.5,
+        width=4,
+        coef_type="ba",
+    )
+
+    # Process first message
+    result1 = proc(msg_in)
+    variance1 = _calc_smoothing_effect(result1)
+    
+    # Small sigma should have minimal effect
+    assert np.allclose(variance1, original_variance, rtol=0.1)
+
+    # Update settings - change to larger sigma (more smoothing)
+    proc.update_settings(sigma=3.0)
+
+    # Process the same message with new settings
+    result2 = proc(msg_in)
+    variance2 = _calc_smoothing_effect(result2)
+
+    # Larger sigma should reduce variance (more smoothing)
+    assert np.all(variance2 < variance1)
+
+    # Test update_settings with complete new settings object
+    new_settings = GaussianSmoothingSettings(
+        axis="time",
+        sigma=5.0,  # Even larger sigma
+        width=6,
+        kernel_size=None,
+        coef_type="ba",
+    )
+
+    proc.update_settings(new_settings=new_settings)
+    result3 = proc(msg_in)
+    variance3 = _calc_smoothing_effect(result3)
+    
+    # Even larger sigma should reduce variance further
+    assert np.all(variance3 < variance2)
+


### PR DESCRIPTION
This is a redo of @hernst1 's PR #95 , but retargeted and rebased, and living here instead of BlackrockNeurotech org thus easier for me to manage. 

Original text:

>This PR contains the gaussian smoothing kernel to be used as a reproduction of the MINT processing - should be verified. >The filter follows the pattern of the [ButterworthFilter](https://github.com/ezmsg-org/ezmsg-sigproc/blob/main/src/ezmsg/sigproc/butterworthfilter.py).
>
>Includes (1) kernel design function, (2) settings, processor inheriting from FilterByDesignTransformer, and unit, and (3) unit tests.