### PR TITLE
Add ResampleConcat; harden Resample against non-monotonic reference clocks

### DIFF
--- a/src/ezmsg/sigproc/resample.py
+++ b/src/ezmsg/sigproc/resample.py
@@ -3,6 +3,7 @@
 import asyncio
 import math
 import time
+import warnings
 
 import ezmsg.core as ez
 import numpy as np
@@ -46,6 +47,41 @@ class ResampleSettings(ez.Settings):
     might be more efficient. For most other scenarios, "immediate" is best.
     """
 
+    output_reference: bool = False
+    """
+    If True, also buffer the *data* carried by INPUT_REFERENCE messages and, for each
+    output chunk, gather the reference samples that sit on the exact same grid the signal
+    was resampled onto. The gathered reference signal is exposed via
+    :attr:`ResampleState.reference_output` (and published on ``OUTPUT_REFERENCE`` by
+    :class:`ResampleUnit`). This is what lets a downstream consumer concatenate the
+    reference stream with the resampled stream without a second time-alignment, because
+    the two share an identical axis *by construction*.
+
+    Only meaningful when ``resample_rate is None`` (reference-driven mode); in prescribed-
+    rate mode the reference grid is synthetic and carries no data.
+    """
+
+    reference_reset_after_chunks: float = 3
+    """
+    Robustness against a non-monotonic reference clock.
+
+    The resampler only emits at reference values greater than the last one it returned
+    (a high-water mark). A *sustained* backward jump in the reference clock (e.g. a
+    misbehaving source whose chunk offsets reset to an earlier time) would otherwise
+    leave every incoming reference value behind the high-water mark forever, so the
+    transformer would stop producing output.
+
+    If this many consecutive reference messages arrive entirely at or below the
+    high-water mark, the jump is treated as a clock reset: the high-water mark is
+    re-anchored to the new (lower) clock and a ``RuntimeWarning`` is emitted. Output then
+    resumes on the new clock. Small, self-correcting jitter (a few out-of-order samples)
+    does not trigger this and is simply skipped, keeping the output monotonic.
+
+    Set to ``float("inf")`` to disable reset recovery (the transformer may then stall
+    indefinitely on a backward clock jump). Output across a genuine reset is necessarily
+    discontinuous; sanitising the reference timestamps upstream remains the robust fix.
+    """
+
 
 @processor_state
 class ResampleState:
@@ -81,11 +117,34 @@ class ResampleState:
     if we have not received an update within max_chunk_delay.
     """
 
+    ref_data_buffer: HybridAxisArrayBuffer | None = None
+    """
+    Buffer for the *data* carried by reference messages, used only when
+    ``output_reference`` is set. Held in lockstep with ``ref_axis_buffer`` (same writes,
+    same seeks) so that the reference data at index ``i`` corresponds to the reference
+    axis value at index ``i``. Lets :meth:`__next__` gather the reference signal on the
+    exact output grid.
+    """
+
+    reference_output: AxisArray | None = None
+    """
+    The reference signal gathered onto the most recent output grid (only populated when
+    ``output_reference`` is set and the last :meth:`__next__` produced data). Shares its
+    axis with the resampled output, so the two can be concatenated without re-aligning.
+    """
+
+    stale_ref_pushes: int = 0
+    """
+    Number of consecutive reference messages that arrived entirely at or below the
+    high-water mark. Used to detect a sustained backward clock jump (reset). See
+    :attr:`ResampleSettings.reference_reset_after_chunks`.
+    """
+
 
 class ResampleProcessor(BaseStatefulProcessor[ResampleSettings, AxisArray, AxisArray, ResampleState]):
     # Both fields are read per-chunk inside `__next__` / `_process` only;
     # `resample_rate` / `buffer_duration` / `axis` all size cached buffers.
-    NONRESET_SETTINGS_FIELDS = frozenset({"max_chunk_delay", "fill_value"})
+    NONRESET_SETTINGS_FIELDS = frozenset({"max_chunk_delay", "fill_value", "reference_reset_after_chunks"})
 
     def _hash_message(self, message: AxisArray) -> int:
         ax_idx: int = message.get_axis_idx(self.settings.axis)
