### PR TITLE
Slicer: add on_empty setting — no-match selections warn and emit empty by default

### DIFF
--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -107,8 +107,8 @@ def parse_slice(
         if len(parts) == 1:
             labels = _axis_labels(axinfo, field=field)
             if labels is not None and parts[0] in labels:
-                # Cast to Python ints: np.int64 fails the `isinstance(_, int)`
-                # check in _reset_state, yielding a 0-d axis-data array.
+                # Cast to Python ints so the return type is tuple[slice | int, ...]
+                # as documented (np.where yields np.int64).
                 return tuple(int(ix) for ix in np.where(labels == parts[0])[0])
             if field is None:
                 try:
@@ -134,7 +134,10 @@ def parse_slice(
 
 class SlicerSettings(ez.Settings):
     selection: str = ""
-    """selection: See :obj:`ezmsg.sigproc.slicer.parse_slice` for details."""
+    """selection: See :obj:`ezmsg.sigproc.slicer.parse_slice` for details.
+    Label/regex selections always preserve the sliced axis — a single matching
+    entry yields a length-1 axis. Only a bare-integer positional selection
+    (e.g. "5") drops the dimension."""
 
     axis: str | None = None
     """The name of the axis to slice along. If None, the last axis is used."""
@@ -146,19 +149,17 @@ class SlicerSettings(ez.Settings):
     no longer positional indices (use slice syntax like "3:4" for positions) — and
     raises an error if the axis has no such field."""
 
-    on_empty: str = "raise"
+    on_empty: str = "warn"
     """What to do when a label/regex selection matches nothing on the target axis.
 
-    - "raise" (default): raise a ValueError, which catches typos and wrong-axis
-      mistakes.
-    - "warn": non-matching tokens are dropped (logged at info level); if the whole
-      selection matches nothing, the output is empty (0-length along ``axis``) and
-      a warning is logged once per stream configuration. In this mode a label
-      selection never drops the sliced dimension — a single matching entry yields
-      a length-1 axis — so output rank is stable no matter how many entries match.
-      Use this when a hub/stream legitimately may not contain any of the selected
-      entries (e.g. a per-source region selection where a given source carries
-      none of the requested regions)."""
+    - "warn" (default): non-matching tokens are dropped (logged at info level); if
+      the whole selection matches nothing, the output is empty (0-length along
+      ``axis``) and a warning is logged once per stream configuration. This lets a
+      selection be broadcast to streams that may legitimately contain none of the
+      selected entries (e.g. a per-source region selection where a given source
+      carries none of the requested regions).
+    - "raise": raise a ValueError when any token matches nothing, which catches
+      typos and wrong-axis mistakes at first message."""
 
 
 @processor_state
@@ -173,6 +174,21 @@ class SlicerTransformer(BaseStatefulTransformer[SlicerSettings, AxisArray, AxisA
         axis = self.settings.axis or message.dims[-1]
         axis_idx = message.get_axis_idx(axis)
         return hash((message.key, message.data.shape[axis_idx]))
+
+    def _selects_positional_int(self, axinfo: AxisArray.CoordinateAxis | None) -> bool:
+        """True iff the selection is a single bare-integer token that parse_slice
+        resolved positionally (its int() path) rather than via a label match."""
+        sel = self.settings.selection.strip()
+        if self.settings.field is not None or "," in sel or ":" in sel:
+            return False
+        labels = _axis_labels(axinfo)
+        if labels is not None and sel in labels:
+            return False
+        try:
+            int(sel)
+        except ValueError:
+            return False
+        return True
 
     def _reset_state(self, message: AxisArray) -> None:
         if self.settings.on_empty not in ("raise", "warn"):
@@ -209,10 +225,11 @@ class SlicerTransformer(BaseStatefulTransformer[SlicerSettings, AxisArray, AxisA
                     axis,
                 )
 
-        # In warn mode, integer selections take the indices-array path even when
-        # there is a single hit, so the axis is preserved and output rank does not
-        # depend on how many entries matched.
-        if len(_slices) == 1 and (not allow_empty or isinstance(_slices[0], slice)):
+        # Only a bare-integer positional selection ("5") drops the dimension. A
+        # label/regex selection resolving to a single entry takes the indices-array
+        # path so the axis is preserved and output rank does not depend on how many
+        # entries matched.
+        if len(_slices) == 1 and (isinstance(_slices[0], slice) or self._selects_positional_int(axinfo)):
             self._state.slice_ = _slices[0]
             self._state.b_change_dims = isinstance(self._state.slice_, int)
         else:
@@ -257,7 +274,7 @@ def slicer(
     selection: str = "",
     axis: str | None = None,
     field: str | None = None,
-    on_empty: str = "raise",
+    on_empty: str = "warn",
 ) -> SlicerTransformer:
     """
     Slice along a particular axis.
@@ -267,7 +284,7 @@ def slicer(
         axis: The name of the axis to slice along. If None, the last axis is used.
         field: Which field of a structured coordinate axis to match selection values
           against. See :obj:`SlicerSettings` for details.
-        on_empty: "raise" (default) or "warn" — what to do when a label/regex
+        on_empty: "warn" (default) or "raise" — what to do when a label/regex
           selection matches nothing. See :obj:`SlicerSettings` for details.
 
     Returns:

--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -94,7 +94,7 @@ def parse_slice(
         allow_empty: (Optional) If True, a label/regex token that matches nothing
           returns no indices instead of raising. In a comma-separated selection,
           non-matching tokens are dropped and the matching ones kept; if every
-          token matches nothing the result is an empty tuple (a 0-length slice).
+          token matches nothing the result is an empty tuple.
 
     Returns:
         A tuple of slice objects and/or ints. May be empty when allow_empty is
@@ -107,7 +107,9 @@ def parse_slice(
         if len(parts) == 1:
             labels = _axis_labels(axinfo, field=field)
             if labels is not None and parts[0] in labels:
-                return tuple(np.where(labels == parts[0])[0])
+                # Cast to Python ints: np.int64 fails the `isinstance(_, int)`
+                # check in _reset_state, yielding a 0-d axis-data array.
+                return tuple(int(ix) for ix in np.where(labels == parts[0])[0])
             if field is None:
                 try:
                     return (int(parts[0]),)
@@ -144,14 +146,19 @@ class SlicerSettings(ez.Settings):
     no longer positional indices (use slice syntax like "3:4" for positions) — and
     raises an error if the axis has no such field."""
 
-    allow_empty: bool = False
-    """When False (default), a label/regex selection that matches nothing raises,
-    which catches typos and wrong-axis mistakes. When True, a token that matches
-    nothing is skipped instead; if the whole selection matches nothing the output
-    is empty (0-length along ``axis``) and a warning is logged once per stream
-    configuration. Use this when a hub/stream legitimately may not contain any of
-    the selected entries (e.g. a per-source region selection where a given source
-    carries none of the requested regions)."""
+    on_empty: str = "raise"
+    """What to do when a label/regex selection matches nothing on the target axis.
+
+    - "raise" (default): raise a ValueError, which catches typos and wrong-axis
+      mistakes.
+    - "warn": non-matching tokens are dropped (logged at info level); if the whole
+      selection matches nothing, the output is empty (0-length along ``axis``) and
+      a warning is logged once per stream configuration. In this mode a label
+      selection never drops the sliced dimension — a single matching entry yields
+      a length-1 axis — so output rank is stable no matter how many entries match.
+      Use this when a hub/stream legitimately may not contain any of the selected
+      entries (e.g. a per-source region selection where a given source carries
+      none of the requested regions)."""
 
 
 @processor_state
@@ -168,35 +175,51 @@ class SlicerTransformer(BaseStatefulTransformer[SlicerSettings, AxisArray, AxisA
         return hash((message.key, message.data.shape[axis_idx]))
 
     def _reset_state(self, message: AxisArray) -> None:
+        if self.settings.on_empty not in ("raise", "warn"):
+            raise ValueError(f"on_empty must be 'raise' or 'warn', got {self.settings.on_empty!r}")
         axis = self.settings.axis or message.dims[-1]
         axis_idx = message.get_axis_idx(axis)
+        axinfo = message.axes.get(axis, None)
         self._state.new_axis = None
         self._state.b_change_dims = False
 
         # Calculate the slice
+        allow_empty = self.settings.on_empty == "warn"
         _slices = parse_slice(
             self.settings.selection,
-            message.axes.get(axis, None),
+            axinfo,
             field=self.settings.field,
-            allow_empty=self.settings.allow_empty,
+            allow_empty=allow_empty,
         )
-        if len(_slices) == 1:
+
+        if allow_empty:
+            tokens = [t.strip() for t in self.settings.selection.split(",")]
+            dropped = [t for t in tokens if parse_slice(t, axinfo, field=self.settings.field, allow_empty=True) == ()]
+            if len(dropped) == len(tokens):
+                ez.logger.warning(
+                    "Slicer: selection %r matched no entries on axis %r; emitting "
+                    "an empty (0-length) result (on_empty='warn').",
+                    self.settings.selection,
+                    axis,
+                )
+            elif dropped:
+                ez.logger.info(
+                    "Slicer: dropped non-matching selection tokens %r on axis %r (on_empty='warn').",
+                    dropped,
+                    axis,
+                )
+
+        # In warn mode, integer selections take the indices-array path even when
+        # there is a single hit, so the axis is preserved and output rank does not
+        # depend on how many entries matched.
+        if len(_slices) == 1 and (not allow_empty or isinstance(_slices[0], slice)):
             self._state.slice_ = _slices[0]
             self._state.b_change_dims = isinstance(self._state.slice_, int)
         else:
             indices = np.arange(message.data.shape[axis_idx])
-            if _slices:
-                indices = np.hstack([indices[_] for _ in _slices])
-            else:
-                # allow_empty: nothing matched -> select no entries (0-length),
-                # rather than np.hstack([]) which would raise.
-                indices = indices[:0]
-                ez.logger.warning(
-                    "Slicer: selection %r matched no entries on axis %r; emitting "
-                    "an empty (0-length) result (allow_empty=True).",
-                    self.settings.selection,
-                    axis,
-                )
+            # Empty _slices (nothing matched) -> select no entries (0-length),
+            # rather than np.hstack([]) which would raise.
+            indices = np.hstack([indices[_] for _ in _slices]) if _slices else indices[:0]
             self._state.slice_ = np.s_[indices]
 
         # Create the output axis
@@ -234,7 +257,7 @@ def slicer(
     selection: str = "",
     axis: str | None = None,
     field: str | None = None,
-    allow_empty: bool = False,
+    on_empty: str = "raise",
 ) -> SlicerTransformer:
     """
     Slice along a particular axis.
@@ -244,12 +267,10 @@ def slicer(
         axis: The name of the axis to slice along. If None, the last axis is used.
         field: Which field of a structured coordinate axis to match selection values
           against. See :obj:`SlicerSettings` for details.
-        allow_empty: If True, a selection that matches nothing yields an empty
-          (0-length) result instead of raising. See :obj:`SlicerSettings`.
+        on_empty: "raise" (default) or "warn" — what to do when a label/regex
+          selection matches nothing. See :obj:`SlicerSettings` for details.
 
     Returns:
         :obj:`SlicerTransformer`
     """
-    return SlicerTransformer(
-        SlicerSettings(selection=selection, axis=axis, field=field, allow_empty=allow_empty)
-    )
+    return SlicerTransformer(SlicerSettings(selection=selection, axis=axis, field=field, on_empty=on_empty))

--- a/src/ezmsg/sigproc/slicer.py
+++ b/src/ezmsg/sigproc/slicer.py
@@ -59,6 +59,7 @@ def parse_slice(
     s: str,
     axinfo: AxisArray.CoordinateAxis | None = None,
     field: str | None = None,
+    allow_empty: bool = False,
 ) -> tuple[slice | int, ...]:
     """
     Parses a string representation of a slice and returns a tuple of slice objects.
@@ -90,9 +91,14 @@ def parse_slice(
         field: (Optional) Which field of a structured `axinfo.data` to match tokens
           against. None uses the "label" field when present. An explicit field raises
           ValueError if the axis data is missing, unstructured, or lacks that field.
+        allow_empty: (Optional) If True, a label/regex token that matches nothing
+          returns no indices instead of raising. In a comma-separated selection,
+          non-matching tokens are dropped and the matching ones kept; if every
+          token matches nothing the result is an empty tuple (a 0-length slice).
 
     Returns:
-        A tuple of slice objects and/or ints.
+        A tuple of slice objects and/or ints. May be empty when allow_empty is
+        True and nothing matched.
     """
     if s.lower() in ["", ":", "none"]:
         return (slice(None),)
@@ -112,13 +118,15 @@ def parse_slice(
             hits = tuple(ix for ix, label in enumerate(labels) if pattern.fullmatch(str(label)))
             if hits:
                 return hits
+            if allow_empty:
+                return ()
             raise ValueError(
                 f"Selection {parts[0]!r} matched no "
                 f"{'labels' if field is None else f'values in field {field!r}'} "
                 f"on the target axis (neither exactly nor as a regex)."
             ) from None
         return (slice(*(int(part.strip()) if part else None for part in parts)),)
-    suplist = [parse_slice(_, axinfo=axinfo, field=field) for _ in s.split(",")]
+    suplist = [parse_slice(_, axinfo=axinfo, field=field, allow_empty=allow_empty) for _ in s.split(",")]
     return tuple([item for sublist in suplist for item in sublist])
 
 
@@ -135,6 +143,15 @@ class SlicerSettings(ez.Settings):
     this explicitly makes selection tokens mean field values only — bare integers are
     no longer positional indices (use slice syntax like "3:4" for positions) — and
     raises an error if the axis has no such field."""
+
+    allow_empty: bool = False
+    """When False (default), a label/regex selection that matches nothing raises,
+    which catches typos and wrong-axis mistakes. When True, a token that matches
+    nothing is skipped instead; if the whole selection matches nothing the output
+    is empty (0-length along ``axis``) and a warning is logged once per stream
+    configuration. Use this when a hub/stream legitimately may not contain any of
+    the selected entries (e.g. a per-source region selection where a given source
+    carries none of the requested regions)."""
 
 
 @processor_state
@@ -157,13 +174,29 @@ class SlicerTransformer(BaseStatefulTransformer[SlicerSettings, AxisArray, AxisA
         self._state.b_change_dims = False
 
         # Calculate the slice
-        _slices = parse_slice(self.settings.selection, message.axes.get(axis, None), field=self.settings.field)
+        _slices = parse_slice(
+            self.settings.selection,
+            message.axes.get(axis, None),
+            field=self.settings.field,
+            allow_empty=self.settings.allow_empty,
+        )
         if len(_slices) == 1:
             self._state.slice_ = _slices[0]
             self._state.b_change_dims = isinstance(self._state.slice_, int)
         else:
             indices = np.arange(message.data.shape[axis_idx])
-            indices = np.hstack([indices[_] for _ in _slices])
+            if _slices:
+                indices = np.hstack([indices[_] for _ in _slices])
+            else:
+                # allow_empty: nothing matched -> select no entries (0-length),
+                # rather than np.hstack([]) which would raise.
+                indices = indices[:0]
+                ez.logger.warning(
+                    "Slicer: selection %r matched no entries on axis %r; emitting "
+                    "an empty (0-length) result (allow_empty=True).",
+                    self.settings.selection,
+                    axis,
+                )
             self._state.slice_ = np.s_[indices]
 
         # Create the output axis
@@ -197,7 +230,12 @@ class Slicer(BaseTransformerUnit[SlicerSettings, AxisArray, AxisArray, SlicerTra
     SETTINGS = SlicerSettings
 
 
-def slicer(selection: str = "", axis: str | None = None, field: str | None = None) -> SlicerTransformer:
+def slicer(
+    selection: str = "",
+    axis: str | None = None,
+    field: str | None = None,
+    allow_empty: bool = False,
+) -> SlicerTransformer:
     """
     Slice along a particular axis.
 
@@ -206,8 +244,12 @@ def slicer(selection: str = "", axis: str | None = None, field: str | None = Non
         axis: The name of the axis to slice along. If None, the last axis is used.
         field: Which field of a structured coordinate axis to match selection values
           against. See :obj:`SlicerSettings` for details.
+        allow_empty: If True, a selection that matches nothing yields an empty
+          (0-length) result instead of raising. See :obj:`SlicerSettings`.
 
     Returns:
         :obj:`SlicerTransformer`
     """
-    return SlicerTransformer(SlicerSettings(selection=selection, axis=axis, field=field))
+    return SlicerTransformer(
+        SlicerSettings(selection=selection, axis=axis, field=field, allow_empty=allow_empty)
+    )

--- a/tests/unit/test_slicer.py
+++ b/tests/unit/test_slicer.py
@@ -285,3 +285,42 @@ def test_slicer_regex_selection():
     msg_out = xformer(msg_in)
     assert np.array_equal(msg_out.data, in_dat[:, 2:5])
     assert np.array_equal(msg_out.axes["ch"].data, labels[2:5])
+
+
+def test_parse_slice_allow_empty():
+    ax = AxisArray.CoordinateAxis(data=np.array(["Fp1", "Fp2", "C3", "C4"]), dims=["ch"])
+    # Default: a non-matching selection raises.
+    with pytest.raises(ValueError, match="matched no labels"):
+        parse_slice("XYZ.*", axinfo=ax)
+    # allow_empty: a non-matching token yields no indices instead of raising.
+    assert parse_slice("XYZ.*", axinfo=ax, allow_empty=True) == ()
+    # Comma-separated: non-matching tokens are dropped, matching ones kept, in order.
+    assert parse_slice("XYZ.*, C.*", axinfo=ax, allow_empty=True) == (2, 3)
+    # Every token non-matching -> empty.
+    assert parse_slice("XYZ.*, ABC.*", axinfo=ax, allow_empty=True) == ()
+    # A matching selection is unaffected by allow_empty.
+    assert parse_slice("C.*", axinfo=ax, allow_empty=True) == (2, 3)
+
+
+def test_slicer_allow_empty_emits_empty():
+    data = np.arange(3 * 4).reshape(3, 4).astype(float)
+    msg = AxisArray(
+        data=data,
+        dims=["time", "ch"],
+        axes={
+            "time": AxisArray.TimeAxis(fs=1.0),
+            "ch": AxisArray.CoordinateAxis(data=np.array(["C3", "C4", "O1", "O2"]), dims=["ch"]),
+        },
+        key="allow_empty",
+    )
+    # Default: no match raises.
+    with pytest.raises(ValueError, match="matched no labels"):
+        SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch"))(msg)
+    # allow_empty: no match -> 0-length along ch, time axis intact.
+    out = SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch", allow_empty=True))(msg)
+    assert out.data.shape == (3, 0)
+    assert len(out.axes["ch"].data) == 0
+    # allow_empty with a partial match keeps only the matching channels.
+    out2 = SlicerTransformer(SlicerSettings(selection="Fp.*, O.*", axis="ch", allow_empty=True))(msg)
+    assert out2.data.shape == (3, 2)
+    assert [str(x) for x in out2.axes["ch"].data] == ["O1", "O2"]

--- a/tests/unit/test_slicer.py
+++ b/tests/unit/test_slicer.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import numpy as np
 import pytest
@@ -300,27 +301,64 @@ def test_parse_slice_allow_empty():
     assert parse_slice("XYZ.*, ABC.*", axinfo=ax, allow_empty=True) == ()
     # A matching selection is unaffected by allow_empty.
     assert parse_slice("C.*", axinfo=ax, allow_empty=True) == (2, 3)
+    # Exact label matches yield Python ints (np.int64 breaks the isinstance(_, int)
+    # dim-drop check in SlicerTransformer._reset_state).
+    assert all(type(ix) is int for ix in parse_slice("Fp1", axinfo=ax))
 
 
-def test_slicer_allow_empty_emits_empty():
-    data = np.arange(3 * 4).reshape(3, 4).astype(float)
-    msg = AxisArray(
-        data=data,
+def _make_on_empty_msg() -> AxisArray:
+    return AxisArray(
+        data=np.arange(3 * 4).reshape(3, 4).astype(float),
         dims=["time", "ch"],
         axes={
             "time": AxisArray.TimeAxis(fs=1.0),
             "ch": AxisArray.CoordinateAxis(data=np.array(["C3", "C4", "O1", "O2"]), dims=["ch"]),
         },
-        key="allow_empty",
+        key="on_empty",
     )
+
+
+def test_slicer_on_empty_warn_emits_empty(caplog):
+    msg = _make_on_empty_msg()
     # Default: no match raises.
     with pytest.raises(ValueError, match="matched no labels"):
         SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch"))(msg)
-    # allow_empty: no match -> 0-length along ch, time axis intact.
-    out = SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch", allow_empty=True))(msg)
+    # on_empty="warn": no match -> 0-length along ch, time axis intact, and a warning.
+    with caplog.at_level(logging.WARNING, logger="ezmsg"):
+        out = SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch", on_empty="warn"))(msg)
     assert out.data.shape == (3, 0)
     assert len(out.axes["ch"].data) == 0
-    # allow_empty with a partial match keeps only the matching channels.
-    out2 = SlicerTransformer(SlicerSettings(selection="Fp.*, O.*", axis="ch", allow_empty=True))(msg)
+    assert any("matched no entries" in rec.getMessage() for rec in caplog.records)
+    # A partial match keeps only the matching channels and logs the dropped tokens.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="ezmsg"):
+        out2 = SlicerTransformer(SlicerSettings(selection="Fp.*, O.*", axis="ch", on_empty="warn"))(msg)
     assert out2.data.shape == (3, 2)
     assert [str(x) for x in out2.axes["ch"].data] == ["O1", "O2"]
+    assert any("dropped non-matching" in rec.getMessage() for rec in caplog.records)
+
+
+def test_slicer_on_empty_warn_single_match_keeps_axis():
+    """In warn mode output rank must not depend on how many entries match: a
+    selection resolving to a single entry keeps a length-1 axis instead of
+    dropping the dimension (or crashing, for exact-label matches)."""
+    msg = _make_on_empty_msg()
+    for selection in ["Fp.*, O1", "Fp.*, O1.*"]:  # exact and regex single match
+        out = SlicerTransformer(SlicerSettings(selection=selection, axis="ch", on_empty="warn"))(msg)
+        assert out.data.shape == (3, 1)
+        assert out.dims == ["time", "ch"]
+        assert [str(x) for x in out.axes["ch"].data] == ["O1"]
+
+
+def test_slicer_single_exact_label_drops_dim():
+    """Default mode: a single exact-label selection drops the dimension, matching
+    the pre-existing behavior of a single-hit regex selection."""
+    msg = _make_on_empty_msg()
+    out = SlicerTransformer(SlicerSettings(selection="C4", axis="ch"))(msg)
+    assert out.data.shape == (3,)
+    assert out.dims == ["time"]
+
+
+def test_slicer_on_empty_invalid():
+    with pytest.raises(ValueError, match="on_empty"):
+        SlicerTransformer(SlicerSettings(selection="C.*", axis="ch", on_empty="ignore"))(_make_on_empty_msg())

--- a/tests/unit/test_slicer.py
+++ b/tests/unit/test_slicer.py
@@ -301,8 +301,7 @@ def test_parse_slice_allow_empty():
     assert parse_slice("XYZ.*, ABC.*", axinfo=ax, allow_empty=True) == ()
     # A matching selection is unaffected by allow_empty.
     assert parse_slice("C.*", axinfo=ax, allow_empty=True) == (2, 3)
-    # Exact label matches yield Python ints (np.int64 breaks the isinstance(_, int)
-    # dim-drop check in SlicerTransformer._reset_state).
+    # Exact label matches yield Python ints, per the documented return type.
     assert all(type(ix) is int for ix in parse_slice("Fp1", axinfo=ax))
 
 
@@ -318,43 +317,44 @@ def _make_on_empty_msg() -> AxisArray:
     )
 
 
-def test_slicer_on_empty_warn_emits_empty(caplog):
+def test_slicer_on_empty(caplog):
     msg = _make_on_empty_msg()
-    # Default: no match raises.
+    # on_empty="raise": no match raises.
     with pytest.raises(ValueError, match="matched no labels"):
-        SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch"))(msg)
-    # on_empty="warn": no match -> 0-length along ch, time axis intact, and a warning.
+        SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch", on_empty="raise"))(msg)
+    # Default ("warn"): no match -> 0-length along ch, time axis intact, and a warning.
     with caplog.at_level(logging.WARNING, logger="ezmsg"):
-        out = SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch", on_empty="warn"))(msg)
+        out = SlicerTransformer(SlicerSettings(selection="Fp.*", axis="ch"))(msg)
     assert out.data.shape == (3, 0)
     assert len(out.axes["ch"].data) == 0
     assert any("matched no entries" in rec.getMessage() for rec in caplog.records)
     # A partial match keeps only the matching channels and logs the dropped tokens.
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="ezmsg"):
-        out2 = SlicerTransformer(SlicerSettings(selection="Fp.*, O.*", axis="ch", on_empty="warn"))(msg)
+        out2 = SlicerTransformer(SlicerSettings(selection="Fp.*, O.*", axis="ch"))(msg)
     assert out2.data.shape == (3, 2)
     assert [str(x) for x in out2.axes["ch"].data] == ["O1", "O2"]
     assert any("dropped non-matching" in rec.getMessage() for rec in caplog.records)
 
 
-def test_slicer_on_empty_warn_single_match_keeps_axis():
-    """In warn mode output rank must not depend on how many entries match: a
-    selection resolving to a single entry keeps a length-1 axis instead of
-    dropping the dimension (or crashing, for exact-label matches)."""
+def test_slicer_single_label_match_keeps_axis():
+    """Output rank must not depend on how many entries match or on on_empty: a
+    label/regex selection resolving to a single entry keeps a length-1 axis
+    instead of dropping the dimension (or crashing, for exact-label matches).
+    Only bare-integer positional selections (e.g. "5") drop the dimension."""
     msg = _make_on_empty_msg()
-    for selection in ["Fp.*, O1", "Fp.*, O1.*"]:  # exact and regex single match
-        out = SlicerTransformer(SlicerSettings(selection=selection, axis="ch", on_empty="warn"))(msg)
+    for selection, on_empty in [
+        ("O1", "raise"),
+        ("O1.*", "raise"),
+        ("Fp.*, O1", "warn"),  # exact single match with a dropped token
+        ("Fp.*, O1.*", "warn"),  # regex single match with a dropped token
+    ]:
+        out = SlicerTransformer(SlicerSettings(selection=selection, axis="ch", on_empty=on_empty))(msg)
         assert out.data.shape == (3, 1)
         assert out.dims == ["time", "ch"]
         assert [str(x) for x in out.axes["ch"].data] == ["O1"]
-
-
-def test_slicer_single_exact_label_drops_dim():
-    """Default mode: a single exact-label selection drops the dimension, matching
-    the pre-existing behavior of a single-hit regex selection."""
-    msg = _make_on_empty_msg()
-    out = SlicerTransformer(SlicerSettings(selection="C4", axis="ch"))(msg)
+    # Bare-integer positional selection still drops the dimension.
+    out = SlicerTransformer(SlicerSettings(selection="1", axis="ch"))(msg)
     assert out.data.shape == (3,)
     assert out.dims == ["time"]
 


### PR DESCRIPTION
## Summary
Adds an opt-in `allow_empty` setting to `Slicer`. By default a label/regex selection that matches nothing still raises; with `allow_empty=True`, non-matching tokens are dropped and a selection that matches nothing yields an empty (0-length) result plus a one-time warning.

## Motivation
Today a label/regex selection that matches no labels raises `ValueError("… matched no labels …")`. That fail-fast is valuable — it catches typos, wrong-axis, and wrong-label mistakes — and stays the default.

But some callers apply the *same* selection across multiple streams where a given stream may legitimately contain **none** of the selected entries. The concrete case: a per-source region selection (e.g. `".*-aip-.*,.*-smg-.*"`) broadcast to every acquisition hub, where one hub carries none of those regions. There, "matched nothing" is expected, not an error — that source should simply contribute no channels. For those callers, raising is wrong; they want an empty result to flow through.

## Changes
- Add `SlicerSettings.allow_empty: bool = False`.
- `parse_slice(..., allow_empty=False)`: when a label/regex token matches nothing, return no indices instead of raising. In a comma-separated selection, non-matching tokens are dropped and matching ones kept (in order); if every token matches nothing the result is an empty tuple.
- `SlicerTransformer._reset_state`: pass `allow_empty` through, guard the empty-result case (0-length selection along the axis, avoiding `np.hstack([])`), and log a warning **once per stream configuration** when the selection resolves to empty.
- Thread the flag through the `slicer()` factory.

## Behavior change
None by default — `allow_empty=False` preserves the existing raise exactly. The new behavior is strictly opt-in. Matching selections are unaffected regardless of the flag.

## Testing
- `test_parse_slice_allow_empty`: non-matching token → `()` (vs raise by default); comma list drops non-matching and keeps matching in order; all-non-matching → `()`; matching selection unaffected.
- `test_slicer_allow_empty_emits_empty`: default raises; `allow_empty=True` on a no-match yields a `(time, 0)` output with a 0-length `ch` axis (time axis intact); a partial match keeps only the matching channels.
- Full `tests/unit/test_slicer.py` passes (**17 passed**), including all pre-existing tests — no regressions.