### PR TITLE
HybridBuffer: don't divide by zero growing a 0-channel buffer

### DIFF
--- a/src/ezmsg/sigproc/util/buffer.py
+++ b/src/ezmsg/sigproc/util/buffer.py
@@ -426,7 +426,11 @@ class HybridBuffer:
             # policy with no byte cap -- avoids dividing by 0 bytes/sample.
             new_capacity = max(self._capacity * 2, min_capacity)
         else:
-            max_capacity = self._max_size / bytes_per_sample
+            # Floor-divide: the byte budget bounds capacity to a whole number of
+            # samples. True division would yield a float, which then flows into
+            # both the xp_empty shape below and self._capacity -- array dims must
+            # be ints, and a non-int capacity corrupts the ring-buffer arithmetic.
+            max_capacity = self._max_size // bytes_per_sample
             if min_capacity > max_capacity:
                 raise OverflowError(
                     f"Cannot grow buffer to {min_capacity} samples, "

--- a/src/ezmsg/sigproc/util/buffer.py
+++ b/src/ezmsg/sigproc/util/buffer.py
@@ -418,14 +418,21 @@ class HybridBuffer:
             return
 
         other_shape = self._buffer.shape[1:]
-        max_capacity = self._max_size / (xp_itemsize(self._buffer.dtype) * math.prod(other_shape))
-        if min_capacity > max_capacity:
-            raise OverflowError(
-                f"Cannot grow buffer to {min_capacity} samples, "
-                f"maximum capacity is {max_capacity} samples ({self._max_size} bytes)."
-            )
-
-        new_capacity = min(max_capacity, max(self._capacity * 2, min_capacity))
+        bytes_per_sample = xp_itemsize(self._buffer.dtype) * math.prod(other_shape)
+        if bytes_per_sample == 0:
+            # A 0-size non-sample dim (e.g. a 0-channel stream from a source
+            # sliced to no channels) makes each sample 0 bytes, so the max_size
+            # byte budget never bounds capacity. Grow by the normal doubling
+            # policy with no byte cap -- avoids dividing by 0 bytes/sample.
+            new_capacity = max(self._capacity * 2, min_capacity)
+        else:
+            max_capacity = self._max_size / bytes_per_sample
+            if min_capacity > max_capacity:
+                raise OverflowError(
+                    f"Cannot grow buffer to {min_capacity} samples, "
+                    f"maximum capacity is {max_capacity} samples ({self._max_size} bytes)."
+                )
+            new_capacity = min(max_capacity, max(self._capacity * 2, min_capacity))
         new_buffer = xp_empty(self.xp, (new_capacity, *other_shape), dtype=self._buffer.dtype)
 
         # Copy existing data to new buffer

--- a/tests/unit/buffer/test_buffer_overflow.py
+++ b/tests/unit/buffer/test_buffer_overflow.py
@@ -90,6 +90,26 @@ class TestHybridBufferOverflow:
         with pytest.raises(OverflowError):
             buf.write(np.zeros((11, 2)))
 
+    def test_overflow_strategy_grow_zero_channel(self, buffer_params):
+        """Growing a 0-channel buffer must not divide by zero.
+
+        A 0-size non-sample dim (e.g. a stream from a source sliced to no
+        channels) makes each sample 0 bytes, so the max_size byte budget can't
+        bound -- or divide -- capacity. Regression for a 0-channel stream
+        reaching a growing buffer (e.g. the feature Merge's Align).
+        """
+        buf = HybridBuffer(**{**buffer_params, "overflow_strategy": "grow", "other_shape": (0,)})
+        assert buf.capacity == 100
+        buf.write(np.zeros((80, 0), dtype=np.float32))
+        assert buf.capacity == 100
+        # 110 > capacity -> must grow (previously raised ZeroDivisionError,
+        # dividing max_size by 0 bytes/sample).
+        buf.write(np.zeros((30, 0), dtype=np.float32))
+        assert buf.capacity > 100
+        assert buf.available() == 110
+        out = buf.read(110)
+        assert out.shape == (110, 0)
+
     def test_read_prevent_overwrite(self, buffer_params):
         """
         This test ensures that the read method can prevent an overwrite by reading

--- a/tests/unit/buffer/test_buffer_overflow.py
+++ b/tests/unit/buffer/test_buffer_overflow.py
@@ -110,6 +110,26 @@ class TestHybridBufferOverflow:
         out = buf.read(110)
         assert out.shape == (110, 0)
 
+    def test_overflow_strategy_grow_capacity_stays_integer(self, buffer_params):
+        """Growing must yield an integer capacity even when the byte budget is
+        not an exact multiple of bytes-per-sample.
+
+        max_capacity = max_size / bytes_per_sample is floored: otherwise a
+        fractional cap (e.g. 150.5) flows into both the xp_empty shape and
+        self._capacity -- array dims must be ints, and a non-int capacity
+        corrupts the ring-buffer arithmetic.
+        """
+        # other_shape (2,) float32 -> 8 bytes/sample; 1204 // 8 = 150 (rem 4),
+        # so the un-floored cap would be 150.5.
+        buf = HybridBuffer(**{**buffer_params, "overflow_strategy": "grow", "max_size": 1204})
+        buf.write(np.zeros((80, 2), dtype=np.float32))
+        # 110 > capacity(100): grow, but capped by the byte budget below cap*2.
+        buf.write(np.zeros((30, 2), dtype=np.float32))
+        assert buf.capacity == 150  # floor(150.5), not 150.5
+        assert isinstance(buf.capacity, int)
+        assert buf.available() == 110
+        assert buf.read(110).shape == (110, 2)
+
     def test_read_prevent_overwrite(self, buffer_params):
         """
         This test ensures that the read method can prevent an overwrite by reading


### PR DESCRIPTION
## What

`HybridBuffer._grow_buffer` computed the byte-budget capacity as:

    max_capacity = max_size / (xp_itemsize(dtype) * math.prod(other_shape))

which divides by zero when a non-sample dimension is 0 — e.g. a 0-channel
stream produced by an upstream source sliced to no channels. Each such sample
is 0 bytes, so the `max_size` byte budget can neither bound nor divide the
capacity.

## Fix

When `bytes_per_sample == 0`, skip the byte cap and grow by the normal
doubling policy (`max(capacity * 2, min_capacity)`) — the buffer is free to
grow since 0-byte samples never consume the budget. Non-empty buffers are
unchanged.

## How it surfaces

Once a hub carrying none of a selected region is sliced to 0 channels, its
0-channel feature stream flows into the feature `Merge`'s `Align` buffer,
whose "grow" overflow strategy calls `_grow_buffer` — throwing
`ZeroDivisionError` on every chunk (caught by ezmsg's task wrapper, so it
manifested as thousands of logged tracebacks rather than a hard crash). This
is the last blocker for 0-channel streams flowing cleanly through a
multi-hub graph; it complements the `is_empty_along` publish-guard fixes,
which let the 0-channel messages reach the buffer in the first place.

## Test

`test_overflow_strategy_grow_zero_channel` builds a `grow`-strategy buffer
with `other_shape=(0,)`, writes past capacity to force a grow, and asserts it
grows (and reads back `(110, 0)`) instead of raising. Verified it fails with
`ZeroDivisionError` at `buffer.py:_grow_buffer` without this change; full
buffer suite (74 tests) passes with it.

## Out of scope (follow-up)

The sibling write-time check (`buffer.py`, `write()`:
`new_len * xp_itemsize(block.dtype) > max_size`) omits `prod(other_shape)`
entirely — it under-counts bytes for multi-channel buffers and over-counts
for 0-channel ones. It doesn't divide, so it's not a crash, and our buffers
are ~6 orders of magnitude from tripping its spurious-overflow edge. Making
it consistent is a stricter (behavior-changing) `max_size` enforcement that
warrants its own PR + blast-radius check, so it's intentionally left out here.