### PR TITLE
flatten -- emit structured CoordinateAxis with per-axis fields 

### DIFF
--- a/src/ezmsg/sigproc/flatten.py
+++ b/src/ezmsg/sigproc/flatten.py
@@ -25,16 +25,12 @@ or position index), separated by :attr:`FlattenSettings.label_separator`
 (default ``"/"``).  This ``"label"`` overwrites any inherited label
 field from the source axes — the original per-axis labels are still
 available via the named fields (``ch``, ``feature``, etc.).
-
-This is the canonical Flatten in the ezmsg ecosystem.
-``ezmsg.learn.process.flatten`` is a thin wrapper that post-processes
-the merged-axis labels for time-lag windowing
-(``"<ch>__t-<lag>"`` semantics).
 """
 
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 
 import ezmsg.core as ez
 import numpy as np
@@ -127,70 +123,67 @@ class FlattenState:
     output_dims: tuple[str, ...] = ()
 
 
-def _axis_contribution(message: AxisArray, ax_name: str, ax_size: int) -> dict:
-    """Per-axis contribution to the merged struct.
+@dataclass
+class _AxisContribution:
+    """How one source axis fills the merged struct.
 
-    Returns a dict with keys:
-      * ``"fields"``: ordered tuple of (field_name, numpy dtype) pairs
-        this axis contributes to the merged struct dtype.
-      * ``"get_row(i)``: callable mapping a 0-based axis position to a
-        ``{field_name: value}`` dict.
-      * ``"primary(i)``: callable mapping a 0-based axis position to the
-        string used for that axis's slot in the cartesian-product
-        ``"label"`` join.
+    ``rows`` is a structured array (length = source axis size)
+    contributing this axis's fields to the merged dtype.  ``primary``
+    is the per-position string column used in the canonical
+    cartesian-product ``"label"`` join.
     """
+
+    rows: np.ndarray
+    primary: np.ndarray
+
+
+def _axis_contribution(message: AxisArray, ax_name: str, ax_size: int) -> _AxisContribution:
+    """Build the per-axis contribution to the merged struct."""
     ax_obj = message.axes.get(ax_name)
     ax_data = getattr(ax_obj, "data", None) if ax_obj is not None else None
 
     if ax_data is not None and getattr(ax_data, "dtype", None) is not None and ax_data.dtype.names is not None:
-        # Structured axis: contribute every field; primary label =
-        # the "label" field if present, else fall back to a 1-based
-        # index so the cartesian-product label stays human-readable.
-        names = tuple(ax_data.dtype.names)
-        fields = tuple((n, ax_data.dtype[n]) for n in names)
-        has_label = "label" in names
-        return {
-            "fields": fields,
-            "get_row": lambda i: {n: ax_data[i][n] for n in names},
-            "primary": (lambda i: str(ax_data[i]["label"])) if has_label else (lambda i: str(i + 1)),
-        }
+        # Structured axis: pass every field through.  Primary label =
+        # the "label" field if present, else a 1-based index so the
+        # cartesian-product label stays human-readable.
+        rows = np.asarray(ax_data)
+        if "label" in rows.dtype.names:
+            primary = rows["label"].astype(str)
+        else:
+            primary = np.arange(1, ax_size + 1).astype(str)
+        return _AxisContribution(rows=rows, primary=primary)
 
     if ax_data is not None:
-        # Simple CoordinateAxis: one virtual field named after the
-        # axis whose value is the per-position label.
-        labels = [str(x) for x in axis_labels(np.asarray(ax_data[:ax_size]))]
-        max_len = max((len(s) for s in labels), default=1)
-        dtype = np.dtype(f"U{max_len}")
-        return {
-            "fields": ((ax_name, dtype),),
-            "get_row": lambda i: {ax_name: labels[i]},
-            "primary": lambda i: labels[i],
-        }
+        # Simple CoordinateAxis: one virtual field named after the axis.
+        str_labels = [str(x) for x in axis_labels(np.asarray(ax_data)[:ax_size])]
+        max_len = max((len(s) for s in str_labels), default=1)
+        labels = np.asarray(str_labels, dtype=f"U{max_len}")
+        rows = np.empty(ax_size, dtype=[(ax_name, labels.dtype)])
+        rows[ax_name] = labels
+        return _AxisContribution(rows=rows, primary=labels)
 
