### PR TITLE
Add a generic sigproc binner unit

### DIFF
--- a/src/ezmsg/sigproc/binned_aggregate.py
+++ b/src/ezmsg/sigproc/binned_aggregate.py
@@ -16,23 +16,22 @@ At a clean rate (e.g. 30000 Hz) those coincide, but at a real recording rate
 (e.g. ~30012 Hz) they diverge in both gain and bin count, so a downstream
 ``Merge``/``AlignAlongAxis`` of the two branches never aligns.
 
-:obj:`BinnedAggregateTransformer` follows ``EventRate``'s fractional+carry
-boundary definition (including the sub-sample output offset) but applies an
-arbitrary :obj:`AggregationFunction` per bin instead of only counting. Driving
-the SBP branch through this with ``operation=MEAN`` puts it on the same grid as
-the spike-rate branch by construction, so the two merge trivially -- no
-post-hoc reconciler/aligner required. Set ``fractional=False`` to instead bin by
-a fixed ``round(bin_duration * fs)`` sample count (sample-locked grid, gain
-``round(bin_duration * fs) / fs``), matching :obj:`Window`'s legacy behaviour.
+:obj:`BinnedAggregateTransformer` applies an arbitrary :obj:`AggregationFunction`
+per bin instead of only counting, but it does *not* define its own bin
+boundaries: it drives them through the shared :obj:`ezmsg.sigproc.util.binning.BinSchedule`,
+the single source of truth for the grid. Driving the SBP branch through this with
+``operation=MEAN`` puts it on the same grid as the spike-rate branch -- because
+both go through the same schedule -- so the two merge trivially with no post-hoc
+reconciler/aligner required. Set ``fractional=False`` to instead bin by a fixed
+``int(bin_duration * fs)`` sample count (sample-locked grid, gain
+``int(bin_duration * fs) / fs``), matching :obj:`Window`.
 
 .. note::