@@ -114,19 +173,73 @@ class ResampleProcessor(BaseStatefulProcessor[ResampleSettings, AxisArray, AxisA
             t0 = in_ax.data[0] if hasattr(in_ax, "data") else in_ax.value(0)
             self.state.last_ref_ax_val = t0 - out_gain
         self.state.last_write_time = -np.inf
+        self.state.reference_output = None
+        self.state.stale_ref_pushes = 0
+
+    @staticmethod
+    def _axis_first_step(ax) -> tuple[float, float]:
+        """Return ``(first_value, step)`` for either a LinearAxis or a CoordinateAxis.
+
+        A CoordinateAxis has no ``gain``; estimate the step from consecutive samples
+        (falling back to 0.0 for a single sample). The step is only used to seed the
+        high-water mark just below the first reference value, so an estimate is fine.
+        """
+        if hasattr(ax, "data"):
+            first = float(ax.data[0])
+            step = float(ax.data[1] - ax.data[0]) if len(ax.data) > 1 else 0.0
+        else:
+            first = ax.value(0)
+            step = ax.gain
+        return first, step
 
     def push_reference(self, message: AxisArray) -> None:
         ax = message.axes[self.settings.axis]
         ax_idx = message.get_axis_idx(self.settings.axis)
+        n = message.data.shape[ax_idx]
         if self.state.ref_axis_buffer is None:
             self.state.ref_axis_buffer = HybridAxisBuffer(
                 duration=self.settings.buffer_duration,
                 update_strategy=self.settings.buffer_update_strategy,
                 overflow_strategy="grow",
             )
-            t0 = ax.data[0] if hasattr(ax, "data") else ax.value(0)
-            self.state.last_ref_ax_val = t0 - ax.gain
-        self.state.ref_axis_buffer.write(ax, n_samples=message.data.shape[ax_idx])
+            first, step = self._axis_first_step(ax)
+            self.state.last_ref_ax_val = first - step
+            if self.settings.output_reference:
+                # Sister buffer for the reference *data*, kept in lockstep with the axis
+                # buffer above so a shared index addresses the same sample in both.
+                self.state.ref_data_buffer = HybridAxisArrayBuffer(
+                    duration=self.settings.buffer_duration,
+                    axis=self.settings.axis,
+                    update_strategy=self.settings.buffer_update_strategy,
+                    overflow_strategy="grow",
+                )
+
+        # --- Detect a sustained backward clock jump (reset) ---
+        # A whole message arriving at/below the high-water mark is abnormal; a run of them
+        # means the clock jumped back and is not catching up. Re-anchor so we don't stall
+        # forever. Self-correcting jitter (a single stale chunk) does not trigger this.
+        if self.state.last_ref_ax_val is not None and n > 0:
+            incoming_max = float(np.max(ax.data)) if hasattr(ax, "data") else ax.value(n - 1)
+            if incoming_max <= self.state.last_ref_ax_val:
+                self.state.stale_ref_pushes += 1
+            else:
+                self.state.stale_ref_pushes = 0
+            if self.state.stale_ref_pushes >= self.settings.reference_reset_after_chunks:
+                first, step = self._axis_first_step(ax)
+                warnings.warn(
+                    "ResampleProcessor: reference clock jumped backward and stayed behind "
+                    f"the last emitted value for {self.state.stale_ref_pushes} consecutive "
+                    "messages; treating it as a clock reset and re-anchoring to the new "
+                    "clock. Output across the reset is discontinuous; make the reference "
+                    "timestamps monotonic upstream to avoid this.",
+                    RuntimeWarning,
+                )
+                self.state.last_ref_ax_val = first - step
+                self.state.stale_ref_pushes = 0
+
+        self.state.ref_axis_buffer.write(ax, n_samples=n)
+        if self.state.ref_data_buffer is not None:
+            self.state.ref_data_buffer.write(message)
 
     def _process(self, message: AxisArray) -> None:
         """
@@ -150,6 +263,8 @@ class ResampleProcessor(BaseStatefulProcessor[ResampleSettings, AxisArray, AxisA
         self.state.last_write_time = time.monotonic()
 
     def __next__(self) -> AxisArray:
+        # Cleared each call; only repopulated on the success path below.
+        self.state.reference_output = None
         if self.state.src_buffer is None or self.state.ref_axis_buffer is None:
             # If we have not received any data, or we require reference data
             #  that we do not yet have, then return an empty template.
@@ -257,13 +372,28 @@ class ResampleProcessor(BaseStatefulProcessor[ResampleSettings, AxisArray, AxisA
             },
         )
 
+        # Gather the reference signal on this same output grid, if requested. We index by
+        # the very same ref_idx used to build the output, so the gathered reference shares
+        # an identical axis with `result` and the two need no further alignment.
+        if self.state.ref_data_buffer is not None:
+            ref_axarr = self.state.ref_data_buffer.peek()
+            if ref_axarr is not None and ref_axarr.data.shape[0] == ref.available():
+                self.state.reference_output = replace(
+                    ref_axarr,
+                    data=ref_axarr.data[ref_idx],
+                    axes={**ref_axarr.axes, self.settings.axis: out_ax},
+                )
+
         # Update the state. For state buffers, seek beyond samples that are no longer needed.
         # src: keep at least 1 sample before the final resampled value
         seek_ix = np.where(x >= xnew[-1])[0]
         if len(seek_ix) > 0:
             self.state.src_buffer.seek(max(0, src_start_ix + seek_ix[0] - 1))
-        # ref: remove samples that have been sent to output
+        # ref: remove samples that have been sent to output. Keep the data buffer in
+        # lockstep with the axis buffer so a shared index keeps addressing the same sample.
         self.state.ref_axis_buffer.seek(ref_idx[-1] + 1)
+        if self.state.ref_data_buffer is not None:
+            self.state.ref_data_buffer.seek(ref_idx[-1] + 1)
         self.state.last_ref_ax_val = xnew[-1]
 
         return result
@@ -277,16 +407,28 @@ class ResampleUnit(BaseConsumerUnit[ResampleSettings, AxisArray, ResampleProcess
     SETTINGS = ResampleSettings
     INPUT_REFERENCE = ez.InputStream(AxisArray)
     OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+    OUTPUT_REFERENCE = ez.OutputStream(AxisArray)
+    """The reference signal gathered onto the same grid as ``OUTPUT_SIGNAL``.
+
+    Only published when ``output_reference`` is set. Because it shares an identical axis
+    with ``OUTPUT_SIGNAL`` by construction, a downstream :class:`~ezmsg.sigproc.concat.Concat`
+    can combine the two without a second time-alignment (see
+    :class:`~ezmsg.sigproc.resampleconcat.ResampleConcat`, which fuses both steps).
+    """
 
     @ez.subscriber(INPUT_REFERENCE)
     async def on_reference(self, message: AxisArray):
         self.processor.push_reference(message)
 
     @ez.publisher(OUTPUT_SIGNAL)
+    @ez.publisher(OUTPUT_REFERENCE)
     async def gen_resampled(self):
         while True:
             result: AxisArray = next(self.processor)
             if np.prod(result.data.shape) > 0:
                 yield self.OUTPUT_SIGNAL, result
+                ref_out = self.processor.state.reference_output
+                if ref_out is not None:
+                    yield self.OUTPUT_REFERENCE, ref_out
             else:
-                await asyncio.sleep(0.001)
+                await asyncio.sleep(0)

--- a/src/ezmsg/sigproc/resampleconcat.py
+++ b/src/ezmsg/sigproc/resampleconcat.py
@@ -1,0 +1,170 @@
+"""Resample one stream onto another's clock and concatenate them in one step.
+
+This fuses :class:`~ezmsg.sigproc.resample.ResampleProcessor` and
+:class:`~ezmsg.sigproc.concat.ConcatProcessor` for the common case of combining two
+acquisition streams that share a nominal sampling rate but drift slightly:
+
+* ``INPUT_REFERENCE`` -- the *reference* stream (its clock is the master timebase, and
+  its data becomes one half of the concatenated output).
+* ``INPUT_SIGNAL`` -- the stream that is resampled onto the reference clock.
+* ``OUTPUT_SIGNAL`` -- the two streams concatenated along ``concat_axis``.
+
+Because the resampler emits the reference signal gathered onto the *exact* grid it
+resampled the signal onto (``output_reference=True``), the two halves share an identical
+alignment axis by construction. No second time-alignment (``Align``) is needed, so this
+collapses the otherwise-diamond graph
+
+    REF  -> RESAMPLE.INPUT_REFERENCE
+    SIG  -> RESAMPLE.INPUT_SIGNAL
+    REF  -> MERGE.INPUT_SIGNAL_A
+    RESAMPLE.OUTPUT -> MERGE.INPUT_SIGNAL_B
+
+into a single linear two-input unit. All interpolation logic is reused from
+``resample.py`` and all axis/attr-merge logic from ``concat.py``; only the orchestration
+is new.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+
+import ezmsg.core as ez
+import numpy as np
+from ezmsg.util.messages.axisarray import AxisArray
+
+from .concat import ConcatProcessor, ConcatSettings
+from .resample import ResampleProcessor, ResampleSettings
+from .util.buffer import UpdateStrategy
+
+
+class ResampleConcatSettings(ez.Settings):
+    axis: str = "time"
+    """Alignment axis: the reference stream's clock that the signal is resampled onto."""
+
+    concat_axis: str = "ch"
+    """Axis along which the reference and resampled signals are concatenated."""
+
+    # --- Resample passthrough ---
+    buffer_duration: float = 2.0
+    fill_value: str = "extrapolate"
+    max_chunk_delay: float = np.inf
+    buffer_update_strategy: UpdateStrategy = "immediate"
+    reference_reset_after_chunks: float = 3
+    """See :attr:`ezmsg.sigproc.resample.ResampleSettings.reference_reset_after_chunks`."""
+
+    # --- Concat passthrough ---
+    relabel_axis: bool = True
+    label_a: str = "_a"
+    """Per-side label for the reference (A) side. See :class:`~ezmsg.sigproc.concat.ConcatSettings`."""
+    label_b: str = "_b"
+    """Per-side label for the resampled-signal (B) side."""
+    assert_identical_shared_axes: bool = False
+    new_key: str | None = None
+    auto_coerce_backend: bool = False
+
+
+class ResampleConcatProcessor:
+    """Resample ``INPUT_SIGNAL`` onto ``INPUT_REFERENCE``'s clock, then concatenate.
+
+    Composes an unmodified :class:`ResampleProcessor` (with ``output_reference=True``)
+    and an unmodified :class:`ConcatProcessor`. The reference signal (A) and the
+    resampled signal (B) are concatenated only when the resampler yields both on the same
+    grid, so the two are aligned by construction.
+    """
+
+    def __init__(self, settings: ResampleConcatSettings):
+        self.settings = settings
+        self._resampler = ResampleProcessor(
+            settings=ResampleSettings(
+                axis=settings.axis,
+                resample_rate=None,  # reference-driven; required for output_reference
+                buffer_duration=settings.buffer_duration,
+                fill_value=settings.fill_value,
+                max_chunk_delay=settings.max_chunk_delay,
+                buffer_update_strategy=settings.buffer_update_strategy,
+                output_reference=True,
+                reference_reset_after_chunks=settings.reference_reset_after_chunks,
+            )
+        )
+        self._concat = ConcatProcessor(
+            ConcatSettings(
+                axis=settings.concat_axis,
+                align_axis=settings.axis,
+                relabel_axis=settings.relabel_axis,
+                label_a=settings.label_a,
+                label_b=settings.label_b,
+                assert_identical_shared_axes=settings.assert_identical_shared_axes,
+                new_key=settings.new_key,
+                auto_coerce_backend=settings.auto_coerce_backend,
+            )
+        )
+
+    @property
+    def resample_state(self):
+        """Expose resampler state for introspection / tests."""
+        return self._resampler.state
+
+    @property
+    def concat_state(self):
+        """Expose concat state for introspection / tests."""
+        return self._concat.state
+
+    def push_reference(self, message: AxisArray) -> None:
+        """Feed a reference (clock + side-A) message."""
+        self._resampler.push_reference(message)
+
+    def push_signal(self, message: AxisArray) -> None:
+        """Feed a signal message to be resampled onto the reference clock (side B)."""
+        self._resampler(message)
+
+    def __call__(self, message: AxisArray) -> AxisArray | None:
+        """Push a signal message and return the next concatenated chunk, if any."""
+        self.push_signal(message)
+        return next(self)
+
+    async def __acall__(self, message: AxisArray) -> AxisArray | None:
+        return self(message)
+
+    def __next__(self) -> AxisArray | None:
+        b = next(self._resampler)  # resampled signal (side B)
+        if b.data.shape[0] == 0:
+            return None
+        a = self._resampler.state.reference_output  # reference on the same grid (side A)
+        if a is None:
+            return None
+        return self._concat._concat(a, b)
+
+
+class ResampleConcat(ez.Unit):
+    """One-step resample-onto-reference + concatenate.
+
+    See module docstring. ``INPUT_REFERENCE`` is the master clock and side A;
+    ``INPUT_SIGNAL`` is resampled onto it and becomes side B.
+    """
+
+    SETTINGS = ResampleConcatSettings
+
+    INPUT_SIGNAL = ez.InputStream(AxisArray)
+    INPUT_REFERENCE = ez.InputStream(AxisArray)
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    async def initialize(self) -> None:
+        self.processor = ResampleConcatProcessor(self.SETTINGS)
+
+    @ez.subscriber(INPUT_REFERENCE)
+    async def on_reference(self, message: AxisArray) -> None:
+        self.processor.push_reference(message)
+
+    @ez.subscriber(INPUT_SIGNAL)
+    async def on_signal(self, message: AxisArray) -> None:
+        self.processor.push_signal(message)
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def output(self) -> typing.AsyncGenerator:
+        while True:
+            result = next(self.processor)
+            if result is not None and np.prod(result.data.shape) > 0:
+                yield self.OUTPUT_SIGNAL, result
+            else:
+                await asyncio.sleep(0)

--- a/tests/integration/ezmsg/test_resample_merge_system.py
+++ b/tests/integration/ezmsg/test_resample_merge_system.py
@@ -1,0 +1,211 @@
+"""Integration tests: combining two mismatched-rate streams onto one clock.
+
+Models the real-world "two acquisition hubs, slightly different effective rates"
+pipeline: HUB1 is the reference clock, HUB2 is resampled onto it, and the two are
+concatenated along the channel axis (256 + 128 -> 384, here 4 + 2 -> 6).
+
+Three wirings are exercised:
+
+* ``raw``       -- HUB1 -> RESAMPLE.INPUT_REFERENCE, HUB1 -> MERGE.INPUT_SIGNAL_A,
+                   RESAMPLE.OUTPUT_SIGNAL -> MERGE.INPUT_SIGNAL_B.  The original graph.
+* ``ref``       -- as above but MERGE.INPUT_SIGNAL_A is fed from RESAMPLE.OUTPUT_REFERENCE
+                   (the reference gathered on the exact output grid), so A and B stay
+                   sample-aligned even when the resampler drops/holds back samples.
+* ``composite`` -- a single :class:`ResampleConcat` unit doing both steps.
+
+The ``glitch`` cases inject a sustained *backward* jump in HUB1's chunk offsets (a
+non-monotonic reference clock, e.g. from a misbehaving simulator).
+"""
+
+import asyncio
+import os
+import typing
+from pathlib import Path
+
+import ezmsg.core as ez
+import numpy as np
+from ezmsg.util.messagecodec import message_log
+from ezmsg.util.messagelogger import MessageLogger, MessageLoggerSettings
+from ezmsg.util.messages.axisarray import AxisArray
+from ezmsg.util.terminate import TerminateOnTimeout, TerminateOnTimeoutSettings
+
+from ezmsg.sigproc.merge import Merge, MergeSettings
+from ezmsg.sigproc.resample import ResampleSettings, ResampleUnit
+from ezmsg.sigproc.resampleconcat import ResampleConcat, ResampleConcatSettings
+from tests.helpers.util import get_test_fn
+
+CHUNK = 30
+N_CHUNKS = 60
+FS = 1000.0
+
+
+class HubSettings(ez.Settings):
+    fs: float
+    n_ch: int
+    chunk: int = CHUNK
+    n_chunks: int = N_CHUNKS
+    glitch_at: int = -1
+    """Chunk index at which to inject a sustained backward offset jump (-1 = never)."""
+    glitch_back: float = 0.0
+    """Seconds to jump the offset backward at (and after) ``glitch_at``."""
+    key: str = "hub"
+    dispatch_dt: float = 0.002
+
+
+class Hub(ez.Unit):
+    """Synthetic acquisition hub emitting [time, ch] AxisArrays on a LinearAxis."""
+
+    SETTINGS = HubSettings
+    OUTPUT_SIGNAL = ez.OutputStream(AxisArray)
+
+    @ez.publisher(OUTPUT_SIGNAL)
+    async def produce(self) -> typing.AsyncGenerator:
+        s = self.SETTINGS
+        ch_ax = AxisArray.CoordinateAxis(
+            data=np.array([f"{s.key}{i}" for i in range(s.n_ch)]), dims=["ch"], unit="label"
+        )
+        shift = 0.0
+        for i in range(s.n_chunks):
+            if i == s.glitch_at:
+                shift = -s.glitch_back
+            offset = i * s.chunk / s.fs + shift
+            yield (
+                self.OUTPUT_SIGNAL,
+                AxisArray(
+                    data=np.random.randn(s.chunk, s.n_ch).astype(np.float32),
+                    dims=["time", "ch"],
+                    axes={
+                        "time": AxisArray.LinearAxis(gain=1 / s.fs, offset=offset, unit="s"),
+                        "ch": ch_ax,
+                    },
+                    key=s.key,
+                ),
+            )
+            await asyncio.sleep(s.dispatch_dt)
+        # Stay alive; let TerminateOnTimeout decide when the graph is done so a seized
+        # graph is distinguishable from one that simply ran out of input.
+        while True:
+            await asyncio.sleep(0.1)
+
+
+def _hubs(glitch_at: int, glitch_back: float) -> dict:
+    return {
+        "HUB1": Hub(HubSettings(fs=FS, n_ch=4, glitch_at=glitch_at, glitch_back=glitch_back, key="h1")),
+        # HUB2 runs 0.3% slow -- the realistic effective-rate mismatch.
+        "HUB2": Hub(HubSettings(fs=FS * 0.997, n_ch=2, key="h2")),
+    }
+
+
+def _run(comps: dict, conns: tuple, output_stream, fn: Path) -> tuple[int, int, int]:
+    log = MessageLogger(MessageLoggerSettings(output=fn))
+    term = TerminateOnTimeout(TerminateOnTimeoutSettings(time=2.0))
+    comps = {**comps, "LOG": log, "TERM": term}
+    conns = (
+        *conns,
+        (output_stream, log.INPUT_MESSAGE),
+        (log.OUTPUT_MESSAGE, term.INPUT),
+    )
+    ez.run(components=comps, connections=conns)
+    msgs: list[AxisArray] = list(message_log(fn))
+    os.remove(fn)
+    total = sum(m.data.shape[0] for m in msgs)
+    n_ch = msgs[0].data.shape[1] if msgs else 0
+    return len(msgs), total, n_ch
+
+
+def _run_resample_merge(glitch_at, glitch_back, reset_after, use_output_reference, fn):
+    comps = {
+        **_hubs(glitch_at, glitch_back),
+        "RESAMPLE": ResampleUnit(
+            ResampleSettings(
+                axis="time",
+                resample_rate=None,
+                buffer_duration=2.0,
+                output_reference=use_output_reference,
+                reference_reset_after_chunks=reset_after,
+            )
+        ),
+        "MERGE": Merge(MergeSettings(axis="ch", align_axis="time", buffer_dur=5.0)),
+    }
+    a_src = comps["RESAMPLE"].OUTPUT_REFERENCE if use_output_reference else comps["HUB1"].OUTPUT_SIGNAL
+    conns = (
+        (comps["HUB1"].OUTPUT_SIGNAL, comps["RESAMPLE"].INPUT_REFERENCE),
+        (comps["HUB2"].OUTPUT_SIGNAL, comps["RESAMPLE"].INPUT_SIGNAL),
+        (a_src, comps["MERGE"].INPUT_SIGNAL_A),
+        (comps["RESAMPLE"].OUTPUT_SIGNAL, comps["MERGE"].INPUT_SIGNAL_B),
+    )
+    return _run(comps, conns, comps["MERGE"].OUTPUT_SIGNAL, fn)
+
+
+def _run_composite(glitch_at, glitch_back, reset_after, fn):
+    comps = {
+        **_hubs(glitch_at, glitch_back),
+        "RC": ResampleConcat(
+            ResampleConcatSettings(
+                axis="time",
+                concat_axis="ch",
+                buffer_duration=2.0,
+                reference_reset_after_chunks=reset_after,
+            )
+        ),
+    }
+    conns = (
+        (comps["HUB1"].OUTPUT_SIGNAL, comps["RC"].INPUT_REFERENCE),
+        (comps["HUB2"].OUTPUT_SIGNAL, comps["RC"].INPUT_SIGNAL),
+    )
+    return _run(comps, conns, comps["RC"].OUTPUT_SIGNAL, fn)
+
+
+def test_resample_merge_healthy_system(test_name: str | None = None):
+    """Monotonic reference clock: the graph streams to completion, 6 channels out."""
+    n_msgs, total, n_ch = _run_resample_merge(
+        glitch_at=-1,
+        glitch_back=0.0,
+        reset_after=3,
+        use_output_reference=False,
+        fn=get_test_fn(test_name),
+    )
+    assert n_msgs >= 50, f"Healthy graph should produce ~60 merged messages, got {n_msgs}."
+    assert total >= 1500 and n_ch == 6
+
+
+def test_resample_merge_seizes_when_recovery_disabled_system(test_name: str | None = None):
+    """Documents the original bug: with recovery disabled, a backward reference jump stops output.
+
+    Setting ``reference_reset_after_chunks=inf`` restores the pre-hardening behaviour, so a
+    large sustained backward offset jump pushes the reference permanently below the
+    resampler's high-water mark and the merged output ceases well before input is exhausted.
+    """
+    n_msgs, _, _ = _run_resample_merge(
+        glitch_at=15,
+        glitch_back=100.0,
+        reset_after=float("inf"),
+        use_output_reference=False,
+        fn=get_test_fn(test_name),
+    )
+    assert n_msgs <= 20, f"Expected output to cease near the chunk-15 glitch, got {n_msgs}."
+
+
+def test_resample_merge_recovers_with_output_reference_system(test_name: str | None = None):
+    """Hardened resampler + OUTPUT_REFERENCE: the graph recovers from a reference reset.
+
+    Reset recovery (default) keeps the resampler producing past the backward jump, and
+    feeding MERGE.INPUT_SIGNAL_A from RESAMPLE.OUTPUT_REFERENCE keeps the two halves
+    sample-aligned through the drops, so the merged 6-channel output continues.
+    """
+    n_msgs, total, n_ch = _run_resample_merge(
+        glitch_at=15,
+        glitch_back=1.0,
+        reset_after=3,
+        use_output_reference=True,
+        fn=get_test_fn(test_name),
+    )
+    assert n_msgs > 25, f"Hardened graph should keep producing after the glitch, got {n_msgs}."
+    assert n_ch == 6, f"Merged output should stay 4+2=6 channels, got {n_ch}."
+
+
+def test_resampleconcat_recovers_system(test_name: str | None = None):
+    """The fused ResampleConcat unit produces aligned 6-channel output and recovers from a reset."""
+    n_msgs, total, n_ch = _run_composite(glitch_at=15, glitch_back=1.0, reset_after=3, fn=get_test_fn(test_name))
+    assert n_msgs > 25, f"Composite should keep producing after the glitch, got {n_msgs}."
+    assert n_ch == 6, f"Composite output should be 4+2=6 channels, got {n_ch}."

--- a/tests/unit/test_resample.py
+++ b/tests/unit/test_resample.py
@@ -166,9 +166,7 @@ def test_resample_preserves_mlx_backend():
         if result.data.shape[0] == 0:
             continue
         seen_output = True
-        assert isinstance(result.data, mx.array), (
-            f"Expected mx.array out, got {type(result.data).__name__}"
-        )
+        assert isinstance(result.data, mx.array), f"Expected mx.array out, got {type(result.data).__name__}"
         assert get_namespace(result.data) is mlx_ns
 
     assert seen_output, "Resampler never produced a non-empty output to check."
@@ -182,3 +180,84 @@ async def test_resample_no_input():
 
     null = next(resample)
     assert np.prod(null.data.shape) == 0
+
+
+def _linear_msg(fs: float, offset: float, n: int, n_ch: int, key: str, coord: bool = False) -> AxisArray:
+    t = offset + np.arange(n) / fs
+    time_ax = (
+        AxisArray.CoordinateAxis(data=t, dims=["time"], unit="s")
+        if coord
+        else AxisArray.LinearAxis(gain=1 / fs, offset=offset, unit="s")
+    )
+    return AxisArray(
+        data=t[:, None] + np.arange(n_ch)[None, :] * 1000.0,
+        dims=["time", "ch"],
+        axes={
+            "time": time_ax,
+            "ch": AxisArray.CoordinateAxis(
+                data=np.array([f"{key}{i}" for i in range(n_ch)]), dims=["ch"], unit="label"
+            ),
+        },
+        key=key,
+    )
+
+
+def test_resample_coordinate_axis_reference():
+    """push_reference must accept a CoordinateAxis reference (no .gain attribute)."""
+    fs, chunk = 100.0, 30
+    resample = ResampleProcessor(resample_rate=None, buffer_duration=4.0)
+    total = 0
+    for i in range(8):
+        resample.push_reference(_linear_msg(fs, i * chunk / fs, chunk, 1, "ref", coord=True))
+        resample(_linear_msg(fs, i * chunk / fs, chunk, 2, "sig", coord=True))
+        total += next(resample).data.shape[0]
+    assert total > 0
+
+
+def test_resample_output_reference_shares_grid():
+    """output_reference yields the reference gathered onto the exact output grid."""
+    fs_ref, fs_sig, chunk = 100.0, 99.7, 30
+    resample = ResampleProcessor(resample_rate=None, buffer_duration=4.0, output_reference=True)
+    for i in range(8):
+        resample.push_reference(_linear_msg(fs_ref, i * chunk / fs_ref, chunk, 4, "ref"))
+        resample(_linear_msg(fs_sig, i * chunk / fs_sig, chunk, 2, "sig"))
+        b = next(resample)
+        a = resample.state.reference_output
+        if b.data.shape[0] == 0:
+            continue
+        assert a is not None
+        # Same length and identical alignment axis as the resampled output.
+        assert a.data.shape[0] == b.data.shape[0]
+        assert a.data.shape[1] == 4 and b.data.shape[1] == 2
+        ta = a.axes["time"].value(np.arange(a.data.shape[0]))
+        tb = b.axes["time"].value(np.arange(b.data.shape[0]))
+        assert np.allclose(ta, tb)
+        # Reference data col 0 encodes its own timestamp -> confirms correct samples gathered.
+        assert np.max(np.abs(a.data[:, 0] - ta)) < 1e-9
+
+
+def test_resample_recovers_from_reference_reset():
+    """A sustained backward reference jump re-anchors (with warning) instead of stalling."""
+    fs, chunk = 100.0, 30
+    resample = ResampleProcessor(resample_rate=None, buffer_duration=4.0, reference_reset_after_chunks=3)
+    counts = []
+    with pytest.warns(RuntimeWarning):
+        for i in range(25):
+            off = i * chunk / fs - (100.0 if i >= 10 else 0.0)
+            resample.push_reference(_linear_msg(fs, off, chunk, 1, "ref"))
+            resample(_linear_msg(fs, i * chunk / fs, chunk, 2, "sig"))
+            counts.append(next(resample).data.shape[0])
+    assert sum(counts[14:]) > 0, "Resampler never recovered after the reference reset."
+
+
+def test_resample_reset_disabled_can_stall():
+    """With recovery disabled (inf threshold), a large backward jump stops output."""
+    fs, chunk = 100.0, 30
+    resample = ResampleProcessor(resample_rate=None, buffer_duration=4.0, reference_reset_after_chunks=float("inf"))
+    counts = []
+    for i in range(25):
+        off = i * chunk / fs - (100.0 if i >= 10 else 0.0)
+        resample.push_reference(_linear_msg(fs, off, chunk, 1, "ref"))
+        resample(_linear_msg(fs, i * chunk / fs, chunk, 2, "sig"))
+        counts.append(next(resample).data.shape[0])
+    assert sum(counts[12:]) == 0, "Expected output to stall when recovery is disabled."

--- a/tests/unit/test_resampleconcat.py
+++ b/tests/unit/test_resampleconcat.py
@@ -1,0 +1,82 @@
+"""Unit tests for the fused resample-onto-reference + concatenate transformer."""
+
+import numpy as np
+import pytest
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.resampleconcat import ResampleConcatProcessor, ResampleConcatSettings
+
+
+def _mk(fs: float, offset: float, n: int, n_ch: int, key: str, encode_time: bool = False) -> AxisArray:
+    """Build a [time, ch] message on a LinearAxis.
+
+    When ``encode_time`` is True, ``data[:, j] == time + 1000*j`` so a test can verify
+    which samples ended up where after resampling/concatenation.
+    """
+    t = offset + np.arange(n) / fs
+    if encode_time:
+        data = t[:, None] + np.arange(n_ch)[None, :] * 1000.0
+    else:
+        data = np.random.randn(n, n_ch)
+    return AxisArray(
+        data=data,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.LinearAxis(gain=1 / fs, offset=offset, unit="s"),
+            "ch": AxisArray.CoordinateAxis(
+                data=np.array([f"{key}{i}" for i in range(n_ch)]), dims=["ch"], unit="label"
+            ),
+        },
+        key=key,
+    )
+
+
+def test_resampleconcat_combines_two_rates():
+    """Reference (4 ch) + signal resampled onto it (2 ch) -> 6 ch on a shared axis."""
+    fs_ref, fs_sig, chunk = 100.0, 99.7, 30
+    proc = ResampleConcatProcessor(
+        ResampleConcatSettings(axis="time", concat_axis="ch", buffer_duration=4.0, label_a="_h1", label_b="_h2")
+    )
+    outs = []
+    for i in range(12):
+        proc.push_reference(_mk(fs_ref, i * chunk / fs_ref, chunk, 4, "h1", encode_time=True))
+        r = proc(_mk(fs_sig, i * chunk / fs_sig, chunk, 2, "h2", encode_time=True))
+        if r is not None and r.data.shape[0] > 0:
+            outs.append(r)
+
+    assert outs, "Composite produced no output."
+    cat = AxisArray.concatenate(*outs, dim="time")
+    assert cat.data.shape[1] == 6, "Expected 4 (reference) + 2 (signal) = 6 channels."
+
+    labels = list(cat.axes["ch"].data)
+    assert all(lbl.endswith("_h1") for lbl in labels[:4])
+    assert all(lbl.endswith("_h2") for lbl in labels[4:])
+
+    t = cat.axes["time"].value(np.arange(cat.data.shape[0]))
+    # Side A is the reference gathered exactly on the output grid: data col 0 == time.
+    assert np.max(np.abs(cat.data[:, 0] - t)) < 1e-9
+    # Side B is the signal linearly resampled onto the same grid: data col 0 == time.
+    assert np.max(np.abs(cat.data[:, 4] - t)) < 1e-6
+
+
+def test_resampleconcat_no_signal_yields_nothing():
+    """With reference but no signal, there is nothing to resample/concatenate."""
+    proc = ResampleConcatProcessor(ResampleConcatSettings(buffer_duration=4.0))
+    for i in range(4):
+        proc.push_reference(_mk(100.0, i * 30 / 100.0, 30, 4, "h1"))
+    assert next(proc) is None
+
+
+def test_resampleconcat_recovers_from_reference_reset():
+    """A sustained backward jump in the reference clock must not stop output forever."""
+    fs, chunk = 100.0, 30
+    proc = ResampleConcatProcessor(ResampleConcatSettings(buffer_duration=4.0, reference_reset_after_chunks=3))
+    post_reset = 0
+    with pytest.warns(RuntimeWarning):
+        for i in range(25):
+            off = i * chunk / fs - (100.0 if i >= 10 else 0.0)  # big reset at chunk 10
+            proc.push_reference(_mk(fs, off, chunk, 4, "h1"))
+            r = proc(_mk(fs, i * chunk / fs, chunk, 2, "h2"))
+            if i >= 14 and r is not None and r.data.shape[0] > 0:
+                post_reset += r.data.shape[0]
+    assert post_reset > 0, "Composite did not recover after the reference clock reset."


### PR DESCRIPTION
## Summary

Combining two acquisition streams that share a nominal rate but drift slightly (e.g. two hubs at ~30 kHz with 0.1–0.5% effective-rate mismatch) is done by resampling one stream onto the other's clock and concatenating along the channel axis. The existing `Resample → Merge` graph has two failure modes when the reference clock misbehaves:

1. **Seizing.** A backward jump in the reference clock leaves every incoming reference value behind the resampler's high-water mark, so it stops emitting and the whole graph hangs.
2. **Silent misalignment.** When the resampler holds back or drops reference samples, the *raw* reference stream feeding `MERGE.INPUT_SIGNAL_A` is no longer sample-aligned with the resampled stream — `Align` does a one-time offset alignment then reads in lockstep, so it concatenates mismatched samples.

## Changes

**`resample.py`**
- **`output_reference` setting** + new **`OUTPUT_REFERENCE`** stream: buffers the reference *data* and emits it gathered onto the exact grid the signal was resampled onto, so a downstream `Concat` can combine the two with no second time-alignment (aligned by construction).
- **`reference_reset_after_chunks`** (default 3): detects a sustained backward clock jump and re-anchors the high-water mark with a `RuntimeWarning` instead of seizing. Self-correcting jitter is dropped, keeping output monotonic. Set to `inf` to restore the previous behaviour.
- **`push_reference` CoordinateAxis fix**: no longer unconditionally reads `ax.gain` (which crashed on a per-sample-timestamp reference).

**`resampleconcat.py` (new)**
- `ResampleConcat` fuses `ResampleProcessor` (`output_reference=True`) and `ConcatProcessor` into a single linear two-input unit — no `Align`, no diamond graph. Reuses all interpolation logic from `resample.py` and all axis/attr-merge logic from `concat.py`; only the orchestration is new.

## Tests
- `tests/unit/test_resample.py`: CoordinateAxis reference, `output_reference` grid-alignment, reset recovery, and reset-disabled-stalls.
- `tests/unit/test_resampleconcat.py` (new): two-rate combine with numeric provenance check, no-signal, reset recovery.
- `tests/integration/ezmsg/test_resample_merge_system.py` (new): healthy graph; seize when recovery disabled (documents the original bug); recovery via `OUTPUT_REFERENCE`; composite recovery.

Full suite: 3596 passed, 5 skipped locally.

## Notes
Output across a *genuine* reference clock reset is necessarily discontinuous — the hardening is a guardrail (don't hang, warn loudly) rather than a substitute for sanitising reference timestamps upstream.