### PR TITLE
Clamp ring invariant on flush to prevent grow ValueError

### DIFF
--- a/src/ezmsg/sigproc/util/buffer.py
+++ b/src/ezmsg/sigproc/util/buffer.py
@@ -403,6 +403,8 @@ class HybridBuffer:
                 # We have wrapped around the buffer; our count of read samples
                 #  is simply the buffer capacity minus the count of unread samples.
                 self._buff_read = self._capacity - self._buff_unread
+            if self._buff_read + self._buff_unread > self._capacity:
+                self._buff_read = self._capacity - self._buff_unread
 
         self._deque.clear()
         self._deque_len = 0


### PR DESCRIPTION
## Summary

Hardens `HybridBuffer.flush()` against a ring-invariant violation that could silently kill the resampler's reference subscriber in a hub child process.

The existing wrap check misses cases where the unread region fills to capacity without tripping the pointer comparison, leaving `_buff_read + _buff_unread > _capacity`. A later `"grow"` flush then reads `total_samples > capacity` and mis-broadcasts the copy in `_grow_buffer`, raising a `ValueError`.

## Fix

Clamp `_buff_read` to `capacity - _buff_unread` immediately after the wrap check.

## Consequences (why this is safe)

- **Pure bookkeeping fix — no unread data is ever dropped.** The clamp only reduces `_buff_read` (already-consumed samples the ring retains for lookback). `_buff_unread` is never touched.
- Read-retained samples are already expendable by design: `n_free`/`n_overflow` are computed against unread-free space only, so the copy loop physically overwrites the read-retained region in every strategy whenever new data spills into it. The clamp just corrects the stale counter to match what already happened.
- **"grow"**: strict no-op in the overflow path — `_grow_buffer` expands capacity before writing, so the clamp condition is never true.
- **"raise"**: the raise is gated on unread-free space, which the clamp does not affect; the clamp is only reachable when no overflow was raised.
- **"drop" / "warn-overwrite"**: consistent with the existing overwrite contract.