-    The grid is reproduced from ``EventRate``'s boundary *formula*
-    (``B(m) = int(m * bin_duration * fs)``), not by sharing code with it.
-    ``EventRate`` lives in a separate package, so the agreement is by
-    construction and is not enforced by a cross-package regression test here.
-    The closed-form ``int(m * spb)`` is in fact more numerically stable than an
-    iterative carry accumulator, so for very long streams the two could differ
-    by at most a sub-sample rounding at a single boundary.
+    The schedule reproduces ``EventRate``'s grid by *shared code*, not by a
+    copied formula: ``BinSchedule`` is the boundary primitive both consume.
+    ``test_bin_schedule.py`` pins ``fractional=True`` against a faithful port of
+    ``EventRate``'s algorithm and ``fractional=False`` against ``Window``'s; the
+    cross-package test against the real ``EventRate`` lives in ezmsg-event.
 """
 
 import typing
@@ -52,6 +51,7 @@ from ezmsg.util.messages.axisarray import (
 )
 
 from .aggregate import AGGREGATORS, AggregationFunction
+from .util.binning import BinSchedule, BinStep
 
 
 class BinnedAggregateSettings(ez.Settings):
@@ -71,32 +71,22 @@ class BinnedAggregateSettings(ez.Settings):
     with a carry accumulator across chunks; bins track wall-clock time and the
     output gain is the nominal ``bin_duration``. This matches
     ``ezmsg.event.rate.EventRate``. If False, bins span a *fixed*
-    ``round(bin_duration * fs)`` samples and the output gain is
-    ``round(bin_duration * fs) / fs`` (sample-locked, matching :obj:`Window`)."""
+    ``int(bin_duration * fs)`` samples and the output gain is
+    ``int(bin_duration * fs) / fs`` (sample-locked, matching :obj:`Window`)."""
 
 
 @processor_state
 class BinnedAggregateState:
-    fs: float | None = None
-    """Input sample rate, cached from the first message's time-axis gain."""
-
-    samples_per_bin: float = 0.0
-    """Bin width in input samples (fractional when ``settings.fractional``)."""
-
-    out_gain: float = 0.0
-    """Gain (seconds per bin) of the output axis."""
-
-    n_bins_done: int = 0
-    """Count of bins already emitted across the stream. Bin boundaries are taken
-    from this *global* index (``B(m) = int(m * samples_per_bin)``) rather than a
-    per-chunk accumulator, so the output is identical regardless of how the
-    input is chunked -- and reproduces ``EventRate``'s grid (gain, offset, bin
-    count) by construction. This makes offline (large chunks) and live (small
-    chunks) feature streams agree exactly."""
+    schedule: BinSchedule | None = None
+    """Shared bin-boundary schedule (see :obj:`ezmsg.sigproc.util.binning`). Owns
+    the sample rate, samples-per-bin, output gain, global bin index, and carried
+    sample *count* -- the boundary arithmetic this transformer shares with
+    ``EventRate``. This transformer adds only the *data* carry below."""
 
     carry: typing.Any = None
     """Raw leftover samples of the open partial bin, carried across chunks so
-    aggregation works for any operation (not just sums)."""
+    aggregation works for any operation (not just sums). Its length is kept in
+    sync with ``schedule.carry_count``."""
 
 
 class BinnedAggregateTransformer(
@@ -115,29 +105,12 @@ class BinnedAggregateTransformer(
 
     def _reset_state(self, message: AxisArray) -> None:
         axis_info = message.get_axis(self.settings.axis)
-        fs = 1.0 / axis_info.gain
-        spb = self.settings.bin_duration * fs
-        if not self.settings.fractional:
-            spb = float(round(spb))
-            if spb < 1.0:
-                ez.logger.warning(
-                    f"bin_duration {self.settings.bin_duration}s rounds to <1 sample at "
-                    f"fs={fs}; clamping to 1 sample per bin."
-                )
-                spb = 1.0
-        elif spb < 1.0:
-            # Fewer than one input sample per bin means the output rate exceeds
-            # the input rate. Bins would span zero samples (NaN aggregates), so
-            # this is a misconfiguration rather than a supported mode.
-            ez.logger.warning(
-                f"bin_duration {self.settings.bin_duration}s is shorter than one sample "
-                f"at fs={fs} (samples_per_bin={spb:.4g} < 1); output will contain empty "
-                f"bins. Increase bin_duration or reduce the input rate."
-            )
-        self._state.fs = fs
-        self._state.samples_per_bin = spb
-        self._state.out_gain = self.settings.bin_duration if self.settings.fractional else spb / fs
-        self._state.n_bins_done = 0
+        schedule = BinSchedule(
+            bin_duration=self.settings.bin_duration,
+            fractional=self.settings.fractional,
+        )
+        schedule.reset(1.0 / axis_info.gain)
+        self._state.schedule = schedule
         self._state.carry = None
 
     def _aggregate(self, xp, segment, axis_idx: int):
@@ -149,14 +122,14 @@ class BinnedAggregateTransformer(
         result = AGGREGATORS[op](np.asarray(segment), axis=axis_idx)
         return xp.asarray(result) if xp is not np else result
 
-    def _empty_like(self, message: AxisArray, axis_idx: int, offset: float) -> AxisArray:
+    def _empty_like(self, message: AxisArray, axis_idx: int, step: BinStep) -> AxisArray:
         axis_info = message.get_axis(self.settings.axis)
         return replace(
             message,
             data=slice_along_axis(message.data, slice(0, 0), axis=axis_idx),
             axes={
                 **message.axes,
-                self.settings.axis: replace(axis_info, gain=self._state.out_gain, offset=offset),
+                self.settings.axis: replace(axis_info, gain=step.output_gain, offset=step.output_offset),
             },
         )
 
@@ -166,50 +139,24 @@ class BinnedAggregateTransformer(
         axis_idx = message.get_axis_idx(axis)
         xp = get_namespace(message.data)
 
-        n = message.data.shape[axis_idx]
-        spb = self._state.samples_per_bin
-        gain_in = axis_info.gain
-
-        m_done = self._state.n_bins_done
         carry = self._state.carry
-        n_carry = 0 if carry is None else carry.shape[axis_idx]
 
-        # Global sample index of carry[0] (== bin boundary B(m_done)); the
-        # incoming chunk's first sample follows the carried samples.
-        in_done = int(m_done * spb)
-        data0_global = in_done + n_carry
-        avail_end = data0_global + n
+        # The schedule owns all boundary/gain/offset arithmetic; this transformer
+        # only slices and aggregates the data at the cut points it returns.
+        step = self._state.schedule.advance(
+            n_new=message.data.shape[axis_idx],
+            in_offset=axis_info.offset,
+            gain_in=axis_info.gain,
+        )
 
-        # Nominal start time of the first (m_done-th) output bin. Derived from the
-        # global bin index, so it is identical regardless of chunking and matches
-        # EventRate's nominal offset (== stream_start + m_done * bin_duration).
-        output_offset = axis_info.offset - data0_global * gain_in + m_done * self._state.out_gain
-
-        # Global bin boundaries B(m) = int(m * spb) for the bins that complete
-        # within the data available so far. Indexing by the *global* m (not a
-        # per-chunk offset) is what makes the output chunk-invariant.
-        b_global = np.empty(0, dtype=np.int64)
-        if spb > 0 and avail_end >= int((m_done + 1) * spb):
-            # A bin m completes once B(m) = int(m*spb) <= avail_end, i.e.
-            # m < (avail_end + 1) / spb. int((avail_end + 1) / spb) is a correct
-            # upper bound on the largest such m (even when spb < 1, where a
-            # plain int(avail_end/spb) could undercount); +2 is slack, and the
-            # `candidates <= avail_end` filter below trims any overshoot.
-            k_est = max(int((avail_end + 1) / spb) - m_done, 0) + 2
-            ms = m_done + 1 + np.arange(k_est)
-            candidates = (ms * spb).astype(np.int64)
-            b_global = candidates[candidates <= avail_end]
-
-        if b_global.size == 0:
+        if step.n_bins == 0:
             # No bin completes in this chunk; grow the carry and emit nothing.
-            self._state.carry = (
-                message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
-            )
-            return self._empty_like(message, axis_idx, output_offset)
+            self._state.carry = message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
+            return self._empty_like(message, axis_idx, step)
 
         # Prepend the carried partial-bin samples so bin 0 spans carry + current.
         work = message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
-        ends_work = (b_global - in_done).tolist()
+        ends_work = step.cut_points
         starts_work = [0] + ends_work[:-1]
 
         bins = [
@@ -218,28 +165,24 @@ class BinnedAggregateTransformer(
         ]
         stacked = xp.stack(bins, axis=axis_idx)
 
-        # Leftover after the last completed bin becomes the next chunk's carry.
+        # Leftover after the last completed bin becomes the next chunk's carry
+        # (its length is step.carry_count, tracked by the schedule).
         last_work = ends_work[-1]
         self._state.carry = (
-            slice_along_axis(work, slice(last_work, None), axis=axis_idx)
-            if last_work < work.shape[axis_idx]
-            else None
+            slice_along_axis(work, slice(last_work, None), axis=axis_idx) if step.carry_count > 0 else None
         )
-        self._state.n_bins_done = m_done + len(ends_work)
 
         return replace(
             message,
             data=stacked,
             axes={
                 **message.axes,
-                axis: replace(axis_info, gain=self._state.out_gain, offset=output_offset),
+                axis: replace(axis_info, gain=step.output_gain, offset=step.output_offset),
             },
         )
 
 
-class BinnedAggregate(
-    BaseTransformerUnit[BinnedAggregateSettings, AxisArray, AxisArray, BinnedAggregateTransformer]
-):
+class BinnedAggregate(BaseTransformerUnit[BinnedAggregateSettings, AxisArray, AxisArray, BinnedAggregateTransformer]):
     SETTINGS = BinnedAggregateSettings
 
     @ez.subscriber(BaseTransformerUnit.INPUT_SIGNAL)
@@ -271,7 +214,7 @@ def binned_aggregate(
         fractional: If True, fractional ``bin_duration * fs`` bins with a carry
             accumulator (wall-clock grid, nominal gain), matching
             ``ezmsg.event.rate.EventRate``. If False, fixed
-            ``round(bin_duration * fs)`` sample bins (sample-locked grid).
+            ``int(bin_duration * fs)`` sample bins (sample-locked grid).
 
     Returns:
         :obj:`BinnedAggregateTransformer`

--- a/src/ezmsg/sigproc/binned_aggregate.py
+++ b/src/ezmsg/sigproc/binned_aggregate.py
@@ -1,0 +1,286 @@
+"""Resample a signal axis to a lower rate by aggregating fixed-duration bins.
+
+This is the dense-signal counterpart to the binning used by
+``ezmsg.event.rate.EventRate`` (spike rate from threshold-crossing events).
+Both reduce a high-rate axis to a lower-rate "bin" axis, but historically they
+disagreed at off-nominal sample rates:
+
+* ``EventRate`` bins by a *fractional* ``samples_per_bin = bin_duration * fs``
+  with a carry accumulator, so its bins track wall-clock time and it labels the
+  output gain as the nominal ``bin_duration``.
+* ``Window`` (the usual SBP path: ``Pow -> Window -> Aggregate``) bins by a
+  *fixed* ``int(bin_duration * fs)`` sample count, so its gain is
+  ``int(bin_duration * fs) / fs``.
+
+At a clean rate (e.g. 30000 Hz) those coincide, but at a real recording rate
+(e.g. ~30012 Hz) they diverge in both gain and bin count, so a downstream
+``Merge``/``AlignAlongAxis`` of the two branches never aligns.
+
+:obj:`BinnedAggregateTransformer` follows ``EventRate``'s fractional+carry
+boundary definition (including the sub-sample output offset) but applies an
+arbitrary :obj:`AggregationFunction` per bin instead of only counting. Driving
+the SBP branch through this with ``operation=MEAN`` puts it on the same grid as
+the spike-rate branch by construction, so the two merge trivially -- no
+post-hoc reconciler/aligner required. Set ``fractional=False`` to instead bin by
+a fixed ``round(bin_duration * fs)`` sample count (sample-locked grid, gain
+``round(bin_duration * fs) / fs``), matching :obj:`Window`'s legacy behaviour.
+
+.. note::
+    The grid is reproduced from ``EventRate``'s boundary *formula*
+    (``B(m) = int(m * bin_duration * fs)``), not by sharing code with it.
+    ``EventRate`` lives in a separate package, so the agreement is by
+    construction and is not enforced by a cross-package regression test here.
+    The closed-form ``int(m * spb)`` is in fact more numerically stable than an
+    iterative carry accumulator, so for very long streams the two could differ
+    by at most a sub-sample rounding at a single boundary.
+"""
+
+import typing
+
+import ezmsg.core as ez
+import numpy as np
+from array_api_compat import get_namespace
+from ezmsg.baseproc import (
+    BaseStatefulTransformer,
+    BaseTransformerUnit,
+    processor_state,
+)
+from ezmsg.util.messages.axisarray import (
+    AxisArray,
+    replace,
+    slice_along_axis,
+)
+
+from .aggregate import AGGREGATORS, AggregationFunction
+
+
+class BinnedAggregateSettings(ez.Settings):
+    """Settings for :obj:`BinnedAggregate`."""
+
+    axis: str = "time"
+    """The name of the axis to bin and aggregate along."""
+
+    bin_duration: float = 0.02
+    """Output bin duration in seconds."""
+
+    operation: AggregationFunction = AggregationFunction.MEAN
+    """:obj:`AggregationFunction` applied within each bin."""
+
+    fractional: bool = True
+    """If True (default), bins span a *fractional* ``bin_duration * fs`` samples
+    with a carry accumulator across chunks; bins track wall-clock time and the
+    output gain is the nominal ``bin_duration``. This matches
+    ``ezmsg.event.rate.EventRate``. If False, bins span a *fixed*
+    ``round(bin_duration * fs)`` samples and the output gain is
+    ``round(bin_duration * fs) / fs`` (sample-locked, matching :obj:`Window`)."""
+
+
+@processor_state
+class BinnedAggregateState:
+    fs: float | None = None
+    """Input sample rate, cached from the first message's time-axis gain."""
+
+    samples_per_bin: float = 0.0
+    """Bin width in input samples (fractional when ``settings.fractional``)."""
+
+    out_gain: float = 0.0
+    """Gain (seconds per bin) of the output axis."""
+
+    n_bins_done: int = 0
+    """Count of bins already emitted across the stream. Bin boundaries are taken
+    from this *global* index (``B(m) = int(m * samples_per_bin)``) rather than a
+    per-chunk accumulator, so the output is identical regardless of how the
+    input is chunked -- and reproduces ``EventRate``'s grid (gain, offset, bin
+    count) by construction. This makes offline (large chunks) and live (small
+    chunks) feature streams agree exactly."""
+
+    carry: typing.Any = None
+    """Raw leftover samples of the open partial bin, carried across chunks so
+    aggregation works for any operation (not just sums)."""
+
+
+class BinnedAggregateTransformer(
+    BaseStatefulTransformer[BinnedAggregateSettings, AxisArray, AxisArray, BinnedAggregateState]
+):
+    """Bin a signal axis at a fixed bin rate and aggregate within each bin.
+
+    Unlike :obj:`AggregateTransformer` (which collapses a whole axis) or
+    :obj:`RangedAggregateTransformer` (which aggregates static coordinate
+    bands), this reduces a high-rate axis to a regularly-binned lower-rate
+    axis, carrying the open partial bin across message boundaries.
+    """
+
+    def _hash_message(self, message: AxisArray) -> int:
+        return hash((message.axes[self.settings.axis].gain, message.key))
+
+    def _reset_state(self, message: AxisArray) -> None:
+        axis_info = message.get_axis(self.settings.axis)
+        fs = 1.0 / axis_info.gain
+        spb = self.settings.bin_duration * fs
+        if not self.settings.fractional:
+            spb = float(round(spb))
+            if spb < 1.0:
+                ez.logger.warning(
+                    f"bin_duration {self.settings.bin_duration}s rounds to <1 sample at "
+                    f"fs={fs}; clamping to 1 sample per bin."
+                )
+                spb = 1.0
+        elif spb < 1.0:
+            # Fewer than one input sample per bin means the output rate exceeds
+            # the input rate. Bins would span zero samples (NaN aggregates), so
+            # this is a misconfiguration rather than a supported mode.
+            ez.logger.warning(
+                f"bin_duration {self.settings.bin_duration}s is shorter than one sample "
+                f"at fs={fs} (samples_per_bin={spb:.4g} < 1); output will contain empty "
+                f"bins. Increase bin_duration or reduce the input rate."
+            )
+        self._state.fs = fs
+        self._state.samples_per_bin = spb
+        self._state.out_gain = self.settings.bin_duration if self.settings.fractional else spb / fs
+        self._state.n_bins_done = 0
+        self._state.carry = None
+
+    def _aggregate(self, xp, segment, axis_idx: int):
+        op = self.settings.operation
+        func_name = op.value
+        if hasattr(xp, func_name):
+            return getattr(xp, func_name)(segment, axis=axis_idx)
+        # nan-variants etc. are not in the Array API; fall back to numpy.
+        result = AGGREGATORS[op](np.asarray(segment), axis=axis_idx)
+        return xp.asarray(result) if xp is not np else result
+
+    def _empty_like(self, message: AxisArray, axis_idx: int, offset: float) -> AxisArray:
+        axis_info = message.get_axis(self.settings.axis)
+        return replace(
+            message,
+            data=slice_along_axis(message.data, slice(0, 0), axis=axis_idx),
+            axes={
+                **message.axes,
+                self.settings.axis: replace(axis_info, gain=self._state.out_gain, offset=offset),
+            },
+        )
+
+    def _process(self, message: AxisArray) -> AxisArray:
+        axis = self.settings.axis
+        axis_info = message.get_axis(axis)
+        axis_idx = message.get_axis_idx(axis)
+        xp = get_namespace(message.data)
+
+        n = message.data.shape[axis_idx]
+        spb = self._state.samples_per_bin
+        gain_in = axis_info.gain
+
+        m_done = self._state.n_bins_done
+        carry = self._state.carry
+        n_carry = 0 if carry is None else carry.shape[axis_idx]
+
+        # Global sample index of carry[0] (== bin boundary B(m_done)); the
+        # incoming chunk's first sample follows the carried samples.
+        in_done = int(m_done * spb)
+        data0_global = in_done + n_carry
+        avail_end = data0_global + n
+
+        # Nominal start time of the first (m_done-th) output bin. Derived from the
+        # global bin index, so it is identical regardless of chunking and matches
+        # EventRate's nominal offset (== stream_start + m_done * bin_duration).
+        output_offset = axis_info.offset - data0_global * gain_in + m_done * self._state.out_gain
+
+        # Global bin boundaries B(m) = int(m * spb) for the bins that complete
+        # within the data available so far. Indexing by the *global* m (not a
+        # per-chunk offset) is what makes the output chunk-invariant.
+        b_global = np.empty(0, dtype=np.int64)
+        if spb > 0 and avail_end >= int((m_done + 1) * spb):
+            # A bin m completes once B(m) = int(m*spb) <= avail_end, i.e.
+            # m < (avail_end + 1) / spb. int((avail_end + 1) / spb) is a correct
+            # upper bound on the largest such m (even when spb < 1, where a
+            # plain int(avail_end/spb) could undercount); +2 is slack, and the
+            # `candidates <= avail_end` filter below trims any overshoot.
+            k_est = max(int((avail_end + 1) / spb) - m_done, 0) + 2
+            ms = m_done + 1 + np.arange(k_est)
+            candidates = (ms * spb).astype(np.int64)
+            b_global = candidates[candidates <= avail_end]
+
+        if b_global.size == 0:
+            # No bin completes in this chunk; grow the carry and emit nothing.
+            self._state.carry = (
+                message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
+            )
+            return self._empty_like(message, axis_idx, output_offset)
+
+        # Prepend the carried partial-bin samples so bin 0 spans carry + current.
+        work = message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
+        ends_work = (b_global - in_done).tolist()
+        starts_work = [0] + ends_work[:-1]
+
+        bins = [
+            self._aggregate(xp, slice_along_axis(work, slice(s, e), axis=axis_idx), axis_idx)
+            for s, e in zip(starts_work, ends_work)
+        ]
+        stacked = xp.stack(bins, axis=axis_idx)
+
+        # Leftover after the last completed bin becomes the next chunk's carry.
+        last_work = ends_work[-1]
+        self._state.carry = (
+            slice_along_axis(work, slice(last_work, None), axis=axis_idx)
+            if last_work < work.shape[axis_idx]
+            else None
+        )
+        self._state.n_bins_done = m_done + len(ends_work)
+
+        return replace(
+            message,
+            data=stacked,
+            axes={
+                **message.axes,
+                axis: replace(axis_info, gain=self._state.out_gain, offset=output_offset),
+            },
+        )
+
+
+class BinnedAggregate(
+    BaseTransformerUnit[BinnedAggregateSettings, AxisArray, AxisArray, BinnedAggregateTransformer]
+):
+    SETTINGS = BinnedAggregateSettings
+
+    @ez.subscriber(BaseTransformerUnit.INPUT_SIGNAL)
+    @ez.publisher(BaseTransformerUnit.OUTPUT_SIGNAL)
+    async def on_signal(self, message: AxisArray) -> typing.AsyncGenerator:
+        """Suppress empty publishes when a chunk spans less than one bin.
+
+        As with :obj:`Downsample`, most input chunks at a high input rate close
+        no new bin, yielding a zero-length payload; broadcasting those wastes a
+        round-trip across SHM/socket.
+        """
+        result = await self.processor.__acall__(message)
+        if result is not None and result.data.size > 0:
+            yield self.OUTPUT_SIGNAL, result
+
+
+def binned_aggregate(
+    axis: str = "time",
+    bin_duration: float = 0.02,
+    operation: AggregationFunction = AggregationFunction.MEAN,
+    fractional: bool = True,
+) -> BinnedAggregateTransformer:
+    """Bin a signal axis at a fixed bin rate and aggregate within each bin.
+
+    Args:
+        axis: The name of the axis to bin and aggregate along.
+        bin_duration: Output bin duration in seconds.
+        operation: :obj:`AggregationFunction` applied within each bin.
+        fractional: If True, fractional ``bin_duration * fs`` bins with a carry
+            accumulator (wall-clock grid, nominal gain), matching
+            ``ezmsg.event.rate.EventRate``. If False, fixed
+            ``round(bin_duration * fs)`` sample bins (sample-locked grid).
+
+    Returns:
+        :obj:`BinnedAggregateTransformer`
+    """
+    return BinnedAggregateTransformer(
+        BinnedAggregateSettings(
+            axis=axis,
+            bin_duration=bin_duration,
+            operation=operation,
+            fractional=fractional,
+        )
+    )

