### PR TITLE
Raise informative errors for CWT misuse instead of opaque crashes

### DIFF
--- a/src/ezmsg/sigproc/filterbank.py
+++ b/src/ezmsg/sigproc/filterbank.py
@@ -110,6 +110,13 @@ class FilterbankTransformer(BaseStatefulTransformer[FilterbankSettings, AxisArra
 
         kernels = self.settings.kernels
         if self.settings.min_phase != MinPhaseMode.NONE:
+            if any(np.iscomplexobj(k) for k in kernels):
+                raise ValueError(
+                    "min_phase conversion is not supported for complex kernels: "
+                    "scipy.signal.minimum_phase only accepts real filters. Complex/analytic "
+                    "wavelets (e.g. 'cmor') cannot be min-phased; use MinPhaseMode.NONE or a "
+                    "real wavelet/kernel."
+                )
             method, half = {
                 MinPhaseMode.HILBERT: ("hilbert", False),
                 MinPhaseMode.HOMOMORPHIC: ("homomorphic", False),

--- a/src/ezmsg/sigproc/wavelets.py
+++ b/src/ezmsg/sigproc/wavelets.py
@@ -53,6 +53,12 @@ class CWTTransformer(BaseStatefulTransformer[CWTSettings, AxisArray, AxisArray, 
         )
 
     def _reset_state(self, message: AxisArray) -> None:
+        if "freq" in message.dims:
+            raise ValueError(
+                "CWT appends a 'freq' axis to its output, but the input already has one "
+                f"(dims={message.dims}). CWT expects a time-domain input; if the upstream "
+                "node emits spectral data, remove or rename its 'freq' axis first."
+            )
         precision = 10
 
         # Process wavelet

--- a/tests/unit/test_wavelets.py
+++ b/tests/unit/test_wavelets.py
@@ -141,3 +141,50 @@ def test_cwt():
         axes[2, ch_ix].set_yscale("log")
     plt.show()
     """
+
+
+def test_cwt_rejects_input_with_freq_axis():
+    """Regression for #41: an input that already carries a 'freq' dim used to
+    crash with an opaque 'dims contains repeated dim names'."""
+    import pytest
+
+    msg = AxisArray(
+        data=np.zeros((3, 2, 100)),
+        dims=["freq", "ch", "time"],
+        axes={
+            "freq": AxisArray.LinearAxis(unit="Hz", offset=0.0, gain=1.0),
+            "ch": AxisArray.CoordinateAxis(data=np.array(["Ch0", "Ch1"]), dims=["ch"]),
+            "time": AxisArray.TimeAxis(fs=1000.0, offset=0.0),
+        },
+        key="test_cwt_freq_input",
+    )
+    proc = CWTTransformer(CWTSettings(frequencies=None, scales=np.geomspace(4, 64, num=8), wavelet="morl", axis="time"))
+    with pytest.raises(ValueError, match="already has"):
+        proc(msg)
+
+
+def test_cwt_complex_wavelet_min_phase_informative_error():
+    """Regression for #41: complex/analytic wavelet + min_phase used to bubble
+    up scipy's bare 'Complex filters not supported'."""
+    import pytest
+
+    msg = AxisArray(
+        data=np.zeros((2, 100)),
+        dims=["ch", "time"],
+        axes={
+            "ch": AxisArray.CoordinateAxis(data=np.array(["Ch0", "Ch1"]), dims=["ch"]),
+            "time": AxisArray.TimeAxis(fs=1000.0, offset=0.0),
+        },
+        key="test_cwt_cmor_minphase",
+    )
+    proc = CWTTransformer(
+        CWTSettings(
+            frequencies=None,
+            scales=np.geomspace(4, 64, num=8),
+            wavelet="cmor3.0-0.5",
+            min_phase=MinPhaseMode.HOMOMORPHIC,
+            axis="time",
+        )
+    )
+    with pytest.raises(ValueError, match="[Cc]omplex.*min[_ ]phase|min_phase.*complex"):
+        proc(msg)


### PR DESCRIPTION
Closes #41.

Both failure modes from the issue are unchanged in current code and fail deep inside internals with messages that don't point at the actual problem. This PR adds two early guards:

1. **`CWTTransformer` rejects input that already carries a `freq` dim.** Previously this crashed in `AxisArray` with `dims contains repeated dim names`; now it explains that CWT appends a `freq` axis and expects time-domain input.
2. **`filterbank` rejects complex kernels when `min_phase != NONE`.** Previously scipy raised a bare `Complex filters not supported`; now the error explains that `scipy.signal.minimum_phase` only accepts real filters, so complex/analytic wavelets (e.g. `cmor`) cannot be min-phased — use `MinPhaseMode.NONE` or a real wavelet.

Both scenarios from the original report have regression tests.