### PR TITLE
sos mlx metal fix

### DIFF
--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -25,6 +25,7 @@ try:
     import mlx.core as _mx
 
     from .util.sosfilt_mlx_metal import MAX_CHUNK_SIZE as _MLX_MAX_CHUNK_SIZE
+    from .util.sosfilt_mlx_metal import sos_float32_stable as _sos_float32_stable
     from .util.sosfilt_mlx_metal import sosfilt_mlx_metal as _sosfilt_mlx_metal_fn
 
     _HAS_MLX_METAL = True
@@ -301,7 +302,7 @@ class FilterState:
     fir_b: typing.Any | None = None  # reshaped taps for FFT path (broadcast shape)
     fir_b_1d: typing.Any | None = None  # 1D taps for conv path
     fir_method: str | None = None  # 'conv', 'fft', or None (scipy)
-    sos_method: str | None = None  # 'mlx_metal' or None (scipy)
+    sos_method: str | None = None  # 'mlx_metal', 'scipy_numpy', or None (scipy)
     sos_mx: typing.Any | None = None  # cached mlx.core.array of SOS coefs
 
 
@@ -372,24 +373,41 @@ class FilterTransformer(BaseStatefulTransformer[FilterSettings, AxisArray, AxisA
             n_tile = (1,) + n_tile
 
         zi_tiled = np.tile(zi[zi_expand], n_tile)
-        if not is_numpy_array(message.data):
-            xp = get_namespace(message.data)
-            zi_tiled = xp_asarray(xp, zi_tiled)
-        self.state.zi = zi_tiled
         self.state.fir_method = None
         self.state.fir_b = None
         self.state.fir_b_1d = None
 
-        # Route SOS on MLX inputs through the on-device Metal kernel.
+        sos_method = None
+        sos_mx = None
+        is_mlx_input = not is_numpy_array(message.data) and get_namespace(message.data).__name__ == "mlx.core"
+
+        # Route SOS on MLX inputs through the on-device Metal kernel when the
+        # float32 SOS remains stable. Ultra-low high-pass filters can become
+        # unstable after float32 quantization; keep those on scipy with a
+        # float64 NumPy state instead of sending them to Metal.
         if (
             self.settings.coef_type == "sos"
             and self.settings.use_mlx_metal
             and _HAS_MLX_METAL
-            and not is_numpy_array(message.data)
-            and get_namespace(message.data).__name__ == "mlx.core"
+            and is_mlx_input
+            and _sos_float32_stable(coefs[0])
         ):
+            sos_method = "mlx_metal"
+            sos_mx = _mx.array(np.asarray(coefs[0]).astype(np.float32))
+        elif self.settings.coef_type == "sos" and is_mlx_input:
+            sos_method = "scipy_numpy"
+
+        if not is_numpy_array(message.data) and sos_method != "scipy_numpy":
+            xp = get_namespace(message.data)
+            zi_tiled = xp_asarray(xp, zi_tiled)
+        self.state.zi = zi_tiled
+
+        if sos_method == "mlx_metal":
             self.state.sos_method = "mlx_metal"
-            self.state.sos_mx = _mx.array(np.asarray(coefs[0]).astype(np.float32))
+            self.state.sos_mx = sos_mx
+        elif sos_method == "scipy_numpy":
+            self.state.sos_method = "scipy_numpy"
+            self.state.sos_mx = None
         else:
             self.state.sos_method = None
             self.state.sos_mx = None
@@ -457,6 +475,16 @@ class FilterTransformer(BaseStatefulTransformer[FilterSettings, AxisArray, AxisA
                     _, coefs = _normalize_coefs(self.settings.coefs)
                     self.state.sos_mx = _mx.array(np.asarray(coefs[0]).astype(np.float32))
                 dat_out, self.state.zi = _sosfilt_mlx_metal_xp(self.state.sos_mx, message.data, axis_idx, self.state.zi)
+            elif self.state.sos_method == "scipy_numpy":
+                _, coefs = _normalize_coefs(self.settings.coefs)
+                filt_func = {"ba": scipy.signal.lfilter, "sos": scipy.signal.sosfilt}[self.settings.coef_type]
+                dat_out_np, self.state.zi = filt_func(
+                    *coefs,
+                    np.asarray(message.data),
+                    axis=axis_idx,
+                    zi=np.asarray(self.state.zi),
+                )
+                dat_out = xp_asarray(get_namespace(message.data), dat_out_np)
             else:
                 _, coefs = _normalize_coefs(self.settings.coefs)
                 filt_func = {"ba": scipy.signal.lfilter, "sos": scipy.signal.sosfilt}[self.settings.coef_type]

--- a/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
+++ b/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
@@ -60,6 +60,7 @@ Regression testing:
 """
 
 import mlx.core as mx
+import numpy as np
 
 # ---------------------------------------------------------------------------
 # Module constants
@@ -71,6 +72,34 @@ import mlx.core as mx
 #: your hardware has additional shared-memory headroom.
 MAX_CHUNK_SIZE = 512
 
+# Prefix-scan composition is fast, but it is numerically fragile when SOS
+# poles are very close to the unit circle. Above this radius we keep the
+# computation on Metal but use a serial DF-II-T kernel per channel.
+SERIAL_KERNEL_POLE_RADIUS = 0.995
+
+
+def sos_float32_max_pole_radius(sos) -> float:
+    """Return the largest denominator pole radius after float32 quantization."""
+    sos_np = np.asarray(sos, dtype=np.float32)
+    if sos_np.ndim != 2 or sos_np.shape[1] != 6:
+        raise ValueError(f"sos must have shape (n_sections, 6); got {tuple(sos_np.shape)}")
+
+    max_radius = 0.0
+    for section in sos_np:
+        den = np.asarray(section[3:6], dtype=np.float64)
+        if den[0] == 0.0:
+            raise ValueError("SOS denominator coefficient a0 must be nonzero")
+        roots = np.roots(den)
+        if roots.size:
+            max_radius = max(max_radius, float(np.max(np.abs(roots))))
+    return max_radius
+
+
+def sos_float32_stable(sos) -> bool:
+    """Whether the SOS denominator remains stable after float32 quantization."""
+    radius = sos_float32_max_pole_radius(sos)
+    return np.isfinite(radius) and radius < 1.0
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -80,10 +109,10 @@ MAX_CHUNK_SIZE = 512
 def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
     """Apply an SOS biquad filter cascade on-device.
 
-    One fused Metal kernel launch per chunk handles all biquad sections
-    sequentially in threadgroup memory, matching scipy.signal.sosfilt
-    semantics (Direct Form II Transposed, sequential sections, zi/zf
-    state continuity).
+    One fused Metal kernel launch per chunk handles typical biquad sections
+    sequentially in threadgroup memory. Filters with poles very close to the
+    unit circle use a slower serial Metal kernel that preserves scipy.signal
+    SOS semantics for numerically delicate low-cutoff filters.
 
     Args:
         sos: :class:`mx.array` of shape ``(n_sections, 6)`` containing the
@@ -107,8 +136,8 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
           suitable to pass as ``zi`` for the next chunk in streaming use.
 
     Raises:
-        ValueError: if ``sos`` has the wrong shape or if ``chunk_size``
-            is out of range.
+        ValueError: if ``sos`` has the wrong shape, if ``chunk_size`` is out
+            of range, or if the float32 SOS denominator would be unstable.
 
     Notes:
         The kernel is compiled once per distinct
@@ -128,6 +157,15 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
         raise ValueError(f"chunk_size must be >= 1; got {chunk_size}")
     if x.ndim < 1:
         raise ValueError(f"x must have at least 1 dimension; got {x.ndim}")
+
+    max_pole_radius = sos_float32_max_pole_radius(sos)
+    if not np.isfinite(max_pole_radius) or max_pole_radius >= 1.0:
+        raise ValueError(
+            "sosfilt_mlx_metal requires SOS denominators to remain stable after "
+            f"float32 quantization; max pole radius is {max_pole_radius:.9g}. "
+            "Use a float64 scipy path or redesign the filter with a higher cutoff."
+        )
+    use_serial_kernel = max_pole_radius >= SERIAL_KERNEL_POLE_RADIUS
 
     sos_f32 = sos.astype(mx.float32) if sos.dtype != mx.float32 else sos
     x_f32 = x.astype(mx.float32) if x.dtype != mx.float32 else x
@@ -162,7 +200,10 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
         end = min(start + chunk_size, n_samples)
         cs = end - start
         x_chunk = x_flat[:, start:end]
-        y_chunk, zi_flat = _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs)
+        if use_serial_kernel:
+            y_chunk, zi_flat = _launch_serial_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs)
+        else:
+            y_chunk, zi_flat = _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs)
         y_chunks.append(y_chunk)
 
     y_combined = y_chunks[0] if len(y_chunks) == 1 else mx.concatenate(y_chunks, axis=-1)
@@ -373,6 +414,88 @@ def _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs)
         ],
         grid=(n_channels * cs, 1, 1),
         threadgroup=(cs, 1, 1),