--- a/src/ezmsg/sigproc/util/binning.py
+++ b/src/ezmsg/sigproc/util/binning.py
@@ -1,0 +1,207 @@
+"""Shared bin-boundary scheduling for fixed-duration binning.
+
+A *bin schedule* answers one question, identically for every consumer that
+needs it: given an input sample rate, a target bin duration, and a stream of
+chunks (each of some length, with a partial bin carried across boundaries),
+*where do the bin boundaries fall* -- and what output ``gain``/``offset`` label
+the resulting low-rate axis?
+
+This is the single piece of arithmetic that historically diverged between
+:obj:`ezmsg.sigproc.window.Window` (which bins by a *fixed* ``int(bin_duration *
+fs)`` sample count) and ``ezmsg.event.rate.EventRate`` (which bins by a
+*fractional* ``bin_duration * fs`` with a carry accumulator). At a clean rate
+the two coincide; at a real recording rate (e.g. ~30012 Hz) they diverge in both
+gain and bin count, so a downstream ``Merge``/``AlignAlongAxis`` of the two
+branches never aligns.
+
+:obj:`BinSchedule` makes the boundary rule a *single source of truth*. Any
+consumer (dense aggregation, event counting, window segmentation) that drives
+its boundaries through one :obj:`BinSchedule`, parameterized identically, is
+guaranteed to land on the same grid -- by construction, not by coincidence.
+
+The schedule deliberately holds only *counts and indices*; it never touches
+array data. Each consumer keeps its own data carry (raw samples for an arbitrary
+aggregator, a scalar partial-sum for a counter), because the right carry
+representation depends on the operation, but the *boundaries* are shared.
+
+Boundary definition
+-------------------
+With ``spb`` samples per bin (fractional when :attr:`fractional`), the global
+sample index of the ``m``-th bin boundary is ``B(m) = int(m * spb)``. Indexing by
+the *global* bin index ``m`` (rather than a per-chunk accumulator) makes the
+output identical regardless of how the input stream is chunked, and reproduces
+``EventRate``'s grid (gain, offset, bin count). The closed form ``int(m * spb)``
+is also more numerically stable than an iterative carry accumulator: there is no
+drift to accumulate over a long stream.
+"""
+
+from dataclasses import dataclass, field
+
+import ezmsg.core as ez
+import numpy as np
+
+
+@dataclass
+class BinStep:
+    """Result of advancing a :obj:`BinSchedule` by one chunk.
+
+    ``cut_points`` are bin *ends* expressed as indices into the consumer's
+    ``work`` array -- i.e. the concatenation of its carried partial-bin samples
+    followed by the new chunk. Bin ``i`` spans ``work[starts[i]:cut_points[i]]``
+    where ``starts = [0] + cut_points[:-1]``. The samples after the final cut
+    (``work[cut_points[-1]:]``) are the new partial bin and become the next
+    chunk's carry.
+    """
+
+    cut_points: list[int]
+    """Bin-end indices into the ``[carry ++ new]`` work array (one per closed bin)."""
+
+    n_bins: int
+    """Number of bins that close in this chunk (``== len(cut_points)``)."""
+
+    output_gain: float
+    """Gain (seconds per bin) to label the output axis with."""
+
+    output_offset: float
+    """Nominal start time of the first bin closing in this chunk. Derived from the
+    global bin index, so it is identical regardless of chunking (and matches
+    ``EventRate``: ``stream_start + bins_before * output_gain``)."""
+
+    carry_count: int
+    """Number of input samples in the still-open partial bin after the last cut.
+    The consumer must keep exactly this many trailing ``work`` samples as carry."""
+
+
+@dataclass
+class BinSchedule:
+    """Stateful, backend-agnostic schedule of fixed-duration bin boundaries.
+
+    Construct once with the target bin duration and mode, then :meth:`reset`
+    with the input sample rate before streaming, and call :meth:`advance` once
+    per input chunk. The schedule tracks the global bin index and the carried
+    sample count; it never holds array data.
+
+    Args:
+        bin_duration: Output bin duration in seconds.
+        fractional: If True (default), bins span a *fractional* ``bin_duration *
+            fs`` samples; bin widths track the nominal duration and the output
+            gain is exactly ``bin_duration`` (matching ``EventRate``). If False,
+            bins span a *fixed* ``int(bin_duration * fs)`` samples and the
+            output gain is ``int(bin_duration * fs) / fs`` (sample-locked,
+            matching :obj:`Window`).
+    """
+
+    bin_duration: float
+    fractional: bool = True
+
+    fs: float | None = field(default=None, init=False)
+    """Input sample rate, set by :meth:`reset`."""
+
+    spb: float = field(default=0.0, init=False)
+    """Bin width in input samples (fractional when :attr:`fractional`)."""
+
+    n_bins_done: int = field(default=0, init=False)
+    """Count of bins emitted so far across the stream (global bin index)."""
+
+    carry_count: int = field(default=0, init=False)
+    """Trailing input samples in the open partial bin, carried across chunks."""
+
+    _out_gain: float = field(default=0.0, init=False)
+
+    def reset(self, fs: float) -> None:
+        """(Re)initialize the schedule for an input stream at rate ``fs``.
+
+        Emits the same sub-sample warnings the dense binner did, so callers that
+        relied on those messages keep getting them from one place.
+        """
+        spb = self.bin_duration * fs
+        if not self.fractional:
+            # Truncate (not round) so the sample-locked grid matches Window's
+            # ``int(window_dur * fs)`` exactly for *any* rate, not just when the
+            # fractional part happens to be < 0.5.
+            spb = float(int(spb))
+            if spb < 1.0:
+                ez.logger.warning(
+                    f"bin_duration {self.bin_duration}s is shorter than one sample at "
+                    f"fs={fs}; clamping to 1 sample per bin."
+                )
+                spb = 1.0
+        elif spb < 1.0:
+            # Fewer than one input sample per bin means the output rate exceeds
+            # the input rate. Bins would span zero samples (NaN aggregates), so
+            # this is a misconfiguration rather than a supported mode.
+            ez.logger.warning(
+                f"bin_duration {self.bin_duration}s is shorter than one sample "
+                f"at fs={fs} (samples_per_bin={spb:.4g} < 1); output will contain empty "
+                f"bins. Increase bin_duration or reduce the input rate."
+            )
+        self.fs = fs
+        self.spb = spb
+        self._out_gain = self.bin_duration if self.fractional else spb / fs
+        self.n_bins_done = 0
+        self.carry_count = 0
+
+    @property
+    def output_gain(self) -> float:
+        """Gain (seconds per bin) of the output axis for this schedule."""
+        return self._out_gain
+
+    def advance(self, n_new: int, in_offset: float, gain_in: float) -> BinStep:
+        """Advance the schedule by a chunk of ``n_new`` new input samples.
+
+        Args:
+            n_new: Number of new input samples in this chunk.
+            in_offset: ``offset`` of the incoming chunk's first *new* sample
+                (i.e. ``message.axes[axis].offset``).
+            gain_in: ``gain`` of the input axis (``1 / fs``).
+
+        Returns:
+            A :obj:`BinStep`. The schedule's :attr:`n_bins_done` and
+            :attr:`carry_count` are updated to reflect the bins it reports closed.
+        """
+        spb = self.spb
+        m_done = self.n_bins_done
+        n_carry = self.carry_count
+
+        # Global sample index of carry[0] (== bin boundary B(m_done)); the
+        # incoming chunk's first new sample follows the carried samples.
+        in_done = int(m_done * spb)
+        data0_global = in_done + n_carry
+        avail_end = data0_global + n_new
+
+        # Nominal start time of the first (m_done-th) output bin. Derived from the
+        # global bin index, so it is identical regardless of chunking and matches
+        # EventRate's nominal offset (== stream_start + m_done * output_gain).
+        output_offset = in_offset - data0_global * gain_in + m_done * self._out_gain
+
+        # Global bin boundaries B(m) = int(m * spb) for the bins that complete
+        # within the data available so far. Indexing by the *global* m (not a
+        # per-chunk offset) is what makes the output chunk-invariant.
+        cut_points: list[int] = []
+        if spb > 0 and avail_end >= int((m_done + 1) * spb):
+            # A bin m completes once B(m) = int(m*spb) <= avail_end, i.e.
+            # m < (avail_end + 1) / spb. int((avail_end + 1) / spb) is a correct
+            # upper bound on the largest such m (even when spb < 1, where a
+            # plain int(avail_end/spb) could undercount); +2 is slack, and the
+            # `candidates <= avail_end` filter below trims any overshoot.
+            k_est = max(int((avail_end + 1) / spb) - m_done, 0) + 2
+            ms = m_done + 1 + np.arange(k_est)
+            candidates = (ms * spb).astype(np.int64)
+            b_global = candidates[candidates <= avail_end]
+            cut_points = (b_global - in_done).tolist()
+
+        work_len = n_carry + n_new
+        if cut_points:
+            self.carry_count = work_len - cut_points[-1]
+            self.n_bins_done = m_done + len(cut_points)
+        else:
+            # No bin completes; everything seen so far stays in the open bin.
+            self.carry_count = work_len
+
+        return BinStep(
+            cut_points=cut_points,
+            n_bins=len(cut_points),
+            output_gain=self._out_gain,
+            output_offset=output_offset,
+            carry_count=self.carry_count,
+        )

