### PR TITLE
Preserve buffered B data on AlignAlongAxis first-message reset

### DIFF
--- a/src/ezmsg/sigproc/align.py
+++ b/src/ezmsg/sigproc/align.py
@@ -108,8 +108,26 @@ class AlignAlongAxisProcessor(
     def _hash_message(self, message: AxisArray) -> int:
         return hash(self._extract_gain(message))
 
+    def _request_reset(self) -> None:
+        # update_settings() calls this (via the base class) when a reset-relevant
+        # setting such as buffer_dur or axis changes, and it invalidates _hash to
+        # -1. That collides with the "first message" sentinel our _reset_state
+        # keys on, so flag the intent explicitly: a requested reset must
+        # full-reset (rebuild the buffers with the new settings), never take the
+        # initialization shortcut below.
+        self._force_full_reset = True
+        super()._request_reset()
+
     def _reset_state(self, message: AxisArray) -> None:
         align_axis = self.settings.axis or message.dims[0]
+        if self._hash == -1 and not getattr(self, "_force_full_reset", False):
+            self._state.align_axis = align_axis
+            if self._state.buf_a is None:
+                self._state.buf_a = HybridAxisArrayBuffer(duration=self.settings.buffer_dur, axis=align_axis)
+            if self._state.buf_b is None:
+                self._state.buf_b = HybridAxisArrayBuffer(duration=self.settings.buffer_dur, axis=align_axis)
+            return
+        self._force_full_reset = False
         self._full_reset(align_axis)
 
     def _process(self, message: AxisArray) -> _AlignPair | None:

--- a/tests/unit/test_align.py
+++ b/tests/unit/test_align.py
@@ -97,6 +97,57 @@ class TestStaggeredArrival:
         np.testing.assert_allclose(aa_a.data, 1.0)
         np.testing.assert_allclose(aa_b.data, 99.0)
 
+    def test_b_arrives_first(self):
+        # B commonly arrives before the first A (e.g. the offline feature merge
+        # pushes sbp before rate). The first A message triggers the base class's
+        # _reset_state; it must NOT discard the B data push_b already buffered,
+        # otherwise the streams desync.
+        settings = AlignAlongAxisSettings(axis="time")
+        proc = AlignAlongAxisProcessor(settings)
+        fs = 100.0
+        chunk = 10
+
+        msg_b = _make_msg(np.ones((chunk, 3)) * 99, fs=fs, offset=0.0)
+        assert proc.push_b(msg_b) is None  # A not present yet; B buffered.
+
+        msg_a = _make_msg(np.ones((chunk, 2)) * 1, fs=fs, offset=0.0)
+        pair = proc(msg_a)  # First A: init reset must preserve buffered B.
+        assert pair is not None
+        aa_a, aa_b = pair
+        assert aa_a.data.shape == (chunk, 2)
+        assert aa_b.data.shape == (chunk, 3)
+        np.testing.assert_allclose(aa_a.data, 1.0)
+        np.testing.assert_allclose(aa_b.data, 99.0)
+
+
+class TestSettingsUpdate:
+    """update_settings() requests a reset via _hash == -1, the same sentinel
+    the first-message init path keys on. A requested reset must still rebuild
+    the buffers with the new settings rather than take the init shortcut."""
+
+    def test_update_settings_rebuilds_buffers(self):
+        settings = AlignAlongAxisSettings(axis="time", buffer_dur=10.0)
+        proc = AlignAlongAxisProcessor(settings)
+        fs = 100.0
+        chunk = 10
+
+        # Establish a running, aligned stream.
+        proc(_make_msg(np.ones((chunk, 2)), fs=fs, offset=0.0))
+        proc.push_b(_make_msg(np.ones((chunk, 3)), fs=fs, offset=0.0))
+        assert proc.state.buf_a.duration == 10.0
+
+        # Change a reset-relevant setting mid-stream. This invalidates _hash to
+        # -1 via _request_reset().
+        proc.update_settings(AlignAlongAxisSettings(axis="time", buffer_dur=30.0))
+        assert proc._hash == -1
+
+        old_buf_a = proc.state.buf_a
+        proc(_make_msg(np.ones((chunk, 2)) * 5, fs=fs, offset=chunk / fs))
+        # The requested reset must have rebuilt the buffers with the new duration,
+        # not preserved the old ones as the first-init path would.
+        assert proc.state.buf_a is not old_buf_a
+        assert proc.state.buf_a.duration == 30.0
+
 
 class TestFloatingPointOffset:
     def test_tiny_epsilon(self):


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in `AlignAlongAxisProcessor` where the first input-A message could discard B-stream data that `push_b` had already buffered, desyncing the two streams and producing a spurious `"Offset mismatch after alignment"`.

## Root cause

The base class calls `_reset_state()` on the **first** input-A message — the `_hash` transition from `-1` to the first gain hash. That is initialization, not a metadata change, but the old code ran a `_full_reset()` there, recreating `buf_b` and throwing away any B data already buffered. B commonly arrives before the first A (e.g. the offline feature merge pushes `sbp` before `rate`, and online input order isn't guaranteed).

## Fix

On the initial `_reset_state` call, only ensure the buffers/axis exist and **preserve their contents**. A genuine later gain change still `_full_reset()`s.

### Sentinel disambiguation

`_hash == -1` is not unique to first-init: `update_settings()` also sets it to `-1` via `_request_reset()` when a reset-relevant setting (`buffer_dur`, `axis`) changes. Left unguarded, the init shortcut would swallow that requested reset and the new settings would silently not take effect. The `_request_reset()` override flags the intent (`_force_full_reset`) so a requested reset always rebuilds the buffers.

## Consequences

- Pure win for the B-before-A ordering: buffered B data is retained and aligned instead of dropped.
- A genuine gain change (`_hash` already set to a real hash) still full-resets — unchanged.
- `update_settings()` still rebuilds buffers with the new duration/axis — preserved by the `_request_reset` override.

## Tests

- `test_b_arrives_first` — B buffered before the first A; the pair survives. Fails on baseline, passes with the fix.
- `test_update_settings_rebuilds_buffers` — a mid-stream `buffer_dur` change rebuilds the buffers. Fails against init-shortcut-without-hardening, passes with the `_request_reset` override.

All 10 align unit tests pass.