### PR TITLE
Dual-timescale EWMA: recover from mid-stream level shifts (scaler, detrend)

### DIFF
--- a/src/ezmsg/sigproc/ewma.py
+++ b/src/ezmsg/sigproc/ewma.py
@@ -175,6 +175,27 @@ class EWMASettings(ez.Settings):
     baseline estimate -- passthrough leaves the data untouched. May be toggled
     at runtime without resetting the filter state."""
 
+    fast_time_constant: float | None = None
+    """Enable dual-timescale level-shift tracking (default None = off). A cheap
+    secondary estimate with this (shorter) time constant is updated once per
+    chunk from the chunk mean; when it diverges from the main estimate by more
+    than ``shift_threshold`` * (within-chunk residual std) for
+    ``shift_hysteresis`` consecutive chunks, the main estimate snaps to it,
+    per channel. This lets the estimate recover from a sudden but persistent
+    level shift (reference change, impedance step) in a couple of chunks
+    instead of ~3*``time_constant``. Detection and snapping are elementwise
+    operations on state at chunk boundaries -- no extra per-sample scan."""
+
+    shift_threshold: float = 4.0
+    """Divergence threshold for the level-shift detector, in multiples of the
+    within-chunk residual standard deviation. Only used when
+    ``fast_time_constant`` is set."""
+
+    shift_hysteresis: int = 2
+    """Number of consecutive divergent chunks required before the main
+    estimate snaps to the fast estimate. Only used when ``fast_time_constant``
+    is set."""
+
 
 @processor_state
 class EWMAState:
@@ -182,6 +203,13 @@ class EWMAState:
     zi: npt.NDArray | None = None
     n_seen: int = 0
     """Cumulative sample count since reset, used to bias-correct the output."""
+
+    alpha_fast: float | None = None
+    fast_est: npt.NDArray | None = None
+    """Chunk-rate fast estimate for the level-shift detector (seeded from the
+    first chunk's mean, so no bias correction is needed)."""
+    shift_run: npt.NDArray | None = None
+    """Per-channel count of consecutive divergent chunks."""
 
 
 class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray, EWMAState]):
@@ -215,6 +243,10 @@ class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray
         xp = np if is_numpy_array(message.data) else get_namespace(message.data)
         self._state.zi = xp.zeros_like(sub_dat)
         self._state.n_seen = 0
+        if self.settings.fast_time_constant is not None:
+            self._state.alpha_fast = _alpha_from_tau(self.settings.fast_time_constant, message.axes[axis].gain)
+            self._state.fast_est = None
+            self._state.shift_run = xp.zeros_like(sub_dat)
 
     def _process(self, message: AxisArray) -> AxisArray:
         axis = self.settings.axis or message.dims[0]
@@ -258,7 +290,41 @@ class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray
         expected = expected / xp.asarray(corr, dtype=expected.dtype)
         if self.settings.accumulate:
             self._state.n_seen += n
+            if self.settings.fast_time_constant is not None:
+                self._update_shift_detector(message.data, expected, axis_idx, xp)
         return replace(message, data=expected)
+
+    def _update_shift_detector(self, data, expected, axis_idx: int, xp) -> None:
+        """Dual-timescale level-shift detection (chunk-boundary state ops only).
+
+        A fast estimate is advanced once per chunk by the chunk's effective
+        forgetting factor. Sustained divergence between the fast and main
+        estimates -- large relative to the chunk's own residual scatter --
+        marks a persistent level shift; the main estimate then snaps to the
+        fast one, per channel, and continues with its own time constant.
+        """
+        n = data.shape[axis_idx]
+        chunk_mean = xp.mean(data, axis=axis_idx, keepdims=True)
+        if self._state.fast_est is None:
+            self._state.fast_est = chunk_mean
+            return
+        beta_fast = (1.0 - self._state.alpha_fast) ** n
+        self._state.fast_est = beta_fast * self._state.fast_est + (1.0 - beta_fast) * chunk_mean
+
+        resid = data - chunk_mean
+        resid_std = xp.sqrt(xp.mean(resid * resid, axis=axis_idx, keepdims=True))
+        slow_est = slice_along_axis(expected, slice(-1, None), axis=axis_idx)
+        diverged = xp.abs(self._state.fast_est - slow_est) > self.settings.shift_threshold * resid_std
+        zeros = xp.zeros_like(self._state.shift_run)
+        self._state.shift_run = xp.where(diverged, self._state.shift_run + 1, zeros)
+
+        snap = self._state.shift_run >= self.settings.shift_hysteresis
+        # Set the scan state such that the bias-corrected main estimate equals
+        # the fast estimate: y_corr = zi / ((1-alpha) * (1-(1-alpha)^t)).
+        corr_t = 1.0 - (1.0 - self._state.alpha) ** self._state.n_seen
+        zi_snap = (1.0 - self._state.alpha) * corr_t * self._state.fast_est
+        self._state.zi = xp.where(snap, zi_snap, self._state.zi)
+        self._state.shift_run = xp.where(snap, zeros, self._state.shift_run)
 
 
 class EWMAUnit(BaseTransformerUnit[EWMASettings, AxisArray, AxisArray, EWMATransformer]):