--- a/tests/unit/test_bin_schedule.py
+++ b/tests/unit/test_bin_schedule.py
@@ -1,0 +1,146 @@
+"""Pin :obj:`BinSchedule` to the two grids it must reproduce.
+
+The whole point of the shared schedule is that, parameterized identically, it
+lands on the *same* bin boundaries as the two units that historically disagreed:
+
+* ``fractional=True``  must match ``ezmsg.event.rate.EventRate`` (which bins by a
+  fractional ``bin_duration * fs`` with a carry accumulator).
+* ``fractional=False`` must match ``ezmsg.sigproc.window.Window`` (which bins by
+  ``int(bin_duration * fs)`` fixed samples).
+
+``EventRate`` lives in a separate package that isn't a test dependency here, so
+its boundary algorithm is *ported faithfully below* as ``eventrate_bin_ends`` (a
+line-for-line port of ``BinnedKernelActivation._process_events``'s boundary math
+in ezmsg-event ``kernel_activation.py``) and we assert the schedule matches it.
+The corresponding cross-package test against the *real* ``EventRate`` lives in
+ezmsg-event, where the import is available.
+"""
+
+import numpy as np
+import pytest
+
+from ezmsg.sigproc.util.binning import BinSchedule
+
+
+# --- Faithful port of EventRate's per-chunk boundary algorithm ----------------
+# Mirrors ezmsg.event.kernel_activation.BinnedKernelActivation._process_events:
+#   samples_per_bin = bin_duration * fs
+#   total = n + accumulator;  n_bins = int(total / spb)
+#   first_bin_end = spb - accumulator;  ends = (first_bin_end + arange(n_bins)*spb).astype(int)
+#   accumulator = total - n_bins * spb
+#   output_offset = input_offset - accumulator_before / fs
+def eventrate_grid(chunk_lengths, fs, bin_duration):
+    """Return (global_bin_end_samples, per_nonempty_chunk_offsets) the way
+    EventRate would compute them for the given chunking (stream_start == 0)."""
+    spb = bin_duration * fs
+    acc = 0.0
+    global_start = 0
+    ends: list[int] = []
+    offsets: list[float] = []
+    for n in chunk_lengths:
+        total = n + acc
+        n_bins = int(total / spb)
+        in_offset = global_start / fs
+        if n_bins > 0:
+            first_bin_end = spb - acc
+            bin_end_samples = (first_bin_end + np.arange(n_bins) * spb).astype(np.int64)
+            ends.extend(global_start + int(be) for be in bin_end_samples)
+            offsets.append(in_offset - acc / fs)
+            acc = total - n_bins * spb
+        else:
+            acc = total
+        global_start += n
+    return ends, offsets
+
+
+def schedule_grid(chunk_lengths, fs, bin_duration, fractional):
+    """Drive a BinSchedule over the same chunking and return the global bin-end
+    samples and the per-nonempty-chunk output offsets."""
+    sched = BinSchedule(bin_duration=bin_duration, fractional=fractional)
+    sched.reset(fs)
+    gain_in = 1.0 / fs
+    global_start = 0
+    ends: list[int] = []
+    offsets: list[float] = []
+    for n in chunk_lengths:
+        m_before = sched.n_bins_done
+        step = sched.advance(n_new=n, in_offset=global_start * gain_in, gain_in=gain_in)
+        # Global bin end of bin m (1-indexed global) is int(m * spb).
+        ends.extend(int(m * sched.spb) for m in range(m_before + 1, sched.n_bins_done + 1))
+        if step.n_bins > 0:
+            offsets.append(step.output_offset)
+        global_start += n
+    return ends, offsets
+
+
+@pytest.mark.parametrize("fs", [30000.0, 30012.0, 30030.0])
+@pytest.mark.parametrize(
+    "chunk_lengths",
+    [
+        [50000],  # single big chunk
+        [1] * 5000,  # worst-case fragmentation
+        [7] * 700 + [101] * 90,  # uneven
+        [777] * 64,  # uneven vs spb
+    ],
+)
+def test_fractional_matches_eventrate_grid(fs, chunk_lengths):
+    """fractional=True reproduces EventRate's bin boundaries and offsets exactly,
+    for any chunking and any (including off-nominal) rate."""
+    bin_duration = 0.02
+    ref_ends, ref_offsets = eventrate_grid(chunk_lengths, fs, bin_duration)
+    got_ends, got_offsets = schedule_grid(chunk_lengths, fs, bin_duration, fractional=True)
+
+    assert got_ends == ref_ends
+    assert len(got_offsets) == len(ref_offsets)
+    np.testing.assert_allclose(got_offsets, ref_offsets, rtol=0, atol=1e-12)
+
+
+@pytest.mark.parametrize("fs", [30000.0, 30012.0, 30030.0])
+def test_fractional_grid_is_chunk_invariant(fs):
+    """The fractional grid does not depend on how the stream is chunked."""
+    bin_duration = 0.02
+    whole, _ = schedule_grid([50000], fs, bin_duration, fractional=True)
+    frag, _ = schedule_grid([1] * 50000, fs, bin_duration, fractional=True)
+    assert whole == frag
+
+
+@pytest.mark.parametrize("fs", [30000.0, 30012.0, 30030.0])
+def test_integer_mode_matches_window_boundaries(fs):
+    """fractional=False bins on Window's grid: fixed int(bin_duration*fs) samples,
+    boundaries at multiples of that count.
+
+    fs=30030 is the discriminating case: 0.02*30030 = 600.6, so Window's
+    int()-truncation gives 600 while round() would give 601. The schedule must
+    truncate to stay on Window's grid.
+    """
+    bin_duration = 0.02
+    window_samples = int(bin_duration * fs)  # exactly Window's window_dur sizing
+    n_total = 50000
+
+    ends, _ = schedule_grid([n_total], fs, bin_duration, fractional=False)
+    n_bins = n_total // window_samples
+    expected = [m * window_samples for m in range(1, n_bins + 1)]
+    assert ends == expected
+
+    sched = BinSchedule(bin_duration=bin_duration, fractional=False)
+    sched.reset(fs)
+    assert sched.spb == float(window_samples)
+    assert sched.output_gain == pytest.approx(window_samples / fs)
+
+
+def test_carry_count_tracks_open_bin():
+    """carry_count equals the number of samples in the still-open partial bin."""
+    fs = 1000.0  # spb = 20 samples per 0.02 s bin
+    sched = BinSchedule(bin_duration=0.02, fractional=True)
+    sched.reset(fs)
+
+    step = sched.advance(n_new=50, in_offset=0.0, gain_in=1.0 / fs)
+    # 50 samples -> 2 full bins (40 samples) + 10 leftover.
+    assert step.n_bins == 2
+    assert step.carry_count == 10
+    assert sched.carry_count == 10
+
+    step = sched.advance(n_new=10, in_offset=50 / fs, gain_in=1.0 / fs)
+    # 10 carried + 10 new = 20 -> exactly 1 more bin, no leftover.
+    assert step.n_bins == 1
+    assert step.carry_count == 0