-    # No CoordinateAxis at all: 1-based uint32 indices.
-    dtype = np.dtype(np.uint32)
-    return {
-        "fields": ((ax_name, dtype),),
-        "get_row": lambda i: {ax_name: np.uint32(i + 1)},
-        "primary": lambda i: str(i + 1),
-    }
+    # No CoordinateAxis: 1-based uint32 positions.
+    positions = np.arange(1, ax_size + 1, dtype=np.uint32)
+    rows = np.empty(ax_size, dtype=[(ax_name, np.uint32)])
+    rows[ax_name] = positions
+    return _AxisContribution(rows=rows, primary=positions.astype(str))
 
 
-def _wider_string_dtype(a: np.dtype, b: np.dtype) -> np.dtype:
-    """Return the wider unicode dtype, or raise if not both unicode."""
-    if a.kind != "U" or b.kind != "U":
-        raise ValueError(
-            f"Cannot merge incompatible dtypes {a!r} and {b!r} on shared "
-            "struct field; widening is only defined for unicode strings."
-        )
-    return np.dtype(f"U{max(a.itemsize, b.itemsize) // 4}")
+def _merge_field_dtype(name: str, a: np.dtype, b: np.dtype) -> np.dtype:
+    """Resolve a shared field's dtype across two contributing axes.
 
-
-def _resolve_field_dtype(name: str, dt_a: np.dtype, dt_b: np.dtype) -> np.dtype:
-    """Resolve a shared field's dtype across two contributing axes."""
-    if dt_a == dt_b:
-        return dt_a
-    return _wider_string_dtype(dt_a, dt_b)
+    Equal dtypes pass through; unicode pairs widen to the larger
+    width; anything else raises — silently coercing mismatched
+    numeric/string fields would corrupt values.
+    """
+    if a == b:
+        return a
+    if a.kind == "U" and b.kind == "U":
+        return np.dtype(f"U{max(a.itemsize, b.itemsize) // 4}")
+    raise ValueError(
+        f"Cannot merge incompatible dtypes {a!r} and {b!r} on shared "
+        f"struct field {name!r}; widening is only defined for unicode strings."
+    )
 
 
 def _build_merged_axis(
@@ -202,58 +195,45 @@ def _build_merged_axis(
 ) -> CoordinateAxis:
     """Build the merged-axis structured CoordinateAxis."""
     if not flatten_axes:
-        # Degenerate case: nothing to flatten → empty struct with a
-        # single uint32 ``label`` placeholder.
-        dtype = np.dtype([("label", np.dtype("U1"))])
+        # Degenerate: nothing to flatten → one row, single canonical field.
+        dtype = np.dtype([("label", "U1")])
         return CoordinateAxis(data=np.zeros(1, dtype=dtype), dims=[output_axis])
 
-    contribs = [_axis_contribution(message, ax_name, ax_size) for ax_name, ax_size in zip(flatten_axes, flatten_sizes)]
-
-    # Build the merged dtype: union of all contributing fields, later
-    # axes overwriting (widening) on conflict.  ``"label"`` is always
-    # appended last and overrides any inherited label field.
-    field_order: list[str] = []
-    field_dtype: dict[str, np.dtype] = {}
-    for c in contribs:
-        for name, dt in c["fields"]:
-            if name in field_dtype:
-                field_dtype[name] = _resolve_field_dtype(name, field_dtype[name], dt)
-            else:
-                field_order.append(name)
-                field_dtype[name] = dt
-
-    # Cartesian product, slowest-changing axis first — mirrors the
-    # C-order reshape so output row k describes data[:, k, ...].
+    contribs = [_axis_contribution(message, name, size) for name, size in zip(flatten_axes, flatten_sizes)]
     n_flat = int(math.prod(flatten_sizes))
-    combos: list[tuple[int, ...]] = [tuple()]
-    for ax_size in flatten_sizes:
-        combos = [(*prefix, i) for prefix in combos for i in range(ax_size)]
-    assert len(combos) == n_flat
 
-    label_column = [
-        separator.join(c["primary"](pos) for c, pos in zip(contribs, combo))
-        if separator
-        else "".join(c["primary"](pos) for c, pos in zip(contribs, combo))
-        for combo in combos
-    ]
-    label_dtype = np.dtype(f"U{max((len(s) for s in label_column), default=1)}")
-    if "label" in field_dtype:
-        field_dtype["label"] = _resolve_field_dtype("label", field_dtype["label"], label_dtype)
-    else:
-        field_order.append("label")
-        field_dtype["label"] = label_dtype
+    # Expand each axis's per-position arrays to the cartesian-product
+    # length via tile+repeat — slowest-changing first mirrors numpy's
+    # C-order reshape so output row k describes data[:, k, ...].
+    def _expand(arr: np.ndarray, axis_idx: int) -> np.ndarray:
+        inner = math.prod(flatten_sizes[axis_idx + 1 :])
+        outer = math.prod(flatten_sizes[:axis_idx])
+        return np.tile(np.repeat(arr, inner), outer)
 
-    struct_dtype = np.dtype([(n, field_dtype[n]) for n in field_order])
-    struct_data = np.zeros(n_flat, dtype=struct_dtype)
+    expanded_rows = [_expand(c.rows, i) for i, c in enumerate(contribs)]
+    expanded_primary = [_expand(c.primary, i) for i, c in enumerate(contribs)]
 
-    for row_idx, combo in enumerate(combos):
-        # Apply per-axis contributions left-to-right; later axes
-        # overwrite shared fields (dict-union with later-wins).
-        for c, pos in zip(contribs, combo):
-            for name, value in c["get_row"](pos).items():
-                struct_data[row_idx][name] = value
-        # The canonical label always wins.
-        struct_data[row_idx]["label"] = label_column[row_idx]
+    # Canonical "label" column: cartesian-product join of primaries.
+    label_column = np.asarray([separator.join(parts) for parts in zip(*expanded_primary)])
+
+    # Merge struct dtype: dict-union with later-wins (widening shared
+    # string fields).  ``"label"`` is always overridden by the join
+    # column, so source-struct labels survive only via their named
+    # fields (``ch``, etc.).
+    fields: dict[str, np.dtype] = {}
+    for c in contribs:
+        for name in c.rows.dtype.names:
+            dt = c.rows.dtype[name]
+            fields[name] = _merge_field_dtype(name, fields[name], dt) if name in fields else dt
+    fields["label"] = (
+        _merge_field_dtype("label", fields["label"], label_column.dtype) if "label" in fields else label_column.dtype
+    )
+
+    struct_data = np.zeros(n_flat, dtype=np.dtype(list(fields.items())))
+    for c, rows in zip(contribs, expanded_rows):
+        for name in c.rows.dtype.names:
+            struct_data[name] = rows[name]
+    struct_data["label"] = label_column
 
     return CoordinateAxis(data=struct_data, dims=[output_axis])
 
@@ -276,7 +256,7 @@ class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, Axi
             if ax not in message.dims:
                 raise ValueError(f"flatten_axes entry {ax!r} not found in dims {message.dims}")
         if preserve_axis in flatten_axes:
-            raise ValueError(f"preserve_axis {preserve_axis!r} cannot also be in " f"flatten_axes {flatten_axes}")
+            raise ValueError(f"preserve_axis {preserve_axis!r} cannot also be in flatten_axes {flatten_axes}")
 
         output_axis = self.settings.output_axis
         if output_axis == sample_axis:
@@ -332,7 +312,7 @@ class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, Axi
         axes: dict = {st.output_axis: st.output_axis_obj}
         preserve_ax = message.axes.get(st.preserve_axis)
         if preserve_ax is not None:
-            if st.sample_axis != st.preserve_axis and hasattr(preserve_ax, "dims"):
+            if st.sample_axis != st.preserve_axis and isinstance(preserve_ax, CoordinateAxis):
                 preserve_ax = replace(preserve_ax, dims=[st.sample_axis])
             axes[st.sample_axis] = preserve_ax
         for ax in st.rest_axes:

--- a/src/ezmsg/sigproc/flatten.py
+++ b/src/ezmsg/sigproc/flatten.py
@@ -2,15 +2,34 @@
 
 The most common use is collapsing a ``(time, ch, feature)`` stream into
 ``(time, ch_x_feature)`` for transports that only support 2-D data (e.g.
-LSL).  When both flatten axes carry CoordinateAxis labels the output gets
-a cartesian-product CoordinateAxis like
-``["ch1-spk", "ch1-sbp", "ch2-spk", ...]`` whose ordering matches numpy's
-C-order reshape — so consumers downstream can recover ``(channel, feature)``
-identity from the labels alone.
+LSL).
+
+The merged axis is always emitted as a numpy *structured* CoordinateAxis
+whose rows are the cartesian product of the source-axis entries.  Per
+cartesian combination, the merge rule is **dict-union with later-wins on
+conflicts**:
+
+* Source axes with a structured CoordinateAxis contribute *all* their
+  fields to the merged row (so an upstream ``ch`` axis carrying
+  ``(x, y, label, bank, elec, device)`` propagates every field through).
+* Source axes with a simple CoordinateAxis contribute one virtual field
+  named after the axis (e.g. ``"feature"``) whose value is the axis
+  label at that position.
+* Source axes without a CoordinateAxis contribute one virtual uint32
+  field with a 1-based position index.
+
+A canonical ``"label"`` field is *always* present on the output struct.
+Its value is the cartesian-product join of each source axis's primary
+label (the axis's own ``"label"`` field if struct, else the axis value
+or position index), separated by :attr:`FlattenSettings.label_separator`
+(default ``"/"``).  This ``"label"`` overwrites any inherited label
+field from the source axes — the original per-axis labels are still
+available via the named fields (``ch``, ``feature``, etc.).
 
 This is the canonical Flatten in the ezmsg ecosystem.
-``ezmsg.learn.process.flatten`` is a thin wrapper around it that adds
-time-lag-windowing label semantics (``"<ch>__t-<lag>"``).
+``ezmsg.learn.process.flatten`` is a thin wrapper that post-processes
+the merged-axis labels for time-lag windowing
+(``"<ch>__t-<lag>"`` semantics).
 """
 
 from __future__ import annotations