--- a/src/ezmsg/sigproc/scaler.py
+++ b/src/ezmsg/sigproc/scaler.py
@@ -127,16 +127,19 @@ class AdaptiveStandardScalerTransformer(
         super().update_settings(new_settings)
 
     def _reset_state(self, message: AxisArray) -> None:
-        self._state.samps_ewma = EWMATransformer(
+        # Each child gets its own level-shift detector (when enabled): a
+        # persistent shift moves both the mean and E[x^2], and their detectors
+        # operate on their respective inputs (x and x^2).
+        child_kwargs = dict(
             time_constant=self.settings.time_constant,
             axis=self.settings.axis,
             accumulate=self.settings.accumulate,
+            fast_time_constant=self.settings.fast_time_constant,
+            shift_threshold=self.settings.shift_threshold,
+            shift_hysteresis=self.settings.shift_hysteresis,
         )
-        self._state.vars_sq_ewma = EWMATransformer(
-            time_constant=self.settings.time_constant,
-            axis=self.settings.axis,
-            accumulate=self.settings.accumulate,
-        )
+        self._state.samps_ewma = EWMATransformer(**child_kwargs)
+        self._state.vars_sq_ewma = EWMATransformer(**child_kwargs)
 
     @property
     def accumulate(self) -> bool:

--- a/tests/unit/test_ewma.py
+++ b/tests/unit/test_ewma.py
@@ -418,3 +418,103 @@ def test_ewma_bias_correction_survives_chunking():
         parts.append(chunked(mk(c, n)).data)
         n += c.shape[0]
     np.testing.assert_allclose(np.concatenate(parts, axis=0), single, rtol=1e-10, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Dual-timescale level-shift tracking (issue #168)
+# ---------------------------------------------------------------------------
+
+_SHIFT_FS = 100.0
+_SHIFT_CHUNK = 20
+
+
+def _stream_shift(proc, mu_fn, sd_fn, n_chunks=30, n_ch=2, seed=0):
+    """Feed chunks with per-chunk per-channel mean/std; return (time, ch) output."""
+    rng = np.random.default_rng(seed)
+    outs = []
+    for i in range(n_chunks):
+        mu = np.broadcast_to(np.asarray(mu_fn(i), dtype=float), (n_ch,))
+        sd = np.broadcast_to(np.asarray(sd_fn(i), dtype=float), (n_ch,))
+        d = rng.normal(mu, sd, size=(_SHIFT_CHUNK, n_ch))
+        msg = AxisArray(
+            data=d,
+            dims=["time", "ch"],
+            axes={
+                "time": AxisArray.TimeAxis(fs=_SHIFT_FS, offset=i * _SHIFT_CHUNK / _SHIFT_FS),
+                "ch": AxisArray.CoordinateAxis(data=np.arange(n_ch).astype(str), dims=["ch"]),
+            },
+            key="test_shift",
+        )
+        outs.append(proc(msg).data)
+    return np.concatenate(outs, axis=0)
+
+
+def _shift_proc(fast_tc):
+    return EWMATransformer(time_constant=10.0, axis="time", accumulate=True, fast_time_constant=fast_tc)
+
+
+def test_ewma_level_shift_snap():
+    """A sustained level shift snaps the estimate to the new level within a few
+    chunks; with the detector off, the estimate lags for ~time_constant."""
+
+    def mu(i):
+        return 10.0 if i >= 10 else 0.0
+
+    def sd(i):
+        return 0.1
+
+    out_on = _stream_shift(_shift_proc(0.05), mu, sd)
+    out_off = _stream_shift(_shift_proc(None), mu, sd)
+
+    # Detector on: recovered to the new level within 3 chunks of the shift.
+    assert np.all(np.abs(out_on[13 * _SHIFT_CHUNK :] - 10.0) < 0.5)
+    # Detector off: still far from the new level at the end of the stream.
+    assert np.all(np.abs(out_off[-1] - 10.0) > 2.0)
+
+
+def test_ewma_level_shift_snap_per_channel():
+    """Only the shifted channel snaps; the other channel's output is untouched
+    (bit-identical to a detector-off run on the same data)."""
+
+    def mu(i):
+        return [0.0, 10.0] if i >= 10 else [0.0, 0.0]
+
+    def sd(i):
+        return 0.1
+
+    out_on = _stream_shift(_shift_proc(0.05), mu, sd)
+    out_off = _stream_shift(_shift_proc(None), mu, sd)
+
+    np.testing.assert_array_equal(out_on[:, 0], out_off[:, 0])
+    assert np.abs(out_on[-1, 1] - 10.0) < 0.5
+    assert np.abs(out_off[-1, 1] - 10.0) > 2.0
+
+
+def test_ewma_no_snap_when_stationary():
+    """With no shift, the detector never fires: output is bit-identical to the
+    detector-off output."""
+
+    def mu(i):
+        return 0.0
+
+    def sd(i):
+        return 0.5
+
+    out_on = _stream_shift(_shift_proc(0.05), mu, sd)
+    out_off = _stream_shift(_shift_proc(None), mu, sd)
+    np.testing.assert_array_equal(out_on, out_off)
+
+
+def test_ewma_no_snap_on_variance_burst():
+    """A variance-only artifact (no level change) inflates the within-chunk
+    residual std, so the detector does not fire."""
+
+    def mu(i):
+        return 0.0
+
+    def sd(i):
+        return 5.0 if i >= 10 else 0.1
+
+    out_on = _stream_shift(_shift_proc(0.05), mu, sd)
+    out_off = _stream_shift(_shift_proc(None), mu, sd)
+    np.testing.assert_array_equal(out_on, out_off)

--- a/tests/unit/test_scaler.py
+++ b/tests/unit/test_scaler.py
@@ -539,7 +539,9 @@ def test_scaler_bias_correction_survives_chunking():
     data = rng.normal(0.0, 1.0, size=(151, 2))
 
     def mk(d, offset):
-        return AxisArray(d, dims=["time", "ch"], axes=frozendict({"time": AxisArray.TimeAxis(fs=fs, offset=offset / fs)}))
+        return AxisArray(
+            d, dims=["time", "ch"], axes=frozendict({"time": AxisArray.TimeAxis(fs=fs, offset=offset / fs)})
+        )
 
     single = AdaptiveStandardScalerTransformer(time_constant=tau, axis="time")(mk(data, 0)).data
     chunked = AdaptiveStandardScalerTransformer(time_constant=tau, axis="time")
@@ -548,3 +550,44 @@ def test_scaler_bias_correction_survives_chunking():
         parts.append(chunked(mk(c, n)).data)
         n += c.shape[0]
     np.testing.assert_allclose(np.concatenate(parts, axis=0), single, atol=1e-10)
+
+
+def test_scaler_recovers_after_level_shift():
+    """Dual-timescale tracking (issue #168): after a sudden persistent level
+    shift, the scaler's z-scores re-center within a few chunks; without it,
+    they stay biased for ~time_constant."""
+    fs, chunk, n_ch = 100.0, 20, 2
+
+    def _run(fast_tc):
+        proc = AdaptiveStandardScalerTransformer(
+            settings=AdaptiveStandardScalerSettings(time_constant=10.0, axis="time", fast_time_constant=fast_tc)
+        )
+        outs = []
+        for i in range(40):
+            mu = 50.0 if i >= 20 else 0.0
+            d = np.random.default_rng(100 + i).normal(mu, 1.0, size=(chunk, n_ch))
+            msg = AxisArray(
+                data=d,
+                dims=["time", "ch"],
+                axes={
+                    "time": AxisArray.TimeAxis(fs=fs, offset=i * chunk / fs),
+                    "ch": AxisArray.CoordinateAxis(data=np.arange(n_ch).astype(str), dims=["ch"]),
+                },
+                key="test_scaler_shift",
+            )
+            outs.append(proc(msg).data)
+        return np.concatenate(outs, axis=0)
+
+    z_on = _run(0.05)
+    z_off = _run(None)
+
+    # Signed mean z over the last 10 chunks. Without tracking, the lagging mean
+    # biases every z-score in the same direction while the lagging second
+    # moment inflates the std (dominated by the offset^2 mismatch), yielding a
+    # systematic one-sided z ~ +1 -- the PR #166 "feature collapse" signature.
+    # With tracking, both statistics snap and z re-centers on 0.
+    tail = slice(30 * chunk, None)
+    assert np.abs(z_on[tail].mean()) < 0.3, f"expected re-centered z-scores, got mean z {z_on[tail].mean():.2f}"
+    assert (
+        z_off[tail].mean() > 0.7
+    ), f"expected one-sided biased z-scores without tracking, got {z_off[tail].mean():.2f}"


### PR DESCRIPTION
Closes #168.

## Problem

Bias correction (#166) fixed cold start, but a sudden **persistent** level shift mid-stream (reference change, electrode impedance step, amplifier re-lock) still biases the EWMA — and downstream z-scores — for ~3·`time_constant`. In the scaler this reproduces the #166 collapse signature mid-session: the lagging mean biases every z-score one direction while the lagging second moment inflates the std, so features sit at a systematic z ≈ ±1 until the EWMA re-converges.

## Design (as proposed in #168, decimated-detector variant)

Opt-in via `EWMASettings.fast_time_constant` (default `None` = off; detector-off output is **bit-identical** to before):

- A **fast estimate** is advanced once per chunk from the chunk mean, using the chunk's effective forgetting factor `(1-α_fast)^n` — no second per-sample scan, so the full-rate cost is unchanged.
- **Divergence test** at each chunk boundary: `|fast − slow| > shift_threshold · (within-chunk residual std)`, with `shift_hysteresis` consecutive divergent chunks required (default 4·std, 2 chunks).
- **Per-channel snap** via `xp.where`: the main estimate's scan state is set so its bias-corrected value equals the fast estimate; it then continues with its own time constant. A single stepping electrode doesn't disturb the other channels.
- All detector work is elementwise on state at chunk boundaries (`mean`/`sqrt`/`abs`/`where`) — **Array API portable**, verified numpy/MLX parity to float32 tolerance.

Normalizing by the within-chunk residual std makes the detector robust to variance-only artifacts: a noise burst inflates the denominator, so no snap (asserted bit-identical in tests).

## Scope

- `EWMATransformer`: detector + snap.
- `AdaptiveStandardScaler`: propagates the settings to both child EWMAs (mean and E[x²] snap on their respective inputs) — z-scores re-center within a few chunks of a shift.
- `Detrend`: inherits through `EWMATransformer`, nothing to change.

## Tests

- Level shift: snapped estimate reaches the new level within 3 chunks; detector-off lags to end of stream.
- Per-channel: un-shifted channel bit-identical to detector-off run; shifted channel snaps.
- Stationary and variance-burst streams: bit-identical to detector-off (no false snaps).
- Scaler: signed mean z re-centers (<0.3) vs. systematic one-sided bias (>0.7) without tracking.

## Defaults / tuning

`shift_threshold=4.0` and `shift_hysteresis=2` are conservative first choices; both only matter when `fast_time_constant` is set. Blend-instead-of-hard-snap and a shared (rather than per-child) detector for the scaler were considered and deferred — noted as follow-ups in #168 if needed.