### PR TITLE
Slicer: support structured coordinate axes and field-based selection

### DIFF
--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -22,9 +22,43 @@ Slicer:Select a subset of data along a particular axis.
 """
 
 
+def _axis_labels(
+    axinfo: AxisArray.CoordinateAxis | None,
+    field: str | None = None,
+) -> npt.NDArray | None:
+    """Return the per-index label values of a coordinate axis, or None if it has none.
+
+    A structured ``.data`` (e.g. ezmsg-blackrock's ChannelMap ``ch`` axis, with
+    fields like ``x``/``y``/``label``/``bank``) contributes one of its fields,
+    stringified so selection tokens can match non-string fields like ``bank``.
+    Comparing a structured array against a string raises a TypeError in numpy,
+    so it must never be matched against directly.
+
+    ``field=None`` means "the ``label`` field, if present" and degrades to None
+    (no usable labels) otherwise. An explicit ``field`` is a user commitment:
+    a missing field or non-structured axis raises instead of silently falling
+    back to positional indexing.
+    """
+    data = getattr(axinfo, "data", None)
+    names = getattr(getattr(data, "dtype", None), "names", None)
+    if field is not None:
+        if names is None:
+            raise ValueError(
+                f"Selection field {field!r} requires the target axis to have structured "
+                f"coordinate data, but it has {'no coordinate data' if data is None else 'unstructured data'}."
+            )
+        if field not in names:
+            raise ValueError(f"Axis data has no field {field!r}; available fields: {list(names)}.")
+        return data[field].astype(str)
+    if names is not None:
+        return data["label"].astype(str) if "label" in names else None
+    return data
+
+
 def parse_slice(
     s: str,
     axinfo: AxisArray.CoordinateAxis | None = None,
+    field: str | None = None,
 ) -> tuple[slice | int, ...]:
     """
     Parses a string representation of a slice and returns a tuple of slice objects.