@@ -57,14 +76,6 @@ def axis_labels(axis_data) -> list:
     return [normalize_axis_label(label) for label in axis_data]
 
 
-def _coord_labels(axis) -> list[str] | None:
-    """Return string labels from a CoordinateAxis, or None if unavailable."""
-    data = getattr(axis, "data", None)
-    if data is None:
-        return None
-    return [str(x) for x in axis_labels(np.asarray(data))]
-
-
 class FlattenSettings(ez.Settings):
     """
     Settings for :obj:`Flatten`.
@@ -83,23 +94,15 @@ class FlattenSettings(ez.Settings):
     """Tuple of axes to collapse, in fastest-varying-last
        order.  Defaults to *all non-preserve dims, in input order*, so a
        ``(time, ch, feature)`` input flattens with ``ch`` slow / ``feature``
-       fast — matching numpy's C-order reshape and the LSL convention of
-       interleaving features within each channel."""
+       fast — matching numpy's C-order reshape."""
 
     output_axis: str = "ch"
-    """Name of the merged axis on the output (default
-       ``"ch"`` so that downstream LSL outlets see a familiar dim name)."""
+    """Name of the merged axis on the output."""
 
-    label_separator: str = "-"
-    """Separator for cartesian-product labels.  Default
-        ``"-"``.  Set to ``""`` to concatenate without a delimiter."""
-
-    flat_labels: tuple[str, ...] | None = None
-    """Optional caller-supplied labels for the merged axis,
-       overriding the auto-generated cartesian product.  Length must
-       equal ``prod(flattened axis sizes)``.  Used by
-       :mod:`ezmsg.learn.process.flatten` to inject time-lag-style
-       labels (``"spk__t-1"``)."""
+    label_separator: str = "/"
+    """Separator for cartesian-product labels in the canonical
+        ``"label"`` field of the output struct.  Default ``"/"``.  Set
+        to ``""`` to concatenate without a delimiter."""
 
 
 @processor_state
