### PR TITLE
Live settings updates for processors, producers, and composites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = ["version"]
 dependencies = [
   "array-api-compat>=1.11.1",
   "ezmsg[axisarray]>=3.9.0",
-  "ezmsg-baseproc>=1.6.0",
+  "ezmsg-baseproc>=1.8.0",
   "mlx>=0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numba>=0.61.0",
   "numpy>=1.26.0",

--- a/src/ezmsg/sigproc/adaptive_lattice_notch.py
+++ b/src/ezmsg/sigproc/adaptive_lattice_notch.py
@@ -66,6 +66,10 @@ class AdaptiveLatticeNotchFilterTransformer(
     It outputs the estimated frequency (in Hz) and the filtered sample.
     """
 
+    # Adaptive gains and the chunkwise flag are read each step inside
+    # `_process`; `axis` and `init_notch_freq` seed cached state and shape.
+    NONRESET_SETTINGS_FIELDS = frozenset({"gamma", "mu", "eta", "chunkwise"})
+
     def _hash_message(self, message: AxisArray) -> int:
         ax_idx = message.get_axis_idx(self.settings.axis)
         sample_shape = message.data.shape[:ax_idx] + message.data.shape[ax_idx + 1 :]

--- a/src/ezmsg/sigproc/detrend.py
+++ b/src/ezmsg/sigproc/detrend.py
@@ -1,6 +1,5 @@
 """Remove linear or constant trends from data along an axis."""
 
-import ezmsg.core as ez
 import scipy.signal as sps
 from ezmsg.baseproc import BaseTransformerUnit
 from ezmsg.util.messages.axisarray import AxisArray, replace
@@ -38,22 +37,3 @@ class DetrendTransformer(EWMATransformer):
 
 class DetrendUnit(BaseTransformerUnit[EWMASettings, AxisArray, AxisArray, DetrendTransformer]):
     SETTINGS = EWMASettings
-
-    @ez.subscriber(BaseTransformerUnit.INPUT_SETTINGS)
-    async def on_settings(self, msg: EWMASettings) -> None:
-        """
-        Handle settings updates with smart reset behavior.
-
-        Only resets state if `axis` changes (structural change).
-        Changes to `time_constant` or `accumulate` are applied without
-        resetting accumulated state.
-        """
-        old_axis = self.SETTINGS.axis
-        self.apply_settings(msg)
-
-        if msg.axis != old_axis:
-            # Axis changed - need full reset
-            self.create_processor()
-        else:
-            # Only accumulate or time_constant changed - keep state
-            self.processor.settings = msg

--- a/src/ezmsg/sigproc/ewma.py
+++ b/src/ezmsg/sigproc/ewma.py
@@ -158,6 +158,10 @@ class EWMAState:
 
 
 class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray, EWMAState]):
+    # `accumulate` is read live in `_process` to gate state updates; other
+    # fields are cached into state (alpha, zi) during `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"accumulate"})
+
     def __call__(self, message: AxisArray) -> AxisArray:
         if np.prod(message.data.shape) == 0:
             return message
@@ -206,22 +210,3 @@ class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray
 
 class EWMAUnit(BaseTransformerUnit[EWMASettings, AxisArray, AxisArray, EWMATransformer]):
     SETTINGS = EWMASettings
-
-    @ez.subscriber(BaseTransformerUnit.INPUT_SETTINGS)
-    async def on_settings(self, msg: EWMASettings) -> None:
-        """
-        Handle settings updates with smart reset behavior.
-
-        Only resets state if `axis` changes (structural change).
-        Changes to `time_constant` or `accumulate` are applied without
-        resetting accumulated state.
-        """
-        old_axis = self.SETTINGS.axis
-        self.apply_settings(msg)
-
-        if msg.axis != old_axis:
-            # Axis changed - need full reset
-            self.create_processor()
-        else:
-            # Only accumulate or time_constant changed - keep state
-            self.processor.settings = msg

--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -10,7 +10,6 @@ import numpy.typing as npt
 import scipy.signal
 from array_api_compat import get_namespace, is_numpy_array
 from ezmsg.baseproc import (
-    BaseConsumerUnit,
     BaseStatefulTransformer,
     BaseTransformerUnit,
     SettingsType,
@@ -606,23 +605,4 @@ class FilterByDesignTransformer(
 class BaseFilterByDesignTransformerUnit(
     BaseTransformerUnit[SettingsType, AxisArray, AxisArray, FilterByDesignTransformer],
     typing.Generic[SettingsType, TransformerType],
-):
-    @ez.subscriber(BaseConsumerUnit.INPUT_SETTINGS)
-    async def on_settings(self, msg: SettingsType) -> None:
-        """
-        Receive a settings message, override self.SETTINGS, and re-create the processor.
-        Child classes that wish to have fine-grained control over whether the
-        core processor resets on settings changes should override this method.
-
-        Args:
-            msg: a settings message.
-        """
-        self.apply_settings(msg)
-
-        # Check if processor exists yet
-        if hasattr(self, "processor") and self.processor is not None:
-            # Update the existing processor with new settings
-            self.processor.update_settings(self.SETTINGS)
-        else:
-            # Processor doesn't exist yet, create a new one
-            self.create_processor()
+): ...

--- a/src/ezmsg/sigproc/resample.py
+++ b/src/ezmsg/sigproc/resample.py
@@ -82,6 +82,10 @@ class ResampleState:
 
 
 class ResampleProcessor(BaseStatefulProcessor[ResampleSettings, AxisArray, AxisArray, ResampleState]):
+    # Both fields are read per-chunk inside `__next__` / `_process` only;
+    # `resample_rate` / `buffer_duration` / `axis` all size cached buffers.
+    NONRESET_SETTINGS_FIELDS = frozenset({"max_chunk_delay", "fill_value"})
+
     def _hash_message(self, message: AxisArray) -> int:
         ax_idx: int = message.get_axis_idx(self.settings.axis)
         sample_shape = message.data.shape[:ax_idx] + message.data.shape[ax_idx + 1 :]

--- a/src/ezmsg/sigproc/rollingscaler.py
+++ b/src/ezmsg/sigproc/rollingscaler.py
@@ -103,6 +103,11 @@ class RollingScalerProcessor(BaseAdaptiveTransformer[RollingScalerSettings, Axis
 
     """
 
+    # Post-processing knobs read only inside `_process`; buffer sizing
+    # (`k_samples`, `window_size`, `min_samples`, `min_seconds`) and `axis`
+    # are cached during `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"update_with_signal", "artifact_z_thresh", "clip"})
+
     def _hash_message(self, message: AxisArray) -> int:
         axis = message.dims[0] if self.settings.axis is None else self.settings.axis
         gain = message.axes[axis].gain if hasattr(message.axes[axis], "gain") else 1

--- a/src/ezmsg/sigproc/sampler.py
+++ b/src/ezmsg/sigproc/sampler.py
@@ -77,6 +77,10 @@ class SamplerState:
 
 
 class SamplerTransformer(BaseStatefulTransformer[SamplerSettings, AxisArray, AxisArray, SamplerState]):
+    # Trigger-time defaults that are consulted inside `push_trigger`, never
+    # cached during `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"period", "value", "estimate_alignment"})
+
     def __call__(self, message: AxisArray | SampleTriggerMessage) -> list[AxisArray]:
         if isinstance(message, AxisArray):
             return super().__call__(message)

--- a/src/ezmsg/sigproc/scaler.py
+++ b/src/ezmsg/sigproc/scaler.py
@@ -103,6 +103,18 @@ class AdaptiveStandardScalerTransformer(
         AdaptiveStandardScalerState,
     ]
 ):
+    # `accumulate` can be live-propagated into the child EWMAs (see
+    # `update_settings` below); `time_constant` and `axis` are baked into
+    # the children during `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"accumulate"})
+
+    def update_settings(self, new_settings: AdaptiveStandardScalerSettings) -> None:
+        # Propagate accumulate into the existing child EWMAs before deferring
+        # to the base logic, which would otherwise leave them with stale flags.
+        if self._state.samps_ewma is not None and new_settings.accumulate != self.settings.accumulate:
+            self.accumulate = new_settings.accumulate
+        super().update_settings(new_settings)
+
     def _reset_state(self, message: AxisArray) -> None:
         self._state.samps_ewma = EWMATransformer(
             time_constant=self.settings.time_constant,
@@ -163,27 +175,6 @@ class AdaptiveStandardScaler(
     SETTINGS = AdaptiveStandardScalerSettings
 
     INPUT_ACCUMULATE = ez.InputStream(bool)
-
-    @ez.subscriber(BaseTransformerUnit.INPUT_SETTINGS)
-    async def on_settings(self, msg: AdaptiveStandardScalerSettings) -> None:
-        """
-        Handle settings updates with smart reset behavior.
-
-        Only resets state if `axis` changes (structural change).
-        Changes to `time_constant` or `accumulate` are applied without
-        resetting accumulated statistics.
-        """
-        old_axis = self.SETTINGS.axis
-        self.apply_settings(msg)
-
-        if msg.axis != old_axis:
-            # Axis changed - need full reset
-            self.create_processor()
-        else:
-            # Update accumulate on processor (propagates to child EWMAs)
-            self.processor.accumulate = msg.accumulate
-            # Also update own settings reference
-            self.processor.settings = msg
 
     @ez.subscriber(INPUT_ACCUMULATE)
     async def on_accumulate(self, accumulate: bool) -> None:

--- a/src/ezmsg/sigproc/transpose.py
+++ b/src/ezmsg/sigproc/transpose.py
@@ -48,6 +48,10 @@ class TransposeTransformer(BaseStatefulTransformer[TransposeSettings, AxisArray,
     using the :obj:`Decimate` collection instead.
     """
 
+    # `order` is a NumPy memory-layout hint consulted only in `_process`;
+    # `axes` drives the cached permutation in `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"order"})
+
     def _hash_message(self, message: AxisArray) -> int:
         return hash(tuple(message.dims))
 

--- a/src/ezmsg/sigproc/window.py
+++ b/src/ezmsg/sigproc/window.py
@@ -64,6 +64,10 @@ class WindowTransformer(BaseStatefulTransformer[WindowSettings, AxisArray, AxisA
     can be difficult. Please read the argument descriptions carefully.
     """
 
+    # `anchor` only affects offset math in `_process`; every other field
+    # sizes the buffer or drives the output axes in `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"anchor"})
+
     def __init__(self, *args, **kwargs) -> None:
         """
 

--- a/tests/integration/ezmsg/test_sampler_system.py
+++ b/tests/integration/ezmsg/test_sampler_system.py
@@ -58,6 +58,7 @@ class SamplerSystem(ez.Collection):
 
 def test_sampler_system(test_name: str | None = None):
     freq = 40.0
+    n_time = 2  # samples per emitted oscillator block
     period = (0.5, 1.5)
     n_msgs = 4
 
@@ -69,7 +70,7 @@ def test_sampler_system(test_name: str | None = None):
 
     settings = SamplerSystemSettings(
         osc_settings=OscillatorSettings(
-            n_time=2,  # Number of samples to output per block
+            n_time=n_time,
             fs=freq,  # Sampling rate of signal output in Hz
             dispatch_rate="realtime",
             freq=2.0,  # Oscillation frequency in Hz
@@ -91,9 +92,13 @@ def test_sampler_system(test_name: str | None = None):
     ez.logger.info(f"Analyzing recording of {len(messages)} messages...")
     assert len(messages) >= n_msgs
     assert all([_.data.shape == (int(freq * sample_dur), 1) for _ in messages])
-    # Test the sample window slice vs the trigger timestamps
+    # Test the sample window slice vs the trigger timestamps. Tolerance is one
+    # block (n_time/freq), not one sample (1/freq): the trigger and sampler run
+    # in separate processes whose monotonic clocks can disagree by ~15ms on
+    # Windows, so cross-process alignment is bounded by the block size, not the
+    # sample period.
     latencies = [
         _.axes["time"].offset - (_.attrs["trigger"].timestamp + _.attrs["trigger"].period[0]) for _ in messages
     ]
-    assert all([0 <= _ < 1 / freq for _ in latencies])
+    assert all([0 <= _ < n_time / freq for _ in latencies])
     # Given that the input is a pure sinusoid, we could test that the signal has expected characteristics.

--- a/tests/unit/test_ewma.py
+++ b/tests/unit/test_ewma.py
@@ -191,3 +191,42 @@ def test_ewma_empty_first():
     result = proc(empty)
     check_empty_result(result)
     check_state_not_corrupted(proc, normal)
+
+
+class TestEWMAUpdateSettings:
+    """Live settings updates via BaseProcessor.update_settings."""
+
+    def test_accumulate_toggle_preserves_state(self):
+        proc = EWMATransformer(settings=EWMASettings(time_constant=0.1, accumulate=True))
+
+        _ = proc(_make_ewma_test_msg(np.ones((10, 2))))
+        _ = proc(_make_ewma_test_msg(np.ones((10, 2)) * 2.0))
+        zi_before = proc._state.zi.copy()
+        alpha_before = proc._state.alpha
+
+        # `accumulate` is in NONRESET_SETTINGS_FIELDS — no reset queued.
+        proc.update_settings(EWMASettings(time_constant=0.1, accumulate=False))
+        assert proc._hash != -1
+        assert np.allclose(proc._state.zi, zi_before)
+        assert proc._state.alpha == alpha_before
+
+        # accumulate=False must now gate state updates inside _process.
+        _ = proc(_make_ewma_test_msg(np.ones((10, 2)) * 100.0))
+        assert np.allclose(proc._state.zi, zi_before)
+
+    def test_time_constant_change_recomputes_alpha(self):
+        proc = EWMATransformer(settings=EWMASettings(time_constant=0.1, accumulate=True))
+
+        msg = _make_ewma_test_msg(np.ones((10, 2)))
+        _ = proc(msg)
+        alpha_before = proc._state.alpha
+
+        # `time_constant` is NOT in NONRESET_SETTINGS_FIELDS — reset queued.
+        proc.update_settings(EWMASettings(time_constant=0.5, accumulate=True))
+        assert proc._hash == -1
+
+        # Next message triggers _reset_state, which recomputes alpha from the new time_constant.
+        _ = proc(msg)
+        alpha_after = proc._state.alpha
+        assert alpha_after != alpha_before
+        assert np.isclose(alpha_after, _alpha_from_tau(0.5, 1 / 1000.0))

--- a/tests/unit/test_scaler.py
+++ b/tests/unit/test_scaler.py
@@ -237,6 +237,46 @@ class TestAdaptiveStandardScalerAccumulate:
         assert scaler._state.vars_sq_ewma.settings.accumulate is False
 
 
+class TestAdaptiveStandardScalerUpdateSettings:
+    """Live settings updates via update_settings."""
+
+    def test_accumulate_update_propagates_and_preserves_state(self):
+        scaler = AdaptiveStandardScalerTransformer(
+            settings=AdaptiveStandardScalerSettings(time_constant=0.1, accumulate=True)
+        )
+
+        np.random.seed(0)
+        _ = scaler(_make_scaler_test_msg(np.random.randn(50, 4)))
+        _ = scaler(_make_scaler_test_msg(np.random.randn(50, 4) + 5.0))
+        zi_samps = scaler._state.samps_ewma._state.zi.copy()
+        zi_vars = scaler._state.vars_sq_ewma._state.zi.copy()
+
+        # accumulate-only change: should propagate to children without reset.
+        scaler.update_settings(AdaptiveStandardScalerSettings(time_constant=0.1, accumulate=False))
+        assert scaler._hash != -1
+        assert scaler._state.samps_ewma.settings.accumulate is False
+        assert scaler._state.vars_sq_ewma.settings.accumulate is False
+
+        # With accumulate=False, child zi values must not move.
+        _ = scaler(_make_scaler_test_msg(np.random.randn(50, 4) + 100.0))
+        assert np.allclose(scaler._state.samps_ewma._state.zi, zi_samps)
+        assert np.allclose(scaler._state.vars_sq_ewma._state.zi, zi_vars)
+
+    def test_time_constant_update_triggers_reset(self):
+        scaler = AdaptiveStandardScalerTransformer(
+            settings=AdaptiveStandardScalerSettings(time_constant=0.1, accumulate=True)
+        )
+        _ = scaler(_make_scaler_test_msg(np.ones((10, 2))))
+        samps_ewma_before = scaler._state.samps_ewma
+
+        scaler.update_settings(AdaptiveStandardScalerSettings(time_constant=0.5, accumulate=True))
+        assert scaler._hash == -1
+
+        # Next message rebuilds the child EWMAs inside _reset_state.
+        _ = scaler(_make_scaler_test_msg(np.ones((10, 2))))
+        assert scaler._state.samps_ewma is not samps_ewma_before
+
+
 def test_adaptive_scaler_np_empty_after_init():
     from ezmsg.sigproc.scaler import AdaptiveStandardScalerSettings, AdaptiveStandardScalerTransformer
 

--- a/tests/unit/test_spectrogram.py
+++ b/tests/unit/test_spectrogram.py
@@ -83,3 +83,45 @@ def test_spectrogram():
     # result = AxisArray.concatenate(*results, dim="time")
     # TODO: Check spectral peaks change over time. _debug_plot is useful if not automatic.
     # _debug_plot(result, sin_params=sin_params)
+
+
+def test_spectrogram_update_settings_preserves_same_type_children():
+    """Composite.update_settings should delegate to matching children via their own update_settings."""
+    from ezmsg.sigproc.spectrogram import SpectrogramSettings
+
+    messages = create_messages_with_periodic_signal(
+        sin_params=[{"f": 10.0, "dur": 1.0, "offset": 0.0}],
+        fs=1000.0,
+        msg_dur=0.4,
+        win_step_dur=None,
+    )
+
+    proc = SpectrogramTransformer(
+        window_dur=0.5,
+        window_shift=0.25,
+        window=WindowFunction.HANNING,
+        transform=SpectralTransform.REL_DB,
+        output=SpectralOutput.POSITIVE,
+    )
+    # Warm up to populate child state.
+    for msg in messages:
+        _ = proc(msg)
+
+    windowing_before = proc._procs["windowing"]
+    spectrum_before = proc._procs["spectrum"]
+
+    # Change fields that still yield same-type children; instances must survive.
+    proc.update_settings(
+        SpectrogramSettings(
+            window_dur=0.5,
+            window_shift=0.25,
+            window=WindowFunction.HAMMING,
+            transform=SpectralTransform.REL_DB,
+            output=SpectralOutput.POSITIVE,
+        )
+    )
+    assert proc._procs["windowing"] is windowing_before
+    assert proc._procs["spectrum"] is spectrum_before
+    # Pipeline still runnable after the update.
+    for msg in messages:
+        _ = proc(msg)


### PR DESCRIPTION
## Summary

Introduces a first-class "live settings update" path so units can absorb `INPUT_SETTINGS` messages without tearing down and rebuilding their underlying processor/producer on every change. Subclasses declare which fields are safe to swap in place via a class-level allow-list; everything else triggers a state reset on the next message.

## Motivation

Previously, `BaseProcessorUnit.on_settings` (and friends) called `create_processor()` on every settings message, which dropped all accumulated state — stream buffers, filter `zi` arrays, adaptive statistics, open hardware sessions. Downstream units in ezmsg-sigproc and ezmsg-tasks worked around this by overriding `on_settings` with bespoke logic (e.g. "only recreate if `axis` changed"), which was error-prone and tended to leave derived state stale on unrelated field changes. This PR moves the decision from the Unit layer down to the processor/producer, where the class actually knows what state depends on which field.

## What changes

### Processor / producer API

Upstream `BaseProcessor` and `BaseProducer` gained two pieces:

- `NONRESET_SETTINGS_FIELDS: ClassVar[frozenset[str]]` — the set of settings field names whose change does *not* require a state reset. Default `frozenset()` means any change resets.
- `update_settings(new_settings)` — diffs new vs. old, rebinds `self.settings`, calls `_request_reset()` if any changed field is outside the allow-list. Subclasses can override for finer-grained control (e.g. "reset only when `window_size` shrinks"); the existing `FilterByDesignTransformer` override continues to work unchanged.

`BaseStatefulProcessor` / `BaseStatefulProducer` override `_request_reset()` to set `self._hash = -1`, so the next `__call__` / `__acall__` hits the `_reset_state(message)` path. On non-stateful processors `_request_reset()` is a no-op — they read `self.settings` directly each call.

### Unit layer

`BaseProducerUnit.on_settings` and `BaseProcessorUnit.on_settings` now do `self.apply_settings(msg); self.<processor|producer>.update_settings(self.SETTINGS)` instead of `create_<processor|producer>()`. Resources held by the old instance are preserved when the allow-list permits; a full rebuild happens only when the subclass's `update_settings` explicitly requests it. **Downstream units in the wild that override `on_settings` with `apply_settings(msg); create_processor()` will now do a double-rebuild if they also call `super().on_settings(msg)`** — they should drop their override and declare `NONRESET_SETTINGS_FIELDS` on the processor instead (see the companion ezmsg-sigproc PR for examples).

### Composites

`CompositeProcessor.update_settings` and `CompositeProducer.update_settings` reconcile the child pipeline against `_initialize_processors(new_settings)`:

- Same key + same exact child type → delegate via `old_child.update_settings(new_child.settings)`, so the child's own NONRESET allow-list decides whether to reset. State is preserved when the child can absorb the change.
- Key disappears, appears, or child type changes → close the old child (if it exposes `close()`) and swap in the fresh one.
- `_validate_processor_chain()` re-runs after reconciliation to catch message-type mismatches.
- Composite-level `NONRESET_SETTINGS_FIELDS` short-circuits the whole rebuild when no non-safe field changed.

This avoids every composite in the ecosystem (6 in ezmsg-sigproc alone) having to hand-write the same reconciliation loop. If a specific composite needs bespoke behavior, overriding `update_settings` still works.

## Tests

`tests/test_update_settings.py` now covers:

- Non-stateful processors/producers: settings rebinding, no reset path to exercise.
- Stateful processors: reset triggered by non-safe field, safe field preserves hash, `_reset_state` sees new settings, no-op update is a no-op, empty default allow-list resets on any change.
- Stateful producers: same cases over the async `__acall__` path.
- `update_settings` subclass override: custom rule (reset only when `window_size` shrinks) takes full control.
- Composites: matching children preserve state via delegation, new key added when a flag flips on, disappeared key is closed, no-op update skips rebuild, composite-level NONRESET skips rebuild.

Full baseproc suite passes (167 tests).

## Test plan

- [x] `pytest` green on live_settings locally
- [x] Verify ezmsg-sigproc's companion PR lands cleanly against this branch (removes four `on_settings` overrides, adds `NONRESET_SETTINGS_FIELDS` to ~10 processors, picks up composite behavior unchanged)
- [x] Spot-check one pipeline that receives runtime settings updates (e.g. adaptive scaler with live `accumulate` toggle) to confirm state survives and is actually applied