@@ -40,13 +74,22 @@ def parse_slice(
       Each value is first compared against the axis labels for an exact match; failing
       that, it is treated as a regular expression and full-matched against the labels
       (e.g. "C[34]" or "Ch.*"). Note: tokens containing ":" are parsed as slices, so
-      regexes may not contain ":".
+      regexes may not contain ":". If the axis ``.data`` is a structured array, its
+      "label" field supplies the labels; a structured array without a "label" field
+      supports only integer/slice selections.
+    - If `field` is provided, tokens are matched against that field of the structured
+      axis data (stringified, so numeric fields like "bank" work). This disables the
+      bare-integer positional fallback: "3" means field value "3", not index 3.
+      Positional selection remains available via slice syntax (e.g. "3:4").
 
     Args:
         s: The string representation of the slice.
         axinfo: (Optional) If provided, and of type CoordinateAxis,
           and `s` is a comma-separated list of values, then the values
           in s will be matched (exactly, then as regex) against the values in axinfo.data.
+        field: (Optional) Which field of a structured `axinfo.data` to match tokens
+          against. None uses the "label" field when present. An explicit field raises
+          ValueError if the axis data is missing, unstructured, or lacks that field.
 
     Returns:
         A tuple of slice objects and/or ints.
@@ -56,23 +99,26 @@ def parse_slice(
     if "," not in s:
         parts = [part.strip() for part in s.split(":")]
         if len(parts) == 1:
-            if axinfo is not None and hasattr(axinfo, "data") and parts[0] in axinfo.data:
-                return tuple(np.where(axinfo.data == parts[0])[0])
-            try:
-                return (int(parts[0]),)
-            except ValueError:
-                if axinfo is not None and hasattr(axinfo, "data"):
-                    pattern = re.compile(parts[0])
-                    hits = tuple(ix for ix, label in enumerate(axinfo.data) if pattern.fullmatch(str(label)))
-                    if hits:
-                        return hits
-                    raise ValueError(
-                        f"Selection {parts[0]!r} matched no labels on the target axis "
-                        f"(neither exactly nor as a regex)."
-                    ) from None
-                raise
+            labels = _axis_labels(axinfo, field=field)
+            if labels is not None and parts[0] in labels:
+                return tuple(np.where(labels == parts[0])[0])
+            if field is None:
+                try:
+                    return (int(parts[0]),)
+                except ValueError:
+                    if labels is None:
+                        raise
+            pattern = re.compile(parts[0])
+            hits = tuple(ix for ix, label in enumerate(labels) if pattern.fullmatch(str(label)))
+            if hits:
+                return hits
+            raise ValueError(
+                f"Selection {parts[0]!r} matched no "
+                f"{'labels' if field is None else f'values in field {field!r}'} "
+                f"on the target axis (neither exactly nor as a regex)."
+            ) from None
         return (slice(*(int(part.strip()) if part else None for part in parts)),)
-    suplist = [parse_slice(_, axinfo=axinfo) for _ in s.split(",")]
+    suplist = [parse_slice(_, axinfo=axinfo, field=field) for _ in s.split(",")]
     return tuple([item for sublist in suplist for item in sublist])
 
 
@@ -82,6 +128,13 @@ class SlicerSettings(ez.Settings):
 
     axis: str | None = None
     """The name of the axis to slice along. If None, the last axis is used."""
+
+    field: str | None = None
+    """Which field of a structured coordinate axis to match selection values against
+    (e.g. "bank", "elec"). If None, the "label" field is used when present. Setting
+    this explicitly makes selection tokens mean field values only — bare integers are
+    no longer positional indices (use slice syntax like "3:4" for positions) — and
+    raises an error if the axis has no such field."""
 
 
 @processor_state
@@ -104,7 +157,7 @@ class SlicerTransformer(BaseStatefulTransformer[SlicerSettings, AxisArray, AxisA
         self._state.b_change_dims = False
 
         # Calculate the slice
-        _slices = parse_slice(self.settings.selection, message.axes.get(axis, None))
+        _slices = parse_slice(self.settings.selection, message.axes.get(axis, None), field=self.settings.field)
         if len(_slices) == 1:
             self._state.slice_ = _slices[0]
             self._state.b_change_dims = isinstance(self._state.slice_, int)
@@ -144,15 +197,17 @@ class Slicer(BaseTransformerUnit[SlicerSettings, AxisArray, AxisArray, SlicerTra
     SETTINGS = SlicerSettings
 
 
-def slicer(selection: str = "", axis: str | None = None) -> SlicerTransformer:
+def slicer(selection: str = "", axis: str | None = None, field: str | None = None) -> SlicerTransformer:
     """
     Slice along a particular axis.
 
     Args:
         selection: See :obj:`ezmsg.sigproc.slicer.parse_slice` for details.
         axis: The name of the axis to slice along. If None, the last axis is used.
+        field: Which field of a structured coordinate axis to match selection values
+          against. See :obj:`SlicerSettings` for details.
 
     Returns:
         :obj:`SlicerTransformer`
     """
-    return SlicerTransformer(SlicerSettings(selection=selection, axis=axis))
+    return SlicerTransformer(SlicerSettings(selection=selection, axis=axis, field=field))

--- a/tests/unit/test_slicer.py
+++ b/tests/unit/test_slicer.py
@@ -169,6 +169,104 @@ def test_parse_slice_regex():
         parse_slice("C[34z]")
 
 
+def _structured_ch_axis(labels: list[str]) -> AxisArray.CoordinateAxis:
+    """Build a ChannelMap-style structured coordinate axis (x/y/label/bank fields)."""
+    dt = np.dtype([("x", float), ("y", float), ("label", "U8"), ("bank", int)])
+    data = np.array([(float(ix % 2), float(ix // 2), lab, ix // 4) for ix, lab in enumerate(labels)], dtype=dt)
+    return AxisArray.CoordinateAxis(data=data, dims=["ch"])
+
+
+def test_parse_slice_structured_axis():
+    ax = _structured_ch_axis(["Fp1", "Fp2", "C3", "C4", "Cz", "O1", "O2"])
+    # Labels come from the "label" field: exact match, then regex.
+    assert parse_slice("C3", axinfo=ax) == (2,)
+    assert parse_slice("C[34z]", axinfo=ax) == (2, 3, 4)
+    assert parse_slice("O.*, C3", axinfo=ax) == (5, 6, 2)
+    # Integer and slice selections must not trip on the structured dtype.
+    assert parse_slice("5", axinfo=ax) == (5,)
+    assert parse_slice("1, 3:5", axinfo=ax) == (1, slice(3, 5))
+    with pytest.raises(ValueError, match="matched no labels"):
+        parse_slice("Fp", axinfo=ax)
+
+    # A structured axis without a "label" field supports only integer/slice selections.
+    dt = np.dtype([("x", float), ("y", float)])
+    ax_nolabel = AxisArray.CoordinateAxis(data=np.zeros(4, dtype=dt), dims=["ch"])
+    assert parse_slice("2", axinfo=ax_nolabel) == (2,)
+    with pytest.raises(ValueError):
+        parse_slice("C3", axinfo=ax_nolabel)
+
+
+def test_parse_slice_explicit_field():
+    # Banks: [0, 0, 0, 0, 1, 1, 1] (see _structured_ch_axis: ix // 4)
+    ax = _structured_ch_axis(["Fp1", "Fp2", "C3", "C4", "Cz", "O1", "O2"])
+    # Tokens match field values (stringified ints), not positions.
+    assert parse_slice("0", axinfo=ax, field="bank") == (0, 1, 2, 3)
+    assert parse_slice("1", axinfo=ax, field="bank") == (4, 5, 6)
+    assert parse_slice("1, 0", axinfo=ax, field="bank") == (4, 5, 6, 0, 1, 2, 3)
+    # With an explicit field there is no positional-int fallback.
+    with pytest.raises(ValueError, match="matched no values in field 'bank'"):
+        parse_slice("5", axinfo=ax, field="bank")
+    # Positional selection is still available via slice syntax.
+    assert parse_slice("3:4", axinfo=ax, field="bank") == (slice(3, 4),)
+    # Regex matches against the stringified field values.
+    assert parse_slice("[01]", axinfo=ax, field="bank") == (0, 1, 2, 3, 4, 5, 6)
+    # A missing field errors and names the available fields.
+    with pytest.raises(ValueError, match="no field 'elec'.*'bank'"):
+        parse_slice("0", axinfo=ax, field="elec")
+    # An unstructured axis errors with an explicit field.
+    ax_flat = AxisArray.CoordinateAxis(data=np.array(["Ch0", "Ch1"]), dims=["ch"])
+    with pytest.raises(ValueError, match="unstructured data"):
+        parse_slice("Ch0", axinfo=ax_flat, field="bank")
+    # A missing axis errors too.
+    with pytest.raises(ValueError, match="no coordinate data"):
+        parse_slice("0", axinfo=None, field="bank")
+
+
+def test_slicer_field_selection():
+    n_times = 20
+    labels = ["Fp1", "Fp2", "C3", "C4", "Cz", "O1", "O2"]
+    n_chans = len(labels)
+    in_dat = np.arange(n_times * n_chans, dtype=float).reshape(n_times, n_chans)
+    ch_axis = _structured_ch_axis(labels)
+    msg_in = AxisArray(
+        in_dat,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.TimeAxis(fs=100.0, offset=0.0),
+            "ch": ch_axis,
+        },
+        key="test_slicer_field_selection",
+    )
+    xformer = SlicerTransformer(SlicerSettings(selection="1", axis="ch", field="bank"))
+    msg_out = xformer(msg_in)
+    assert np.array_equal(msg_out.data, in_dat[:, 4:7])
+    assert msg_out.axes["ch"].data.dtype == ch_axis.data.dtype
+    assert np.array_equal(msg_out.axes["ch"].data, ch_axis.data[4:7])
+
+
+def test_slicer_structured_axis():
+    n_times = 20
+    labels = ["Fp1", "Fp2", "C3", "C4", "Cz", "O1", "O2"]
+    n_chans = len(labels)
+    in_dat = np.arange(n_times * n_chans, dtype=float).reshape(n_times, n_chans)
+    ch_axis = _structured_ch_axis(labels)
+    msg_in = AxisArray(
+        in_dat,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.TimeAxis(fs=100.0, offset=0.0),
+            "ch": ch_axis,
+        },
+        key="test_slicer_structured_axis",
+    )
+    xformer = SlicerTransformer(SlicerSettings(selection="C.*", axis="ch"))
+    msg_out = xformer(msg_in)
+    assert np.array_equal(msg_out.data, in_dat[:, 2:5])
+    # The sliced axis keeps its structured records.
+    assert msg_out.axes["ch"].data.dtype == ch_axis.data.dtype
+    assert np.array_equal(msg_out.axes["ch"].data, ch_axis.data[2:5])
+
+
 def test_slicer_regex_selection():
     n_times = 20
     labels = np.array(["Fp1", "Fp2", "C3", "C4", "Cz", "O1", "O2"])


### PR DESCRIPTION
## Problem

`SlicerTransformer` crashed on axes whose `.data` is a numpy structured array (e.g. the `ch` axis emitted by ezmsg-blackrock's `ChannelMap`, with `x`/`y`/`label`/`bank`/`elec` fields). Any selection token without `:` — including plain integers like `"5"` or `"1,3"` — hit `parts[0] in axinfo.data`, which raises `TypeError: Cannot compare structured or void to non-void arrays` in numpy 2.x. Label/regex selection was meaningless even in principle, since a record's `str()` is the whole-tuple repr.

## Changes

- New `_axis_labels()` helper resolves what selection tokens match against: plain `.data` as before; for structured `.data`, the `"label"` field (stringified), degrading to int/slice-only parsing when no `"label"` field exists. Both the exact-match and regex paths in `parse_slice` go through it, so integer, exact-label, and regex selections all work on structured axes. The output-axis rebuild already round-trips structured dtypes, so sliced axes keep their full per-channel records.
- New `SlicerSettings.field` (also on `parse_slice` and `slicer()`): match selection values against another field of the structured axis, e.g. `field="bank"`, `selection="1"` selects all bank-1 channels. Two deliberate rules when a field is set explicitly:
  - Tokens mean field values only — the bare-integer positional fallback is disabled (values are stringified, so `"1"` matches int bank `1`). Positional selection remains available via slice syntax (`"3:4"`).
  - A missing field, unstructured axis, or absent axis raises a `ValueError` naming the available fields, rather than silently falling back.

Default behavior (`field=None`) is unchanged for plain label axes.

## Tests

Structured-axis coverage in `test_slicer.py`: exact/regex/integer parsing, ChannelMap-style end-to-end slicing preserving structured records, bank-value selection, disabled positional fallback, and all explicit-field error cases. Full unit suite passes (3600 passed, 5 skipped).