+        output_shapes=[
+            (n_channels, cs),
+            (n_sections * n_channels * 2,),
+        ],
+        output_dtypes=[mx.float32, mx.float32],
+    )
+    return y_chunk, zf_flat
+
+
+# ---------------------------------------------------------------------------
+# Serial kernel (near-unit-pole path)
+# ---------------------------------------------------------------------------
+#
+# The fused prefix-scan kernel composes section state matrices in float32.
+# For poles very close to the unit circle, those matrix products can drift
+# enough to swamp low-cutoff high-pass outputs. This kernel keeps the same
+# data on Metal but assigns one thread per channel and runs scipy's DF-II-T
+# recurrence in time order. It is slower, but it matches scipy's float32 SOS
+# semantics for filters that are too numerically delicate for the scan.
+
+_SERIAL_KERNEL_SOURCE = r"""
+    uint ch = thread_position_in_grid.x;
+
+    float z0[N_SECTIONS];
+    float z1[N_SECTIONS];
+    for (uint sec = 0; sec < N_SECTIONS; sec++) {
+        uint zi_base = (sec * N_CHANNELS + ch) * 2;
+        z0[sec] = zi_all[zi_base + 0];
+        z1[sec] = zi_all[zi_base + 1];
+    }
+
+    for (uint t = 0; t < CS; t++) {
+        float x_val = x_in[ch * CS + t];
+
+        for (uint sec = 0; sec < N_SECTIONS; sec++) {
+            uint sbase = sec * 6;
+            float b0 = sos_all[sbase + 0];
+            float b1 = sos_all[sbase + 1];
+            float b2 = sos_all[sbase + 2];
+            float a1 = sos_all[sbase + 4];
+            float a2 = sos_all[sbase + 5];
+
+            float y_val = b0 * x_val + z0[sec];
+            float next_z0 = b1 * x_val - a1 * y_val + z1[sec];
+            float next_z1 = b2 * x_val - a2 * y_val;
+
+            z0[sec] = next_z0;
+            z1[sec] = next_z1;
+            x_val = y_val;
+        }
+
+        y_out[ch * CS + t] = x_val;
+    }
+
+    for (uint sec = 0; sec < N_SECTIONS; sec++) {
+        uint zi_base = (sec * N_CHANNELS + ch) * 2;
+        zf_all[zi_base + 0] = z0[sec];
+        zf_all[zi_base + 1] = z1[sec];
+    }
+"""
+
+
+_serial_kernel = mx.fast.metal_kernel(
+    name="sosfilt_biquad_serial",
+    input_names=["x_in", "sos_all", "zi_all"],
+    output_names=["y_out", "zf_all"],
+    source=_SERIAL_KERNEL_SOURCE,
+)
+
+
+def _launch_serial_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs):
+    """One serial DF-II-T kernel dispatch for numerically delicate SOS filters."""
+    y_chunk, zf_flat = _serial_kernel(
+        inputs=[x_chunk, sos_flat, zi_flat],
+        template=[
+            ("T", mx.float32),
+            ("CS", cs),
+            ("N_SECTIONS", n_sections),
+            ("N_CHANNELS", n_channels),
+        ],
+        grid=(n_channels, 1, 1),
+        threadgroup=(1, 1, 1),
         output_shapes=[
             (n_channels, cs),
             (n_sections * n_channels * 2,),

--- a/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
+++ b/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
@@ -59,6 +59,8 @@ Regression testing:
     cross-check for any future kernel modifications.
 """
 
+import weakref
+
 import mlx.core as mx
 import numpy as np
 
@@ -76,6 +78,8 @@ MAX_CHUNK_SIZE = 512
 # poles are very close to the unit circle. Above this radius we keep the
 # computation on Metal but use a serial DF-II-T kernel per channel.
 SERIAL_KERNEL_POLE_RADIUS = 0.995
+
+_SOS_POLE_RADIUS_CACHE: dict[int, tuple[weakref.ReferenceType, tuple[int, ...], str, float]] = {}
 
 
 def sos_float32_max_pole_radius(sos) -> float:
@@ -99,6 +103,26 @@ def sos_float32_stable(sos) -> bool:
     """Whether the SOS denominator remains stable after float32 quantization."""
     radius = sos_float32_max_pole_radius(sos)
     return np.isfinite(radius) and radius < 1.0
+
+
+def _cached_sos_float32_max_pole_radius(sos) -> float:
+    """Return SOS pole radius, reusing the result for repeated MLX array calls."""
+    if not isinstance(sos, mx.array):
+        return sos_float32_max_pole_radius(sos)
+
+    key = id(sos)
+    shape = tuple(sos.shape)
+    dtype = str(sos.dtype)
+    cached = _SOS_POLE_RADIUS_CACHE.get(key)
+    if cached is not None:
+        ref, cached_shape, cached_dtype, radius = cached
+        if ref() is sos and cached_shape == shape and cached_dtype == dtype:
+            return radius
+
+    radius = sos_float32_max_pole_radius(sos)
+    ref = weakref.ref(sos, lambda _ref, cache_key=key: _SOS_POLE_RADIUS_CACHE.pop(cache_key, None))
+    _SOS_POLE_RADIUS_CACHE[key] = (ref, shape, dtype, radius)
+    return radius
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +182,7 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
     if x.ndim < 1:
         raise ValueError(f"x must have at least 1 dimension; got {x.ndim}")
 
-    max_pole_radius = sos_float32_max_pole_radius(sos)
+    max_pole_radius = _cached_sos_float32_max_pole_radius(sos)
     if not np.isfinite(max_pole_radius) or max_pole_radius >= 1.0:
         raise ValueError(
             "sosfilt_mlx_metal requires SOS denominators to remain stable after "

--- a/tests/unit/test_sosfilt_mlx_metal.py
+++ b/tests/unit/test_sosfilt_mlx_metal.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+import scipy.signal
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.butterworthfilter import ButterworthFilterSettings, ButterworthFilterTransformer
+from tests.helpers.util import requires_mlx
+
+
+@requires_mlx
+def test_sosfilt_mlx_metal_low_highpass_matches_scipy_float32():
+    import mlx.core as mx
+
+    from ezmsg.sigproc.util.sosfilt_mlx_metal import sosfilt_mlx_metal
+
+    fs = 30_000.0
+    sos = scipy.signal.butter(4, 3.0, btype="highpass", fs=fs, output="sos").astype(np.float32)
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((3, 4096)).astype(np.float32)
+
+    zi = np.zeros((sos.shape[0], data.shape[0], 2), dtype=np.float32)
+    expected, expected_zf = scipy.signal.sosfilt(sos, data, axis=-1, zi=zi)
+
+    actual, actual_zf = sosfilt_mlx_metal(mx.array(sos), mx.array(data))
+    mx.eval(actual, actual_zf)
+
+    actual_np = np.asarray(actual)
+    assert np.isfinite(actual_np).all()
+    assert np.allclose(actual_np, expected, rtol=1e-5, atol=2e-5)
+    assert np.allclose(np.asarray(actual_zf), expected_zf, rtol=1e-5, atol=2e-5)
+
+
+@requires_mlx
+def test_sosfilt_mlx_metal_rejects_float32_unstable_highpass():
+    import mlx.core as mx
+
+    from ezmsg.sigproc.util.sosfilt_mlx_metal import sosfilt_mlx_metal
+
+    fs = 30_000.0
+    sos = scipy.signal.butter(4, 0.3, btype="highpass", fs=fs, output="sos").astype(np.float32)
+    data = np.zeros((1, 64), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="float32 quantization"):
+        sosfilt_mlx_metal(mx.array(sos), mx.array(data))
+
+
+@requires_mlx
+def test_butterworth_mlx_float32_unstable_highpass_uses_scipy_numpy_state():
+    import mlx.core as mx
+
+    fs = 30_000.0
+    n_samples = 4096
+    n_channels = 2
+    rng = np.random.default_rng(1)
+    data = rng.standard_normal((n_samples, n_channels)).astype(np.float32)
+    msg = AxisArray(
+        mx.array(data),
+        dims=["time", "ch"],
+        axes={"time": AxisArray.TimeAxis(fs=fs, offset=0.0)},
+        key="low-highpass",
+    )
+
+    transformer = ButterworthFilterTransformer(
+        ButterworthFilterSettings(
+            axis="time",
+            order=4,
+            cuton=0.3,
+            cutoff=None,
+            coef_type="sos",
+            use_mlx_metal=True,
+        )
+    )
+
+    result = transformer(msg)
+    mx.eval(result.data)
+
+    assert transformer.state.filter.state.sos_method == "scipy_numpy"
+    assert isinstance(transformer.state.filter.state.zi, np.ndarray)
+
+    sos = scipy.signal.butter(4, 0.3, btype="highpass", fs=fs, output="sos")
+    zi = scipy.signal.sosfilt_zi(sos)[:, :, None] + np.zeros((1, 1, n_channels))
+    expected, _ = scipy.signal.sosfilt(sos, data, axis=0, zi=zi)
+
+    actual = np.asarray(result.data)
+    assert np.isfinite(actual).all()
+    assert np.allclose(actual, expected.astype(np.float32), rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
This PR makes the MLX/Metal SOS path safer for low-cutoff high-pass filters (current ACIC implementation). It does not make Metal SOS match BA64/SciPy float64 identically for the ACIC filter but its close enough it doesn't change the decoding of the end features.