--- a/tests/unit/test_binned_aggregate.py
+++ b/tests/unit/test_binned_aggregate.py
@@ -1,0 +1,253 @@
+import asyncio
+import copy
+import logging
+
+import numpy as np
+import pytest
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.messages.modify import ModifyAxisSettings, ModifyAxisTransformer
+from frozendict import frozendict
+
+from ezmsg.sigproc.aggregate import AggregateSettings, AggregateTransformer, AggregationFunction
+from ezmsg.sigproc.binned_aggregate import (
+    BinnedAggregate,
+    BinnedAggregateSettings,
+    BinnedAggregateTransformer,
+)
+from ezmsg.sigproc.math.pow import PowSettings, PowTransformer
+from ezmsg.sigproc.window import WindowSettings, WindowTransformer
+from tests.helpers.empty_time import check_empty_result, check_state_not_corrupted, make_empty_msg, make_msg
+from tests.helpers.util import assert_messages_equal
+
+
+def _sig_msgs(sig: np.ndarray, fs: float, block_size: int) -> list[AxisArray]:
+    n = sig.shape[0]
+    msgs = []
+    for start in range(0, n, block_size):
+        chunk = sig[start : start + block_size]
+        msgs.append(
+            AxisArray(
+                data=chunk,
+                dims=["time", "ch"],
+                axes=frozendict(
+                    {
+                        "time": AxisArray.TimeAxis(fs=fs, offset=start / fs),
+                        "ch": AxisArray.CoordinateAxis(data=np.arange(sig.shape[1]).astype(str), dims=["ch"]),
+                    }
+                ),
+                key="test_binned_aggregate",
+            )
+        )
+    return msgs
+
+
+def _ref_binned(x: np.ndarray, spb: float, op=np.mean) -> np.ndarray:
+    """Ground truth: aggregate x over global bins [int((m-1)*spb), int(m*spb))."""
+    n = x.shape[0]
+    n_bins = int(n / spb)
+    return np.stack([op(x[int((m - 1) * spb) : int(m * spb)], axis=0) for m in range(1, n_bins + 1)], axis=0)
+
+
+def _run(proc: BinnedAggregateTransformer, msgs: list[AxisArray]) -> list[AxisArray]:
+    out = []
+    for msg in msgs:
+        res = proc(msg)
+        if res.data.size:
+            out.append(res)
+    return out
+
+
+@pytest.mark.parametrize("block_size", [1, 7, 64, 100000])
+@pytest.mark.parametrize("fs", [30000.0, 30012.0])
+def test_matches_global_bin_reference(block_size: int, fs: float):
+    """Output equals the global-bin numpy reference regardless of chunking."""
+    bin_dur = 0.02
+    sig = np.random.default_rng(0).standard_normal((30000, 3))
+    spb = bin_dur * fs
+
+    in_msgs = _sig_msgs(sig, fs, block_size)
+    backup = [copy.deepcopy(m) for m in in_msgs]
+
+    proc = BinnedAggregateTransformer(
+        axis="time", bin_duration=bin_dur, operation=AggregationFunction.MEAN, fractional=True
+    )
+    out = _run(proc, in_msgs)
+
+    assert_messages_equal(in_msgs, backup)  # input not mutated
+
+    data = np.concatenate([m.data for m in out], axis=0)
+    ref = _ref_binned(sig, spb, op=np.mean)
+    assert data.shape == ref.shape
+    np.testing.assert_allclose(data, ref, rtol=0, atol=1e-12)
+
+    # Fractional grid is labelled with the nominal gain and a zero offset.
+    assert out[0].axes["time"].gain == pytest.approx(bin_dur)
+    assert out[0].axes["time"].offset == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize("fs", [30000.0, 30012.0])
+def test_chunk_invariance(fs: float):
+    """Single-chunk and heavily-fragmented streams give identical output."""
+    sig = np.random.default_rng(1).standard_normal((50000, 2))
+    proc_a = BinnedAggregateTransformer(axis="time", bin_duration=0.02, fractional=True)
+    proc_b = BinnedAggregateTransformer(axis="time", bin_duration=0.02, fractional=True)
+
+    whole = np.concatenate([m.data for m in _run(proc_a, _sig_msgs(sig, fs, 50000))], axis=0)
+    # Worst-case fragmentation: one sample per message.
+    fragmented = np.concatenate([m.data for m in _run(proc_b, _sig_msgs(sig, fs, 1))], axis=0)
+
+    assert whole.shape == fragmented.shape
+    np.testing.assert_array_equal(whole, fragmented)
+
+
+@pytest.mark.parametrize("fs", [30000.0, 30012.0])
+def test_integer_mode_matches_window(fs: float):
+    """fractional=False reproduces the legacy Window+Aggregate(mean) grid+values."""
+    bin_dur = 0.02
+    sig = np.random.default_rng(2).standard_normal((30000, 4))
+
+    # Legacy SBP-style path: square -> window(bins) -> mean -> rename.
+    win = [
+        PowTransformer(PowSettings(exponent=2.0)),
+        WindowTransformer(
+            WindowSettings(axis="time", newaxis="win", window_dur=bin_dur, window_shift=bin_dur, zero_pad_until="none")
+        ),
+        AggregateTransformer(AggregateSettings(axis="time", operation=AggregationFunction.MEAN)),
+        ModifyAxisTransformer(ModifyAxisSettings(name_map={"win": "time"})),
+    ]
+    msg = _sig_msgs(sig, fs, 30000)[0]
+    w = msg
+    for t in win:
+        w = t(w)
+
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=bin_dur, fractional=False)
+    b = proc(_sig_msgs(sig**2, fs, 30000)[0])
+
+    assert b.data.shape == w.data.shape
+    assert b.axes["time"].gain == pytest.approx(w.axes["time"].gain)
+    np.testing.assert_allclose(b.data, w.data, rtol=0, atol=1e-12)
+
+
+def test_sum_operation():
+    """SUM aggregation sums each bin (basis for delegating EventRate's count)."""
+    fs = 1000.0
+    sig = np.ones((100, 2))
+    proc = BinnedAggregateTransformer(
+        axis="time", bin_duration=0.02, operation=AggregationFunction.SUM, fractional=True
+    )
+    out = proc(_sig_msgs(sig, fs, 100)[0])
+    # spb = 20 -> 5 bins of 20 ones -> sum 20 each.
+    assert out.data.shape == (5, 2)
+    np.testing.assert_allclose(out.data, 20.0)
+
+
+def test_empty_message_propagates():
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, fractional=True)
+    result = proc(make_empty_msg())
+    check_empty_result(result)
+    check_state_not_corrupted(proc, make_msg())
+
+
+def test_output_offset_tracks_stream_grid():
+    """Each output message is labelled with the nominal start time of its first
+    bin (stream_start + bins_before * bin_duration), independent of chunking.
+
+    This is the property the module exists for: it is what lets a downstream
+    Merge align this branch with the EventRate branch.
+    """
+    fs = 30012.0
+    bin_dur = 0.02
+    stream_start = 12.5  # arbitrary non-zero stream offset
+    sig = np.random.default_rng(7).standard_normal((30000, 2))
+
+    msgs = []
+    for start in range(0, sig.shape[0], 777):  # uneven chunking
+        chunk = sig[start : start + 777]
+        msgs.append(
+            AxisArray(
+                data=chunk,
+                dims=["time", "ch"],
+                axes=frozendict(
+                    {
+                        "time": AxisArray.TimeAxis(fs=fs, offset=stream_start + start / fs),
+                        "ch": AxisArray.CoordinateAxis(data=np.arange(2).astype(str), dims=["ch"]),
+                    }
+                ),
+                key="offset_grid",
+            )
+        )
+
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=bin_dur, fractional=True)
+    out = _run(proc, msgs)
+
+    bins_before = 0
+    for m in out:
+        assert m.axes["time"].gain == pytest.approx(bin_dur)
+        expected_offset = stream_start + bins_before * bin_dur
+        assert m.axes["time"].offset == pytest.approx(expected_offset)
+        bins_before += m.data.shape[0]
+
+
+def test_integer_mode_subsample_clamps_with_warning(caplog):
+    """fractional=False with a sub-sample bin_duration clamps to 1 sample/bin
+    and warns, rather than producing zero-width bins."""
+    fs = 1000.0
+    sig = np.ones((50, 2))
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.0001, fractional=False)
+    with caplog.at_level(logging.WARNING, logger="ezmsg"):
+        out = proc(_sig_msgs(sig, fs, 50)[0])
+
+    assert any("clamping to 1 sample" in r.message for r in caplog.records)
+    # One bin per input sample; mean of a single sample is itself.
+    assert out.data.shape == (50, 2)
+    assert out.axes["time"].gain == pytest.approx(1.0 / fs)
+    np.testing.assert_allclose(out.data, 1.0)
+
+
+def test_fractional_subsample_warns(caplog):
+    """fractional=True with a sub-sample bin_duration warns about empty bins."""
+    fs = 1000.0
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.0001, fractional=True)
+    with caplog.at_level(logging.WARNING, logger="ezmsg"):
+        proc(_sig_msgs(np.ones((50, 2)), fs, 50)[0])
+    assert any("shorter than one sample" in r.message for r in caplog.records)
+
+
+def test_state_resets_on_fs_change():
+    """A change in the input gain (fs) restarts the binning grid and discards
+    any carried partial bin from the previous stream."""
+    bin_dur = 0.02
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=bin_dur, fractional=True)
+
+    # First stream at fs1: 30 samples (spb=600) leaves a partial bin in carry.
+    proc(_sig_msgs(np.ones((30, 2)), 30000.0, 30)[0])
+    assert proc._state.carry is not None  # partial bin pending
+
+    # Second stream at a different fs forces _reset_state.
+    fs2 = 30012.0
+    out = proc(_sig_msgs(np.ones((30000, 2)), fs2, 30000)[0])
+
+    assert proc._state.fs == fs2
+    assert proc._state.samples_per_bin == pytest.approx(bin_dur * fs2)
+    # Output offset reflects the new stream start (0.0), not stale fs1 state.
+    assert out.axes["time"].offset == pytest.approx(0.0)
+    assert np.all(np.isfinite(out.data))
+
+
+def test_unit_suppresses_empty_publishes():
+    """The BinnedAggregate Unit publishes nothing when a chunk closes no bin,
+    but publishes once a bin completes."""
+    fs = 1000.0  # spb = 20 samples per 0.02s bin
+    unit = BinnedAggregate(BinnedAggregateSettings(axis="time", bin_duration=0.02))
+    unit.create_processor()
+
+    async def drive(msg):
+        return [m async for m in unit.on_signal(msg)]
+
+    # 10 samples: no bin completes -> nothing published.
+    assert asyncio.run(drive(_sig_msgs(np.ones((10, 2)), fs, 10)[0])) == []
+    # 40 more samples (50 total -> 2 bins): a publish occurs.
+    published = asyncio.run(drive(_sig_msgs(np.ones((40, 2)), fs, 40)[0]))
+    assert len(published) == 1
+    _, msg_out = published[0]
+    assert msg_out.data.shape[0] > 0

