### PR TITLE
De-flake test_decimate_system

### DIFF
--- a/tests/integration/ezmsg/test_decimate_system.py
+++ b/tests/integration/ezmsg/test_decimate_system.py
@@ -54,4 +54,13 @@ def test_decimate_system(target_rate: float):
         antialiased, _ = scipy.signal.lfilter(b, a, inputs.data, axis=0, zi=zi)
         expected = antialiased[:: int(expected_factor)]
 
-    assert np.allclose(outputs.data, expected)
+    # The raw and decimated streams are logged by independent MessageLoggers, and
+    # the graph is torn down on the *output* count (TERM watches LOGFILT), so the
+    # raw log can end a message or two ahead of the filtered log -- leaving
+    # `expected` (built from all raw samples) longer than `outputs`. The anti-alias
+    # filter is causal and zi-initialized, so each stream is a prefix of a longer
+    # run; compare only the overlapping prefix rather than requiring equal length.
+    # (test_filter_system applies the same truncation for the same race.)
+    n = min(outputs.data.shape[0], expected.shape[0])
+    assert n > 0
+    np.testing.assert_allclose(outputs.data[:n], expected[:n])


### PR DESCRIPTION
`test_decimate_system` intermittently fails CI with a shape mismatch (e.g. `(100,8)` vs `(120,8)`) — the failure seen on PR #159, unrelated to that PR's changes.

**Cause:** the raw and decimated streams are logged by two independent `MessageLogger`s, and the graph is torn down on the *output* count (`TERM` watches `LOGFILT`). Under load the raw logger can capture a message or two more than the filtered logger, so `expected` (built from all raw samples) ends up longer than `outputs`, and the full-length `np.allclose` fails on shape.

**Fix:** the anti-alias filter is causal and zi-initialized, so each stream is a prefix of a longer run — compare only the overlapping prefix. This is the same truncation `test_filter_system` already applies for the identical termination race; this just brings the decimate test in line.

No production code touched. `test_decimate_system` + `test_filter_system` pass (14, run repeatedly).