### PR TITLE
Small fixes for online settings changing in filters and downsample

### DIFF
--- a/src/ezmsg/sigproc/downsample.py
+++ b/src/ezmsg/sigproc/downsample.py
@@ -1,5 +1,7 @@
 """Integer downsampling by selecting every Nth sample along an axis."""
 
+import typing
+
 import ezmsg.core as ez
 import numpy as np
 from ezmsg.baseproc import (
@@ -103,6 +105,20 @@ class DownsampleTransformer(BaseStatefulTransformer[DownsampleSettings, AxisArra
 
 class Downsample(BaseTransformerUnit[DownsampleSettings, AxisArray, AxisArray, DownsampleTransformer]):
     SETTINGS = DownsampleSettings
+
+    @ez.subscriber(BaseTransformerUnit.INPUT_SIGNAL)
+    @ez.publisher(BaseTransformerUnit.OUTPUT_SIGNAL)
+    async def on_signal(self, message: AxisArray) -> typing.AsyncGenerator:
+        """Skip the publish when no samples accumulated.
+
+        At ``factor > 1`` most input chunks span less than one downsample
+        period, so ``DownsampleTransformer._process`` returns a payload with
+        a zero-length axis. Suppressing the broadcast in that case avoids
+        shipping an empty AxisArray across SHM/socket every input chunk.
+        """
+        result = await self.processor.__acall__(message)
+        if result is not None and result.data.size > 0:
+            yield self.OUTPUT_SIGNAL, result
 
 
 def downsample(

--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -524,8 +524,16 @@ class FilterByDesignTransformer(
 
         new_settings = FilterSettings(axis=axis, coef_type=self.settings.coef_type, coefs=coefs)
         self.state.filter = FilterTransformer(settings=new_settings)
+        self.state.needs_redesign = False
 
     def _process(self, message: AxisArray) -> AxisArray:
+        # The settings-change redesign logic in __call__ above is only reached
+        # by sync callers. Async callers (every BaseTransformerUnit) go
+        # through _aprocess → _process, so we honor needs_redesign here too,
+        # otherwise live setting updates never take effect on the filter
+        # coefficients.
+        if self.state.needs_redesign:
+            self._reset_state(message)
         return self.state.filter(message)
 
 


### PR DESCRIPTION
* downsample - don't publish empty messages
* filter - enable redesign in async pathway