### PR TITLE
De-hang resample-merge system tests: arm idle terminator at startup + absolute watchdog

### DIFF
--- a/tests/integration/ezmsg/test_resample_merge_system.py
+++ b/tests/integration/ezmsg/test_resample_merge_system.py
@@ -19,6 +19,7 @@ non-monotonic reference clock, e.g. from a misbehaving simulator).
 
 import asyncio
 import os
+import time
 import typing
 from pathlib import Path
 
@@ -37,6 +38,17 @@ from tests.helpers.util import get_test_fn
 CHUNK = 30
 N_CHUNKS = 60
 FS = 1000.0
+
+
+class ArmedTerminateOnTimeout(TerminateOnTimeout):
+    """TerminateOnTimeout arms its idle timer only on the first received message;
+    a graph that never produces output therefore never terminates (the hubs stay
+    alive by design, so there is no other exit path and CI hangs). Arm the timer
+    at startup so an all-idle graph still tears down after ``time`` seconds and
+    the test fails on its assertions instead of hanging."""
+
+    async def initialize(self) -> None:
+        self.STATE.last_msg_timestamp = time.time()
 
 
 class HubSettings(ez.Settings):
@@ -103,8 +115,14 @@ def _run(comps: dict, conns: tuple, output_stream, fn: Path) -> tuple[int, int, 
     # stall on a loaded CI runner -- if a transient stall opens an output gap
     # longer than `time` mid-stream, the graph is torn down early and the output
     # is truncated. 2.0 s was too tight on Windows CI; 4.0 s gives headroom.
-    term = TerminateOnTimeout(TerminateOnTimeoutSettings(time=4.0))
-    comps = {**comps, "LOG": log, "TERM": term}
+    # (Armed at startup, so it also covers the zero-output case.)
+    term = ArmedTerminateOnTimeout(TerminateOnTimeoutSettings(time=4.0))
+    # Absolute-deadline watchdog: no input is connected, so its armed timer is
+    # never refreshed and it unconditionally ends the graph after 30 s. A full
+    # run terminates via `term` in well under 10 s, so this only fires if the
+    # graph is wired in a way that defeats the idle terminator.
+    watchdog = ArmedTerminateOnTimeout(TerminateOnTimeoutSettings(time=30.0))
+    comps = {**comps, "LOG": log, "TERM": term, "WATCHDOG": watchdog}
     conns = (
         *conns,
         (output_stream, log.INPUT_MESSAGE),


### PR DESCRIPTION
Fixes the semi-frequent CI hangs on `test_resample_merge_system.py`.

## Root cause

`TerminateOnTimeout.poll_terminate` only checks the idle gap once `last_msg_timestamp` is set — i.e. **the idle timer arms only on the first received message**. The hubs in these tests deliberately never complete (`while True: await asyncio.sleep(0.1)`, from the earlier de-flake, so a seized graph is distinguishable from exhausted input), which leaves the idle terminator as the graph's only exit path. But it is fed from the **merged output**: a run that produces zero output messages never arms the timer, and `ez.run` blocks until the CI job timeout.

Zero-output runs are timing-dependent and exactly what these tests court: the seize test's glitch lands ~30 ms in, and on a loaded runner the resampler warmup + merge alignment can lose the race, so no merged message precedes the seize. That matches the semi-frequent, CI-only signature.

## Fix (belt and suspenders)

1. `ArmedTerminateOnTimeout` — sets `last_msg_timestamp` in `initialize()`, so an all-idle graph tears down after the 4 s idle window and the test **fails on its assertions** (`n_msgs > 0` / `last_t = -inf`) instead of hanging for hours.
2. An unconnected armed terminator as a **30 s absolute deadline** per graph run, in case future wiring defeats the idle terminator. A full run terminates via the idle path in well under 10 s, so it never fires in healthy runs.

If the seize test ever *fails* on a slow runner post-fix (zero output before the glitch), the remedy is a later `glitch_at` or larger `dispatch_dt` — visible failure beats a silent hang.

Worth considering upstream: `TerminateOnTimeout` arming at startup in `ezmsg.util.terminate` itself — an idle terminator that cannot fire from the all-idle state is a footgun for any graph shaped like this one.

All 4 tests pass locally (~18.5 s total).