### PR TITLE
channel cluster from field helper, car cluster by field

### DIFF
--- a/src/ezmsg/sigproc/affinetransform.py
+++ b/src/ezmsg/sigproc/affinetransform.py
@@ -480,7 +480,10 @@ class CommonRereferenceSettings(ez.Settings):
     channel coordinate axis (e.g. ``"bank"`` to rereference within each electrode
     bank). Used only when ``channel_clusters`` is None and the axis actually
     carries that field; otherwise falls back to a single all-channel cluster.
-    Explicit ``channel_clusters`` always takes precedence."""
+    Explicit ``channel_clusters`` always takes precedence.
+    Note: the any changes to the field values are not detected. The channel->field
+    map is expected to be static for the stream's life.
+    """
 
 
 @processor_state
@@ -496,18 +499,12 @@ class CommonRereferenceTransformer(
         axis = self.settings.axis or message.dims[-1]
         axis_idx = message.get_axis_idx(axis)
         components: tuple = (message.key, message.data.shape[axis_idx])
-        # When clusters are derived from a structured channel-axis field, the
-        # cached clusters go stale if that field's values change even though the
-        # key and channel count are unchanged. Fold the field's bytes into the
-        # hash so the state re-derives. Scoped to the cluster_by_field path so
-        # the common (no-field) case pays nothing; the cost is O(channels) once
-        # per message, far below the O(channels x samples) rereference compute.
+        # On the cluster_by_field path, re-derive clusters only when the channel
+        # axis gains or loses the target structured field
         if self.settings.channel_clusters is None and self.settings.cluster_by_field is not None:
             ax = message.axes.get(axis)
-            data = getattr(ax, "data", None)
-            names = getattr(getattr(data, "dtype", None), "names", None)
-            if data is not None and names and self.settings.cluster_by_field in names:
-                components += (data[self.settings.cluster_by_field].tobytes(),)
+            names = getattr(getattr(getattr(ax, "data", None), "dtype", None), "names", None)
+            components += (bool(names and self.settings.cluster_by_field in names),)
         return hash(components)
 
     def _reset_state(self, message: AxisArray) -> None:

--- a/src/ezmsg/sigproc/affinetransform.py
+++ b/src/ezmsg/sigproc/affinetransform.py
@@ -540,7 +540,15 @@ class CommonRereferenceTransformer(
 
             if not self.settings.include_current:
                 N = cluster_data.shape[axis_idx]
-                ref_data = (N / (N - 1)) * ref_data - cluster_data / (N - 1)
+                if N > 1:
+                    ref_data = (N / (N - 1)) * ref_data - cluster_data / (N - 1)
+                else:
+                    # A single-channel cluster has no "other" channels to form a
+                    # leave-one-out reference from, so pass it through unchanged
+                    # rather than dividing by N - 1 == 0. This is reachable via
+                    # cluster_by_field when a derived group (e.g. an electrode
+                    # bank) happens to contain a lone channel.
+                    ref_data = xp.zeros_like(ref_data)
 
             # Write per-cluster result into output at the correct axis position
             idx = [slice(None)] * output.ndim

--- a/src/ezmsg/sigproc/affinetransform.py
+++ b/src/ezmsg/sigproc/affinetransform.py
@@ -25,6 +25,7 @@ from ezmsg.util.messages.axisarray import AxisArray, AxisBase
 from ezmsg.util.messages.util import replace
 
 from ezmsg.sigproc.util.array import array_device, is_float_dtype, xp_asarray, xp_create
+from ezmsg.sigproc.util.channels import channel_clusters_from_field
 
 
 def _find_block_diagonal_clusters(weights: np.ndarray) -> list[tuple[np.ndarray, np.ndarray]] | None:
@@ -474,6 +475,13 @@ class CommonRereferenceSettings(ez.Settings):
     list of channel indices forming one cluster. The common reference is computed
     independently within each cluster. If None, all channels form a single cluster."""
 
+    cluster_by_field: str | None = None
+    """Derive ``channel_clusters`` automatically from a structured field of the
+    channel coordinate axis (e.g. ``"bank"`` to rereference within each electrode
+    bank). Used only when ``channel_clusters`` is None and the axis actually
+    carries that field; otherwise falls back to a single all-channel cluster.
+    Explicit ``channel_clusters`` always takes precedence."""
+
 
 @processor_state
 class CommonRereferenceState:
@@ -487,7 +495,20 @@ class CommonRereferenceTransformer(
     def _hash_message(self, message: AxisArray) -> int:
         axis = self.settings.axis or message.dims[-1]
         axis_idx = message.get_axis_idx(axis)
-        return hash((message.key, message.data.shape[axis_idx]))
+        components: tuple = (message.key, message.data.shape[axis_idx])
+        # When clusters are derived from a structured channel-axis field, the
+        # cached clusters go stale if that field's values change even though the
+        # key and channel count are unchanged. Fold the field's bytes into the
+        # hash so the state re-derives. Scoped to the cluster_by_field path so
+        # the common (no-field) case pays nothing; the cost is O(channels) once
+        # per message, far below the O(channels x samples) rereference compute.
+        if self.settings.channel_clusters is None and self.settings.cluster_by_field is not None:
+            ax = message.axes.get(axis)
+            data = getattr(ax, "data", None)
+            names = getattr(getattr(data, "dtype", None), "names", None)
+            if data is not None and names and self.settings.cluster_by_field in names:
+                components += (data[self.settings.cluster_by_field].tobytes(),)
+        return hash(components)
 
     def _reset_state(self, message: AxisArray) -> None:
         xp = get_namespace(message.data)
@@ -495,8 +516,11 @@ class CommonRereferenceTransformer(
         axis_idx = message.get_axis_idx(axis)
         n_chans = message.data.shape[axis_idx]
 
-        if self.settings.channel_clusters is not None:
-            self._state.clusters = [xp.asarray(group) for group in self.settings.channel_clusters]
+        clusters = self.settings.channel_clusters
+        if clusters is None and self.settings.cluster_by_field is not None:
+            clusters = channel_clusters_from_field(message, axis, self.settings.cluster_by_field)
+        if clusters is not None:
+            self._state.clusters = [xp.asarray(group) for group in clusters]
         else:
             self._state.clusters = [xp.arange(n_chans)]
 
@@ -540,6 +564,7 @@ def common_rereference(
     axis: str | None = None,
     include_current: bool = True,
     channel_clusters: list[list[int]] | None = None,
+    cluster_by_field: str | None = None,
 ) -> CommonRereferenceTransformer:
     """
     Perform common average referencing (CAR) on streaming data.
@@ -550,12 +575,18 @@ def common_rereference(
         include_current: Set False to exclude each channel from participating in the calculation of its reference.
         channel_clusters: Optional channel clusters for per-cluster rereferencing. See
             :attr:`CommonRereferenceSettings.channel_clusters`.
+        cluster_by_field: Optionally derive clusters from a structured channel-axis field
+            (e.g. ``"bank"``). See :attr:`CommonRereferenceSettings.cluster_by_field`.
 
     Returns:
         :obj:`CommonRereferenceTransformer`
     """
     return CommonRereferenceTransformer(
         CommonRereferenceSettings(
-            mode=mode, axis=axis, include_current=include_current, channel_clusters=channel_clusters
+            mode=mode,
+            axis=axis,
+            include_current=include_current,
+            channel_clusters=channel_clusters,
+            cluster_by_field=cluster_by_field,
         )
     )

--- a/src/ezmsg/sigproc/util/channels.py
+++ b/src/ezmsg/sigproc/util/channels.py
@@ -1,0 +1,64 @@
+"""Helpers for deriving channel clusters from structured coordinate-axis metadata.
+
+Several sources attach a structured ``CoordinateAxis`` to the channel dimension
+carrying per-channel fields — e.g. ezmsg-blackrock's ``ChannelMap`` emits a
+``ch`` axis with ``x``/``y``/``size``/``label``/``bank``/``elec``/``headstage``.
+``channel_clusters_from_field`` turns one such field (``bank`` by default) into
+the ``list[list[int]]`` cluster spec consumed by per-cluster operations like
+common-average rereferencing and linear-regression rereferencing, so those units
+can become "bank aware" by reading metadata that already rides on the stream.
+"""
+
+from __future__ import annotations
+
+from ezmsg.util.messages.axisarray import AxisArray
+
+
+def channel_clusters_from_field(
+    message: AxisArray,
+    axis: str | None = None,
+    field: str = "bank",
+) -> list[list[int]] | None:
+    """Group channel indices by a field of a structured coordinate axis.
+
+    Args:
+        message: Message whose ``axis`` coordinate is a structured
+            ``CoordinateAxis`` (its ``.data`` is a structured numpy array).
+        axis: Channel axis name. ``None`` defaults to the last dimension.
+        field: Structured-array field to group by (e.g. ``"bank"``).
+
+    Returns:
+        Clusters as a list of index lists, one per distinct ``field`` value in
+        first-appearance order. Returns ``None`` when the axis carries no usable
+        structured ``field`` (no such axis, no ``.data``, unstructured ``.data``,
+        the field is absent, or the per-channel length doesn't match the data).
+        Returning ``None`` rather than a single all-channel cluster lets callers
+        distinguish "no metadata, fall back to my default" from "one bank".
+    """
+    axis = axis or message.dims[-1]
+    ax = message.axes.get(axis)
+    if ax is None or not hasattr(ax, "data"):
+        return None
+
+    data = ax.data
+    names = getattr(getattr(data, "dtype", None), "names", None)
+    if not names or field not in names:
+        return None
+
+    axis_idx = message.get_axis_idx(axis)
+    n = message.data.shape[axis_idx]
+    if data.shape[0] != n:
+        return None
+
+    values = data[field]
+    clusters: dict[object, list[int]] = {}
+    order: list[object] = []
+    for i in range(n):
+        v = values[i]
+        key = v.item() if hasattr(v, "item") else v
+        if key not in clusters:
+            clusters[key] = []
+            order.append(key)
+        clusters[key].append(i)
+
+    return [clusters[k] for k in order]

--- a/tests/unit/test_affine_transform.py
+++ b/tests/unit/test_affine_transform.py
@@ -194,9 +194,7 @@ def test_common_rereference_cluster_by_field():
     ch_ax = _banked_ch_axis(banks)
     msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": ch_ax})
 
-    xformer = CommonRereferenceTransformer(
-        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
-    )
+    xformer = CommonRereferenceTransformer(CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank"))
     msg_out = xformer(msg_in)
 
     # Expected: per-bank CAR (bank A = ch 0-3, bank B = ch 4-7)
@@ -217,9 +215,7 @@ def test_common_rereference_cluster_by_field_fallback():
     ch_ax = AxisArray.CoordinateAxis(data=np.array([str(i) for i in range(n_chans)]), dims=["ch"])
     msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": ch_ax})
 
-    xformer = CommonRereferenceTransformer(
-        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
-    )
+    xformer = CommonRereferenceTransformer(CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank"))
     msg_out = xformer(msg_in)
     assert np.allclose(msg_out.data, in_dat - in_dat.mean(axis=1, keepdims=True))
 
@@ -232,9 +228,7 @@ def test_common_rereference_cluster_by_field_interleaved():
     in_dat = rng.standard_normal((n_times, len(banks)))
     msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(banks)})
 
-    xformer = CommonRereferenceTransformer(
-        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
-    )
+    xformer = CommonRereferenceTransformer(CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank"))
     msg_out = xformer(msg_in)
 
     expected = np.zeros_like(in_dat)
@@ -267,24 +261,32 @@ def test_common_rereference_cluster_by_field_exclude_current():
     assert np.allclose(msg_out.data, expected)
 
 
-def test_common_rereference_rederives_when_field_changes():
-    """Clusters re-derive if the bank field changes while key/channel-count stay fixed."""
+def test_common_rereference_field_values_change_is_not_detected():
+    """Intentional concession: a live bank remap at fixed key + channel count is
+    NOT re-derived. _hash_message folds only an O(1) "field present" boolean, not
+    the field's bytes, to keep the per-message hash from scaling with channel
+    count. A genuine remap on real hardware arrives with a new key or channel
+    count (see the escape-hatch assertion below)."""
     n_times = 80
     rng = np.random.default_rng(11)
     in_dat = rng.standard_normal((n_times, 4))
 
-    xformer = CommonRereferenceTransformer(
-        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
-    )
+    xformer = CommonRereferenceTransformer(CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank"))
 
     # First layout: two banks of two.
     msg1 = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(["A", "A", "B", "B"])}, key="dev")
     xformer(msg1)
     assert [list(c) for c in xformer._state.clusters] == [[0, 1], [2, 3]]
 
-    # Same key and channel count, different bank assignment -> must re-derive.
+    # Same key and channel count, different bank assignment -> hash unchanged,
+    # so the cached clusters are (deliberately) NOT re-derived.
     msg2 = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(["A", "B", "A", "B"])}, key="dev")
     xformer(msg2)
+    assert [list(c) for c in xformer._state.clusters] == [[0, 1], [2, 3]]
+
+    # Escape hatch: a new key (as a real remap would carry) forces re-derivation.
+    msg3 = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(["A", "B", "A", "B"])}, key="dev2")
+    xformer(msg3)
     assert [list(c) for c in xformer._state.clusters] == [[0, 2], [1, 3]]
 
 

--- a/tests/unit/test_affine_transform.py
+++ b/tests/unit/test_affine_transform.py
@@ -175,6 +175,137 @@ def test_common_rereference_clusters():
     assert np.allclose(msg_out.data, expected)
 
 
+def _banked_ch_axis(banks: list[str]):
+    """Structured ch CoordinateAxis like ezmsg-blackrock ChannelMap emits."""
+    dt = np.dtype([("label", "U16"), ("bank", "U1"), ("elec", "i4")])
+    ch = np.zeros(len(banks), dtype=dt)
+    ch["bank"] = banks
+    ch["elec"] = list(range(1, len(banks) + 1))
+    ch["label"] = [f"ch{i}" for i in range(len(banks))]
+    return AxisArray.CoordinateAxis(data=ch, dims=["ch"])
+
+
+def test_common_rereference_cluster_by_field():
+    """cluster_by_field='bank' derives per-bank clusters from a structured ch axis."""
+    n_times = 300
+    banks = ["A", "A", "A", "A", "B", "B", "B", "B"]
+    rng = np.random.default_rng(42)
+    in_dat = rng.standard_normal((n_times, len(banks)))
+    ch_ax = _banked_ch_axis(banks)
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": ch_ax})
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
+    )
+    msg_out = xformer(msg_in)
+
+    # Expected: per-bank CAR (bank A = ch 0-3, bank B = ch 4-7)
+    expected = np.zeros_like(in_dat)
+    for cluster in ([0, 1, 2, 3], [4, 5, 6, 7]):
+        cd = in_dat[:, cluster]
+        expected[:, cluster] = cd - np.mean(cd, axis=1, keepdims=True)
+    assert np.allclose(msg_out.data, expected)
+
+
+def test_common_rereference_cluster_by_field_fallback():
+    """cluster_by_field with no structured 'bank' field falls back to global CAR."""
+    n_times = 50
+    n_chans = 8
+    rng = np.random.default_rng(0)
+    in_dat = rng.standard_normal((n_times, n_chans))
+    # Unstructured (label-only) ch axis -> no 'bank' field available.
+    ch_ax = AxisArray.CoordinateAxis(data=np.array([str(i) for i in range(n_chans)]), dims=["ch"])
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": ch_ax})
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
+    )
+    msg_out = xformer(msg_in)
+    assert np.allclose(msg_out.data, in_dat - in_dat.mean(axis=1, keepdims=True))
+
+
+def test_common_rereference_cluster_by_field_interleaved():
+    """Per-bank CAR works when channels of a bank are non-contiguous."""
+    n_times = 200
+    banks = ["A", "B", "A", "B", "A", "B"]  # interleaved -> non-contiguous clusters
+    rng = np.random.default_rng(7)
+    in_dat = rng.standard_normal((n_times, len(banks)))
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(banks)})
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
+    )
+    msg_out = xformer(msg_in)
+
+    expected = np.zeros_like(in_dat)
+    for cluster in ([0, 2, 4], [1, 3, 5]):
+        cd = in_dat[:, cluster]
+        expected[:, cluster] = cd - np.mean(cd, axis=1, keepdims=True)
+    assert np.allclose(msg_out.data, expected)
+
+
+def test_common_rereference_cluster_by_field_exclude_current():
+    """cluster_by_field composes with include_current=False (per-bank, leave-one-out)."""
+    n_times = 100
+    banks = ["A", "A", "A", "B", "B", "B"]
+    rng = np.random.default_rng(3)
+    in_dat = rng.standard_normal((n_times, len(banks)))
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(banks)})
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank", include_current=False)
+    )
+    msg_out = xformer(msg_in)
+
+    expected = np.zeros_like(in_dat)
+    for cluster in ([0, 1, 2], [3, 4, 5]):
+        cd = in_dat[:, cluster]
+        n = cd.shape[1]
+        # leave-one-out mean within the bank: (sum - self) / (n - 1)
+        loo_ref = (cd.sum(axis=1, keepdims=True) - cd) / (n - 1)
+        expected[:, cluster] = cd - loo_ref
+    assert np.allclose(msg_out.data, expected)
+
+
+def test_common_rereference_rederives_when_field_changes():
+    """Clusters re-derive if the bank field changes while key/channel-count stay fixed."""
+    n_times = 80
+    rng = np.random.default_rng(11)
+    in_dat = rng.standard_normal((n_times, 4))
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank")
+    )
+
+    # First layout: two banks of two.
+    msg1 = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(["A", "A", "B", "B"])}, key="dev")
+    xformer(msg1)
+    assert [list(c) for c in xformer._state.clusters] == [[0, 1], [2, 3]]
+
+    # Same key and channel count, different bank assignment -> must re-derive.
+    msg2 = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(["A", "B", "A", "B"])}, key="dev")
+    xformer(msg2)
+    assert [list(c) for c in xformer._state.clusters] == [[0, 2], [1, 3]]
+
+
+def test_common_rereference_explicit_clusters_beat_field():
+    """Explicit channel_clusters take precedence over cluster_by_field."""
+    n_times = 50
+    banks = ["A", "A", "A", "A", "B", "B", "B", "B"]
+    rng = np.random.default_rng(1)
+    in_dat = rng.standard_normal((n_times, len(banks)))
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(banks)})
+
+    # One explicit all-channel cluster should override the bank grouping -> global CAR.
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(
+            mode="mean", axis="ch", channel_clusters=[list(range(len(banks)))], cluster_by_field="bank"
+        )
+    )
+    msg_out = xformer(msg_in)
+    assert np.allclose(msg_out.data, in_dat - in_dat.mean(axis=1, keepdims=True))
+
+
 def test_car_passthrough():
     n_times = 300
     n_chans = 64

--- a/tests/unit/test_affine_transform.py
+++ b/tests/unit/test_affine_transform.py
@@ -261,6 +261,30 @@ def test_common_rereference_cluster_by_field_exclude_current():
     assert np.allclose(msg_out.data, expected)
 
 
+def test_common_rereference_singleton_cluster_exclude_current():
+    """A lone channel in a derived bank + include_current=False must not divide by
+    N-1 == 0. The singleton passes through unchanged; larger banks still do LOO."""
+    n_times = 100
+    banks = ["A", "B", "B", "B"]  # bank A is a single channel
+    rng = np.random.default_rng(5)
+    in_dat = rng.standard_normal((n_times, len(banks)))
+    msg_in = AxisArray(in_dat, dims=["time", "ch"], axes={"ch": _banked_ch_axis(banks)})
+
+    xformer = CommonRereferenceTransformer(
+        CommonRereferenceSettings(mode="mean", axis="ch", cluster_by_field="bank", include_current=False)
+    )
+    msg_out = xformer(msg_in)  # must not raise ZeroDivisionError
+
+    expected = np.zeros_like(in_dat)
+    # Lone channel: no other channels to reference -> unchanged.
+    expected[:, 0] = in_dat[:, 0]
+    # Bank B: leave-one-out mean within the bank.
+    cd = in_dat[:, [1, 2, 3]]
+    loo_ref = (cd.sum(axis=1, keepdims=True) - cd) / (cd.shape[1] - 1)
+    expected[:, [1, 2, 3]] = cd - loo_ref
+    assert np.allclose(msg_out.data, expected)
+
+
 def test_common_rereference_field_values_change_is_not_detected():
     """Intentional concession: a live bank remap at fixed key + channel count is
     NOT re-derived. _hash_message folds only an O(1) "field present" boolean, not

--- a/tests/unit/test_util_channels.py
+++ b/tests/unit/test_util_channels.py
@@ -1,0 +1,81 @@
+import numpy as np
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.util.channels import channel_clusters_from_field
+
+
+def _msg(banks: list[str], n_data: int | None = None, field: str = "bank") -> AxisArray:
+    """AxisArray with a structured ch CoordinateAxis carrying `field`=banks.
+
+    `n_data` overrides the channel-dim size of the data array (to exercise the
+    coord/data length-mismatch guard); defaults to len(banks).
+    """
+    dt = np.dtype([(field, "U2")])
+    ch = np.zeros(len(banks), dtype=dt)
+    ch[field] = banks
+    n = len(banks) if n_data is None else n_data
+    return AxisArray(
+        data=np.zeros((3, n)),
+        dims=["time", "ch"],
+        axes={"ch": AxisArray.CoordinateAxis(data=ch, dims=["ch"])},
+    )
+
+
+def test_contiguous_blocks():
+    clusters = channel_clusters_from_field(_msg(["A", "A", "B", "B"]), "ch", "bank")
+    assert clusters == [[0, 1], [2, 3]]
+
+
+def test_interleaved_first_appearance_order():
+    """Non-contiguous channels group correctly and clusters keep first-seen order."""
+    clusters = channel_clusters_from_field(_msg(["B", "A", "B", "A"]), "ch", "bank")
+    assert clusters == [[0, 2], [1, 3]]  # 'B' seen first -> first cluster
+
+
+def test_single_bank():
+    clusters = channel_clusters_from_field(_msg(["A", "A", "A"]), "ch", "bank")
+    assert clusters == [[0, 1, 2]]
+
+
+def test_axis_defaults_to_last_dim():
+    """axis=None resolves to the last dimension ('ch' here)."""
+    clusters = channel_clusters_from_field(_msg(["A", "B"]), None, "bank")
+    assert clusters == [[0], [1]]
+
+
+def test_absent_field_returns_none():
+    assert channel_clusters_from_field(_msg(["A", "B"]), "ch", "nonexistent") is None
+
+
+def test_unstructured_axis_returns_none():
+    """A plain (non-structured) coordinate axis has no fields -> None."""
+    msg = AxisArray(
+        data=np.zeros((3, 2)),
+        dims=["time", "ch"],
+        axes={"ch": AxisArray.CoordinateAxis(data=np.array(["0", "1"]), dims=["ch"])},
+    )
+    assert channel_clusters_from_field(msg, "ch", "bank") is None
+
+
+def test_no_such_axis_returns_none():
+    msg = AxisArray(
+        data=np.zeros((3, 2)),
+        dims=["time", "ch"],
+        axes={"ch": AxisArray.CoordinateAxis(data=np.array(["0", "1"]), dims=["ch"])},
+    )
+    assert channel_clusters_from_field(msg, "missing_axis", "bank") is None
+
+
+def test_linear_axis_returns_none():
+    """A LinearAxis (no `.data`) yields None rather than raising."""
+    msg = AxisArray(
+        data=np.zeros((3, 2)),
+        dims=["time", "ch"],
+        axes={"time": AxisArray.TimeAxis(fs=100.0)},
+    )
+    assert channel_clusters_from_field(msg, "time", "bank") is None
+
+
+def test_length_mismatch_returns_none():
+    """Coord length != channel-dim size is treated as unusable metadata."""
+    assert channel_clusters_from_field(_msg(["A", "A"], n_data=4), "ch", "bank") is None


### PR DESCRIPTION
## Summary

Adds a way to derive per-cluster rereferencing groups from a structured field
of the channel coordinate axis, so `CommonRereference` (CAR) can rereference
within electrode banks without the caller hand-specifying index lists.

- **New helper** `ezmsg.sigproc.util.channels.channel_clusters_from_field(message, axis, field="bank")`
  — groups channel indices by a structured-axis field, returns `list[list[int]]`
  or `None` when the axis carries no usable field (so callers can fall back).
- **`CommonRereference`** gains a `cluster_by_field` setting. Precedence:
  explicit `channel_clusters` > `cluster_by_field` derivation > single
  all-channel cluster. Default `None` preserves current behavior.
- **`_hash_message`** now folds the field's bytes into the state hash on the
  `cluster_by_field` path, so cached clusters re-derive if the field's values
  change while key/channel-count don't (scoped so the common case pays nothing).

This keys off a *structured field*, not channel-name strings, so it's
independent of channel naming.

## Tests
`test_util_channels.py` (helper: grouping, first-appearance order, and every
`None` fallback) + bank-aware CAR cases in `test_affine_transform.py`. **54 pass.**