--- a/tests/unit/test_binned_aggregate.py
+++ b/tests/unit/test_binned_aggregate.py
@@ -100,9 +100,13 @@ def test_chunk_invariance(fs: float):
     np.testing.assert_array_equal(whole, fragmented)
 
 
-@pytest.mark.parametrize("fs", [30000.0, 30012.0])
+@pytest.mark.parametrize("fs", [30000.0, 30012.0, 30030.0])
 def test_integer_mode_matches_window(fs: float):
-    """fractional=False reproduces the legacy Window+Aggregate(mean) grid+values."""
+    """fractional=False reproduces the legacy Window+Aggregate(mean) grid+values.
+
+    fs=30030 (0.02*fs = 600.6) is the case that distinguishes Window's
+    int()-truncation from round(): the integer grid must truncate to match.
+    """
     bin_dur = 0.02
     sig = np.random.default_rng(2).standard_normal((30000, 4))
 
@@ -227,8 +231,8 @@ def test_state_resets_on_fs_change():
     fs2 = 30012.0
     out = proc(_sig_msgs(np.ones((30000, 2)), fs2, 30000)[0])
 
-    assert proc._state.fs == fs2
-    assert proc._state.samples_per_bin == pytest.approx(bin_dur * fs2)
+    assert proc._state.schedule.fs == fs2
+    assert proc._state.schedule.spb == pytest.approx(bin_dur * fs2)
     # Output offset reflects the new stream start (0.0), not stale fs1 state.
     assert out.axes["time"].offset == pytest.approx(0.0)
     assert np.all(np.isfinite(out.data))

--- a/tests/unit/test_concat.py
+++ b/tests/unit/test_concat.py
@@ -175,7 +175,10 @@ class TestBasicConcat:
 
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(proc.__acall__())
+        # asyncio.run (not get_event_loop) so this is robust to other tests in the
+        # suite that close/clear the loop policy (e.g. via asyncio.run); get_event_loop
+        # raises "no current event loop" on 3.10+ once that has happened.
+        result = asyncio.run(proc.__acall__())
         assert result.data.shape == (n, 5)
         np.testing.assert_array_equal(result.data[:, :2], data_a)
         np.testing.assert_array_equal(result.data[:, 2:], data_b)


### PR DESCRIPTION
Add a generic sigproc binner that other units can use to bin in the same way. Different binning was causing the root of the mismatch SBP vs SPK pathway timestamps.