@@ -118,10 +121,141 @@ class FlattenState:
     # Final shape after permute_dims + reshape: (n_preserve, n_flat, *rest_shape).
     target_shape: tuple[int, ...] = ()
 
-    # Precomputed merged-axis CoordinateAxis (cartesian product / arange / flat_labels).
+    # Precomputed merged-axis CoordinateAxis (structured array).
     output_axis_obj: CoordinateAxis | None = None
 
     output_dims: tuple[str, ...] = ()
+
+
+def _axis_contribution(message: AxisArray, ax_name: str, ax_size: int) -> dict:
+    """Per-axis contribution to the merged struct.
+
+    Returns a dict with keys:
+      * ``"fields"``: ordered tuple of (field_name, numpy dtype) pairs
+        this axis contributes to the merged struct dtype.
+      * ``"get_row(i)``: callable mapping a 0-based axis position to a
+        ``{field_name: value}`` dict.
+      * ``"primary(i)``: callable mapping a 0-based axis position to the
+        string used for that axis's slot in the cartesian-product
+        ``"label"`` join.
+    """
+    ax_obj = message.axes.get(ax_name)
+    ax_data = getattr(ax_obj, "data", None) if ax_obj is not None else None
+
+    if ax_data is not None and getattr(ax_data, "dtype", None) is not None and ax_data.dtype.names is not None:
+        # Structured axis: contribute every field; primary label =
+        # the "label" field if present, else fall back to a 1-based
+        # index so the cartesian-product label stays human-readable.
+        names = tuple(ax_data.dtype.names)
+        fields = tuple((n, ax_data.dtype[n]) for n in names)
+        has_label = "label" in names
+        return {
+            "fields": fields,
+            "get_row": lambda i: {n: ax_data[i][n] for n in names},
+            "primary": (lambda i: str(ax_data[i]["label"])) if has_label else (lambda i: str(i + 1)),
+        }
+
+    if ax_data is not None:
+        # Simple CoordinateAxis: one virtual field named after the
+        # axis whose value is the per-position label.
+        labels = [str(x) for x in axis_labels(np.asarray(ax_data[:ax_size]))]
+        max_len = max((len(s) for s in labels), default=1)
+        dtype = np.dtype(f"U{max_len}")
+        return {
+            "fields": ((ax_name, dtype),),
+            "get_row": lambda i: {ax_name: labels[i]},
+            "primary": lambda i: labels[i],
+        }
+
+    # No CoordinateAxis at all: 1-based uint32 indices.
+    dtype = np.dtype(np.uint32)
+    return {
+        "fields": ((ax_name, dtype),),
+        "get_row": lambda i: {ax_name: np.uint32(i + 1)},
+        "primary": lambda i: str(i + 1),
+    }
+
+
+def _wider_string_dtype(a: np.dtype, b: np.dtype) -> np.dtype:
+    """Return the wider unicode dtype, or raise if not both unicode."""
+    if a.kind != "U" or b.kind != "U":
+        raise ValueError(
+            f"Cannot merge incompatible dtypes {a!r} and {b!r} on shared "
+            "struct field; widening is only defined for unicode strings."
+        )
+    return np.dtype(f"U{max(a.itemsize, b.itemsize) // 4}")
+
+
+def _resolve_field_dtype(name: str, dt_a: np.dtype, dt_b: np.dtype) -> np.dtype:
+    """Resolve a shared field's dtype across two contributing axes."""
+    if dt_a == dt_b:
+        return dt_a
+    return _wider_string_dtype(dt_a, dt_b)
+
+
+def _build_merged_axis(
+    message: AxisArray,
+    flatten_axes: tuple[str, ...],
+    flatten_sizes: tuple[int, ...],
+    output_axis: str,
+    separator: str,
+) -> CoordinateAxis:
+    """Build the merged-axis structured CoordinateAxis."""
+    if not flatten_axes:
+        # Degenerate case: nothing to flatten → empty struct with a
+        # single uint32 ``label`` placeholder.
+        dtype = np.dtype([("label", np.dtype("U1"))])
+        return CoordinateAxis(data=np.zeros(1, dtype=dtype), dims=[output_axis])
+
+    contribs = [_axis_contribution(message, ax_name, ax_size) for ax_name, ax_size in zip(flatten_axes, flatten_sizes)]
+
+    # Build the merged dtype: union of all contributing fields, later
+    # axes overwriting (widening) on conflict.  ``"label"`` is always
+    # appended last and overrides any inherited label field.
+    field_order: list[str] = []
+    field_dtype: dict[str, np.dtype] = {}
+    for c in contribs:
+        for name, dt in c["fields"]:
+            if name in field_dtype:
+                field_dtype[name] = _resolve_field_dtype(name, field_dtype[name], dt)
+            else:
+                field_order.append(name)
+                field_dtype[name] = dt
+
+    # Cartesian product, slowest-changing axis first — mirrors the
+    # C-order reshape so output row k describes data[:, k, ...].
+    n_flat = int(math.prod(flatten_sizes))
+    combos: list[tuple[int, ...]] = [tuple()]
+    for ax_size in flatten_sizes:
+        combos = [(*prefix, i) for prefix in combos for i in range(ax_size)]
+    assert len(combos) == n_flat
+
+    label_column = [
+        separator.join(c["primary"](pos) for c, pos in zip(contribs, combo))
+        if separator
+        else "".join(c["primary"](pos) for c, pos in zip(contribs, combo))
+        for combo in combos
+    ]
+    label_dtype = np.dtype(f"U{max((len(s) for s in label_column), default=1)}")
+    if "label" in field_dtype:
+        field_dtype["label"] = _resolve_field_dtype("label", field_dtype["label"], label_dtype)
+    else:
+        field_order.append("label")
+        field_dtype["label"] = label_dtype
+
+    struct_dtype = np.dtype([(n, field_dtype[n]) for n in field_order])
+    struct_data = np.zeros(n_flat, dtype=struct_dtype)
+
+    for row_idx, combo in enumerate(combos):
+        # Apply per-axis contributions left-to-right; later axes
+        # overwrite shared fields (dict-union with later-wins).
+        for c, pos in zip(contribs, combo):
+            for name, value in c["get_row"](pos).items():
+                struct_data[row_idx][name] = value
+        # The canonical label always wins.
+        struct_data[row_idx]["label"] = label_column[row_idx]
+
+    return CoordinateAxis(data=struct_data, dims=[output_axis])
 
 
 class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, AxisArray, FlattenState]):
