### PR TITLE
Accept zero-output as a valid seize in the recovery-disabled resample-merge test

### DIFF
--- a/tests/integration/ezmsg/test_resample_merge_system.py
+++ b/tests/integration/ezmsg/test_resample_merge_system.py
@@ -218,7 +218,7 @@ def test_resample_merge_seizes_when_recovery_disabled_system(test_name: str | No
     large sustained backward offset jump pushes the reference permanently below the
     resampler's high-water mark and the merged output ceases well before input is exhausted.
     """
-    n_msgs, _, _, last_t = _run_resample_merge(
+    _, _, _, last_t = _run_resample_merge(
         glitch_at=15,
         glitch_back=100.0,
         reset_after=float("inf"),
@@ -228,8 +228,12 @@ def test_resample_merge_seizes_when_recovery_disabled_system(test_name: str | No
     # Output ceases at the chunk-15 glitch, so the last emitted sample sits near
     # 15*30/1000 = 0.45 s; a recovered/healthy run reaches >= 0.799 s. Assert on
     # last sample time (see _run) -- it isolates "output stopped early" from the
-    # variable amount of data dropped. n_msgs > 0 is a liveness sanity.
-    assert n_msgs > 0 and last_t < 0.6, f"Expected output to cease near the chunk-15 glitch, got {last_t:.3f} s."
+    # variable amount of data dropped. Zero output (last_t == -inf) also
+    # satisfies the property under test: on a loaded runner the pipeline's
+    # warmup can lose the race with the seize, so the graph ceases before its
+    # *first* emission. Liveness of the wiring itself is covered by
+    # test_resample_merge_healthy_system on the identical graph.
+    assert last_t < 0.6, f"Expected output to cease near the chunk-15 glitch, got {last_t:.3f} s."
 
 
 def test_resample_merge_recovers_with_output_reference_system(test_name: str | None = None):


### PR DESCRIPTION
Follow-up to #172, fixing the CI failure observed on PR #173 (Windows runner).

## What happened

Exactly the failure mode anticipated in #172's description, converted from a silent multi-hour hang into a visible 4-second failure: under heavy runner load (both hubs logged `under subscriber backpressure`), the resampler's warmup lost the race with the chunk-15 seize. The reference jumped backward before the first merged message was ever emitted, the armed idle terminator tore the graph down, and the test failed with `n_msgs = 0`, `last_t = -inf`.

## Why relaxing the assertion is the right fix (not later glitch_at / slower dispatch)

The property this test documents is: *with recovery disabled, output ceases and never reaches the end of the stream*. Zero output **is** that property — the seize simply won before the first emission. Retiming the schedule (`glitch_at`/`dispatch_dt`) would only shrink the race window, leaving the flake in place for a sufficiently loaded runner.

The `n_msgs > 0` conjunct was a liveness sanity, but it is redundant: `test_resample_merge_healthy_system` proves liveness of the identical wiring (no glitch) and asserts the stream reaches ~1.8 s. A regression that silenced the pipeline entirely would fail there.

The seize upper bound (`last_t < 0.6`) is unchanged, so a run where recovery *does* happen (output past the glitch) still fails.

All 4 tests pass locally. After merge, re-running #173's checks should clear it — the flake is in dev's test, not that PR's code.