@@ -131,7 +265,7 @@ class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, Axi
     def _reset_state(self, message: AxisArray) -> None:
         preserve_axis = self.settings.preserve_axis or message.dims[0]
         if preserve_axis not in message.dims:
-            raise ValueError(f"preserve_axis {preserve_axis!r} not found in dims " f"{message.dims}")
+            raise ValueError(f"preserve_axis {preserve_axis!r} not found in dims {message.dims}")
 
         sample_axis = self.settings.sample_axis or preserve_axis
 
@@ -140,13 +274,13 @@ class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, Axi
             flatten_axes = tuple(d for d in message.dims if d != preserve_axis)
         for ax in flatten_axes:
             if ax not in message.dims:
-                raise ValueError(f"flatten_axes entry {ax!r} not found in dims " f"{message.dims}")
+                raise ValueError(f"flatten_axes entry {ax!r} not found in dims {message.dims}")
         if preserve_axis in flatten_axes:
             raise ValueError(f"preserve_axis {preserve_axis!r} cannot also be in " f"flatten_axes {flatten_axes}")
 
         output_axis = self.settings.output_axis
         if output_axis == sample_axis:
-            raise ValueError(f"sample_axis and output_axis must differ; both are " f"{sample_axis!r}")
+            raise ValueError(f"sample_axis and output_axis must differ; both are {sample_axis!r}")
 
         rest_axes = tuple(d for d in message.dims if d != preserve_axis and d not in flatten_axes)
         target_order = (preserve_axis, *flatten_axes, *rest_axes)
@@ -163,37 +297,13 @@ class FlattenTransformer(BaseStatefulTransformer[FlattenSettings, AxisArray, Axi
         rest_shape = permuted_shape[1 + len(flatten_axes) :]
         target_shape = (n_preserve, n_flat, *rest_shape)
 
-        # Build the merged-axis CoordinateAxis once.  Precedence:
-        #   1. ``flat_labels`` override — the caller fully specifies the
-        #      labels (used by the time-lag-aware learn-side wrapper).
-        #   2. Cartesian product of input axis labels when *every* flatten
-        #      axis carries CoordinateAxis labels matching its size.
-        #   3. Integer positions ``np.arange(n_flat)`` as a last resort.
-        if self.settings.flat_labels is not None:
-            if len(self.settings.flat_labels) != n_flat:
-                raise ValueError(
-                    f"flat_labels has length {len(self.settings.flat_labels)} " f"but flattened axis size is {n_flat}"
-                )
-            output_axis_obj = CoordinateAxis(
-                data=np.asarray(self.settings.flat_labels),
-                dims=[output_axis],
-            )
-        else:
-            per_axis_labels: list[list[str] | None] = [_coord_labels(message.axes.get(ax)) for ax in flatten_axes]
-            all_labeled = all(
-                labels is not None and len(labels) == size for labels, size in zip(per_axis_labels, flatten_sizes)
-            )
-            if all_labeled and flatten_axes:
-                sep = self.settings.label_separator
-                # Cartesian product, slowest-changing first — matches the
-                # C-order reshape so labels[k] describes data[:, k, ...].
-                combined = [""]
-                for labels in per_axis_labels:
-                    assert labels is not None  # guarded by all_labeled
-                    combined = [f"{c}{sep}{lbl}" if c else lbl for c in combined for lbl in labels]
-                output_axis_obj = CoordinateAxis(data=np.asarray(combined), dims=[output_axis])
-            else:
-                output_axis_obj = CoordinateAxis(data=np.arange(n_flat), dims=[output_axis])
+        output_axis_obj = _build_merged_axis(
+            message,
+            flatten_axes,
+            flatten_sizes,
+            output_axis,
+            self.settings.label_separator,
+        )
 
         st = self._state
         st.preserve_axis = preserve_axis

--- a/tests/unit/test_flatten.py
+++ b/tests/unit/test_flatten.py
@@ -34,10 +34,10 @@ class TestCartesianProductLabels:
     def test_default_flatten_3d_to_2d(self):
         """Default flatten_axes = all-non-preserve, in input order.
 
-        For ``(time, ch, feature)`` that means the 'feature' axis varies
-        fastest in the merged axis labels, matching numpy's C-order reshape
-        (which puts feature samples consecutively per channel — the LSL
-        convention).
+        For ``(time, ch, feature)`` the 'feature' axis varies fastest in
+        the merged axis (matching numpy's C-order reshape).  Output is a
+        structured axis with one field per source axis plus a canonical
+        ``"label"`` field carrying the cartesian-product join.
         """
         msg = _make_3d()
         proc = FlattenTransformer(FlattenSettings())
@@ -46,40 +46,46 @@ class TestCartesianProductLabels:
         assert out.data.shape == (5, 6)
         # data[0,0,0]=0, data[0,0,1]=1, data[0,1,0]=2, data[0,1,1]=3, ...
         np.testing.assert_array_equal(out.data[0], [0, 1, 2, 3, 4, 5])
-        labels = list(out.axes["ch"].data)
-        assert labels == [
-            "c1-spk",
-            "c1-sbp",
-            "c2-spk",
-            "c2-sbp",
-            "c3-spk",
-            "c3-sbp",
+
+        ch_axis = out.axes["ch"]
+        assert ch_axis.data.dtype.names == ("ch", "feature", "label")
+        assert list(ch_axis.data["ch"]) == ["c1", "c1", "c2", "c2", "c3", "c3"]
+        assert list(ch_axis.data["feature"]) == ["spk", "sbp", "spk", "sbp", "spk", "sbp"]
+        assert list(ch_axis.data["label"]) == [
+            "c1/spk",
+            "c1/sbp",
+            "c2/spk",
+            "c2/sbp",
+            "c3/spk",
+            "c3/sbp",
         ]
 
     def test_label_separator_override(self):
         msg = _make_3d()
         proc = FlattenTransformer(FlattenSettings(label_separator="__"))
-        labels = list(proc(msg).axes["ch"].data)
-        assert labels[0] == "c1__spk"
-        assert labels[5] == "c3__sbp"
+        ch_axis = proc(msg).axes["ch"]
+        assert ch_axis.data["label"][0] == "c1__spk"
+        assert ch_axis.data["label"][5] == "c3__sbp"
 
     def test_explicit_flatten_axes_order_changes_label_grouping(self):
         """``flatten_axes=("feature", "ch")`` → labels group by feature first."""
         msg = _make_3d()
         proc = FlattenTransformer(FlattenSettings(flatten_axes=("feature", "ch")))
-        out = proc(msg)
-        labels = list(out.axes["ch"].data)
-        # Now feature is slowest-varying, ch is fastest:
-        assert labels == [
-            "spk-c1",
-            "spk-c2",
-            "spk-c3",
-            "sbp-c1",
-            "sbp-c2",
-            "sbp-c3",
+        ch_axis = proc(msg).axes["ch"]
+        # Now feature is slowest-varying, ch is fastest.
+        assert list(ch_axis.data["label"]) == [
+            "spk/c1",
+            "spk/c2",
+            "spk/c3",
+            "sbp/c1",
+            "sbp/c2",
+            "sbp/c3",
         ]
+        assert list(ch_axis.data["feature"]) == ["spk"] * 3 + ["sbp"] * 3
+        assert list(ch_axis.data["ch"]) == ["c1", "c2", "c3"] * 2
 
     def test_falls_back_to_int_labels_when_axes_unlabeled(self):
+        """Axes without CoordinateAxis → 1-based uint32 indices per axis."""
         data = np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4)
         msg = AxisArray(
             data=data,
@@ -88,9 +94,30 @@ class TestCartesianProductLabels:
             key="raw",
         )
         proc = FlattenTransformer(FlattenSettings())
-        out = proc(msg)
-        labels = list(out.axes["ch"].data)
-        assert labels == list(range(12))
+        ch_axis = proc(msg).axes["ch"]
+        # ch is slowest (size 3), feature is fastest (size 4).
+        np.testing.assert_array_equal(
+            ch_axis.data["ch"],
+            np.asarray([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3], dtype=np.uint32),
+        )
+        np.testing.assert_array_equal(
+            ch_axis.data["feature"],
+            np.asarray([1, 2, 3, 4] * 3, dtype=np.uint32),
+        )
+        assert list(ch_axis.data["label"]) == [
+            "1/1",
+            "1/2",
+            "1/3",
+            "1/4",
+            "2/1",
+            "2/2",
+            "2/3",
+            "2/4",
+            "3/1",
+            "3/2",
+            "3/3",
+            "3/4",
+        ]
 
     def test_preserve_axis_kept_through(self):
         msg = _make_3d(fs=200.0)
@@ -100,12 +127,49 @@ class TestCartesianProductLabels:
         assert time_ax.gain == pytest.approx(1.0 / 200.0)
 
 
+class TestStructFieldPassthrough:
+    def test_struct_axis_propagates_all_fields(self):
+        """A structured ``ch`` axis contributes every field to the merged struct."""
+        ch_dtype = np.dtype(
+            [
+                ("x", "f4"),
+                ("y", "f4"),
+                ("label", "U16"),
+                ("device", "U8"),
+            ]
+        )
+        ch_data = np.zeros(2, dtype=ch_dtype)
+        ch_data["x"] = [1.0, 2.0]
+        ch_data["y"] = [3.0, 4.0]
+        ch_data["label"] = ["e1", "e2"]
+        ch_data["device"] = ["HUB1", "HUB2"]
+        msg = AxisArray(
+            data=np.arange(2 * 2 * 2, dtype=float).reshape(2, 2, 2),
+            dims=["time", "ch", "feature"],
+            axes={
+                "time": AxisArray.TimeAxis(fs=50.0, offset=0.0),
+                "ch": CoordinateAxis(data=ch_data, dims=["ch"]),
+                "feature": CoordinateAxis(data=np.array(("spk", "sbp")), dims=["feature"]),
+            },
+            key="features",
+        )
+        proc = FlattenTransformer(FlattenSettings())
+        out_ax = proc(msg).axes["ch"]
+
+        # All struct fields from ``ch`` survive + the ``feature`` axis
+        # contributes its own field + ``label`` is the cartesian join.
+        assert out_ax.data.dtype.names == ("x", "y", "label", "device", "feature")
+        np.testing.assert_array_equal(out_ax.data["x"], [1.0, 1.0, 2.0, 2.0])
+        np.testing.assert_array_equal(out_ax.data["y"], [3.0, 3.0, 4.0, 4.0])
+        assert list(out_ax.data["device"]) == ["HUB1", "HUB1", "HUB2", "HUB2"]
+        assert list(out_ax.data["feature"]) == ["spk", "sbp", "spk", "sbp"]
+        # Canonical label overwrites the inherited per-channel label.
+        assert list(out_ax.data["label"]) == ["e1/spk", "e1/sbp", "e2/spk", "e2/sbp"]
+
+
 class TestSampleAxisRename:
     def test_sample_axis_renames_preserve(self):
         """``sample_axis`` renames preserve_axis on the output (e.g. win→time)."""
-        # Simulate the time-lag windowing input: (win, time, ch).  Flatten
-        # collapses (time, ch) into the output's "ch" while preserving
-        # "win" but renaming it to "time".
         data = np.arange(2 * 3 * 2, dtype=float).reshape(2, 3, 2)
         msg = AxisArray(
             data=data,
@@ -119,29 +183,9 @@ class TestSampleAxisRename:
         )
         proc = FlattenTransformer(FlattenSettings(preserve_axis="win", sample_axis="time"))
         out = proc(msg)
-        # Output preserves the win-axis values under the renamed dim
-        # "time" — which replaces both the original win axis (now hidden
-        # under that name) and the inner "time" axis (folded into "ch").
         assert out.dims == ["time", "ch"]
         assert out.data.shape == (2, 6)
         assert out.axes["time"].gain == pytest.approx(1.0 / 10.0)
-
-
-class TestFlatLabelsOverride:
-    def test_explicit_flat_labels_used_directly(self):
-        msg = _make_3d()
-        proc = FlattenTransformer(FlattenSettings(flat_labels=("a", "b", "c", "d", "e", "f")))
-        out = proc(msg)
-        np.testing.assert_array_equal(
-            np.asarray(out.axes["ch"].data),
-            np.array(["a", "b", "c", "d", "e", "f"]),
-        )
-
-    def test_flat_labels_wrong_length_raises(self):
-        msg = _make_3d()
-        proc = FlattenTransformer(FlattenSettings(flat_labels=("only", "two")))
-        with pytest.raises(ValueError, match="flat_labels has length"):
-            proc(msg)
 
 
 class TestSettingsValidation:
@@ -210,8 +254,8 @@ class TestMLXBackend:
         assert out_mx.data.shape == out_np.data.shape == (5, 6)
         assert out_mx.dims == out_np.dims == ["time", "ch"]
         np.testing.assert_allclose(np.asarray(out_mx.data), out_np.data)
-        # Cartesian-product labels are backend-independent.
-        assert list(out_mx.axes["ch"].data) == list(out_np.axes["ch"].data)
+        # Cartesian-product label field is backend-independent.
+        np.testing.assert_array_equal(out_mx.axes["ch"].data["label"], out_np.axes["ch"].data["label"])
 
     def test_permute_path_mlx_matches_numpy(self):
         """Permute path: explicit flatten_axes reorders the axes."""


### PR DESCRIPTION
Merged axis is now always a numpy structured array. Each source axis contributes its fields (or a virtual field for simple/unlabeled axes) via dict-union with later-wins, plus a canonical "label" field carrying the cartesian-product join. Default separator is now "/". The flat_labels override is removed — the learn-side wrapper now post-processes the label field instead.