### PR TITLE
Add util.rereference: deterministic cluster-aware rereference matrices

### DIFF
--- a/src/ezmsg/sigproc/affinetransform.py
+++ b/src/ezmsg/sigproc/affinetransform.py
@@ -25,7 +25,8 @@ from ezmsg.util.messages.axisarray import AxisArray, AxisBase
 from ezmsg.util.messages.util import replace
 
 from ezmsg.sigproc.util.array import array_device, is_float_dtype, xp_asarray, xp_create
-from ezmsg.sigproc.util.channels import channel_clusters_from_field
+from ezmsg.sigproc.util.channels import channel_clusters_from_field, validate_channel_clusters
+from ezmsg.sigproc.util.rereference import RereferenceKind, rereference_matrix
 
 
 def _find_block_diagonal_clusters(weights: np.ndarray) -> list[tuple[np.ndarray, np.ndarray]] | None:
@@ -144,9 +145,21 @@ class AffineTransformSettings(ez.Settings):
     Settings for :obj:`AffineTransform`.
     """
 
-    weights: np.ndarray | str | Path | Callable[[int], np.ndarray]
-    """An array of weights, a path to a file with weights compatible with np.loadtxt,
-    or a callable that accepts ``n_in: int`` and returns an ndarray of shape ``(n_in, n_out)``."""
+    weights: np.ndarray | str | Path | RereferenceKind | Callable[[int], np.ndarray]
+    """An array of weights; a path to a file with weights compatible with np.loadtxt;
+    a :class:`~ezmsg.sigproc.util.rereference.RereferenceKind` or its string value
+    (e.g. ``"car"``) to build a deterministic rereference matrix over
+    ``channel_clusters``; or a callable that accepts ``n_in: int`` and returns an
+    ndarray of shape ``(n_in, n_out)``.
+
+    Note: if you simply want streaming CAR, :obj:`CommonRereference` in this module
+    is usually the better choice (per-sample mean subtraction instead of a matmul,
+    plus ``median`` support). Kind-based weights are useful for discovering the
+    available deterministic transforms and for workflows that start from such a
+    matrix and later replace it externally via
+    :meth:`AffineTransformTransformer.set_weights`. For variants (leave-one-out,
+    minimum cluster size) pass a callable, e.g.
+    ``lambda n: car_matrix(n, clusters=..., include_current=False)``."""
 
     axis: str | None = None
     """The name of the axis to apply the transformation to. Defaults to the leading (0th) axis in the array."""
@@ -213,11 +226,21 @@ class AffineTransformTransformer(
 
     def _reset_state(self, message: AxisArray) -> None:
         weights = self.settings.weights
-        if callable(weights):
+        if isinstance(weights, str):
+            # Bare strings may name a RereferenceKind (e.g. "car" from config);
+            # anything else is treated as a weights file path below.
+            try:
+                weights = RereferenceKind(weights)
+            except ValueError:
+                pass
+        if isinstance(weights, RereferenceKind) or callable(weights):
             axis = self.settings.axis or message.dims[-1]
             axis_idx = message.get_axis_idx(axis)
             n_in = message.data.shape[axis_idx]
-            weights = weights(n_in)
+            if isinstance(weights, RereferenceKind):
+                weights = rereference_matrix(weights, n_in, clusters=self.settings.channel_clusters)
+            else:
+                weights = weights(n_in)
         if isinstance(weights, str):
             weights = Path(os.path.abspath(os.path.expanduser(weights)))
         if isinstance(weights, Path):
@@ -301,12 +324,7 @@ class AffineTransformTransformer(
             w_np = np.ascontiguousarray(weights)
             n_in, n_out = w_np.shape
             if self.settings.channel_clusters is not None:
-                # Validate input index bounds
-                all_in = np.concatenate([np.asarray(group) for group in self.settings.channel_clusters])
-                if np.any((all_in < 0) | (all_in >= n_in)):
-                    raise ValueError(
-                        f"channel_clusters contains out-of-range input indices (valid range: 0..{n_in - 1})"
-                    )
+                validate_channel_clusters(self.settings.channel_clusters, n_in)
 
                 # Derive output indices from non-zero weights for each input cluster
                 clusters = []
@@ -427,7 +445,7 @@ class AffineTransform(BaseTransformerUnit[AffineTransformSettings, AxisArray, Ax
 
 
 def affine_transform(
-    weights: np.ndarray | str | Path | Callable[[int], np.ndarray],
+    weights: np.ndarray | str | Path | RereferenceKind | Callable[[int], np.ndarray],
     axis: str | None = None,
     right_multiply: bool = True,
     channel_clusters: list[list[int]] | None = None,
@@ -438,7 +456,10 @@ def affine_transform(
 
     Args:
         weights: An array of weights, a path to a file with weights compatible with np.loadtxt,
+            a :class:`~ezmsg.sigproc.util.rereference.RereferenceKind` (or its string value),
             or a callable that accepts ``n_in`` and returns an ndarray of shape ``(n_in, n_out)``.
+            See :attr:`AffineTransformSettings.weights`; for streaming CAR prefer
+            :func:`common_rereference`.
         axis: The name of the axis to apply the transformation to. Defaults to the leading (0th) axis in the array.
         right_multiply: Set False to transpose the weights before applying.
         channel_clusters: Optional explicit channel cluster specification. See

--- a/src/ezmsg/sigproc/util/channels.py
+++ b/src/ezmsg/sigproc/util/channels.py
@@ -11,7 +11,20 @@ can become "bank aware" by reading metadata that already rides on the stream.
 
 from __future__ import annotations
 
+import numpy as np
 from ezmsg.util.messages.axisarray import AxisArray
+
+
+def validate_channel_clusters(clusters: list[list[int]], n_channels: int) -> None:
+    """Raise ``ValueError`` if any cluster index falls outside ``0..n_channels-1``.
+
+    An empty *clusters* list (or empty groups within it) validates trivially;
+    whether an empty spec is permitted at all is caller policy.
+    """
+    for cluster in clusters:
+        idx = np.asarray(cluster, dtype=np.intp)
+        if idx.size and (np.any(idx < 0) or np.any(idx >= n_channels)):
+            raise ValueError(f"channel_clusters contains out-of-range indices (valid range: 0..{n_channels - 1})")
 
 
 def channel_clusters_from_field(

--- a/src/ezmsg/sigproc/util/rereference.py
+++ b/src/ezmsg/sigproc/util/rereference.py
@@ -1,0 +1,121 @@
+"""Deterministic rereferencing schemes expressed as affine weight matrices.
+
+These helpers build weight matrices for deterministic, cluster-aware
+rereferencing — identity passthrough and per-cluster common-average
+reference (CAR) — suitable for
+:class:`ezmsg.sigproc.affinetransform.AffineTransformTransformer`
+(``y = x @ A``). All returned matrices are symmetric, so the
+``right_multiply`` orientation does not matter.
+
+Matrices are built with numpy: ``AffineTransformTransformer`` converts its
+weights to the message's array namespace, dtype, and device on first use, so
+a host-side float64 matrix is the correct interchange format even for
+GPU-backed streams.
+
+The matrix form of mean-CAR is equivalent to the streaming
+:class:`ezmsg.sigproc.affinetransform.CommonRereferenceTransformer` with
+``mode="mean"``. The streaming form is cheaper per sample (mean subtraction
+vs. matmul) and also supports ``median``; the matrix form composes with
+other affine transforms and provides a deterministic cold-start for adaptive
+rereferencing (e.g. LRR in ezmsg-learn).
+"""
+
+from __future__ import annotations
+
+import enum
+
+import numpy as np
+import numpy.typing as npt
+
+from ezmsg.sigproc.util.channels import validate_channel_clusters
+
+
+class RereferenceKind(str, enum.Enum):
+    """Deterministic rereference schemes expressible as a weight matrix.
+
+    ``str`` enum so values round-trip through config as their plain strings.
+    """
+
+    IDENTITY = "identity"
+    """Pass the signal through unchanged."""
+
+    CAR = "car"
+    """Per-cluster common-average reference."""
+
+
+def car_matrix(
+    n_channels: int,
+    *,
+    clusters: list[list[int]] | None = None,
+    include_current: bool = True,
+    min_reref_size: int = 1,
+    dtype: npt.DTypeLike = np.float64,
+) -> np.ndarray:
+    """Build a per-cluster common-average-reference matrix.
+
+    Within each cluster of ``k`` channels the sub-block subtracts the cluster
+    mean: ``y_i = x_i - mean_j x_j`` (``include_current=True``), or the
+    leave-one-out mean ``y_i = x_i - mean_{j != i} x_j``
+    (``include_current=False``). Channels outside every cluster — and all
+    cross-cluster terms — stay identity.
+
+    Args:
+        n_channels: Total number of channels (matrix is ``n x n``).
+        clusters: Disjoint channel-index groups, e.g. from
+            :func:`ezmsg.sigproc.util.channels.channel_clusters_from_field`.
+            ``None`` treats all channels as a single cluster.
+        include_current: Set False for the leave-one-out reference (each
+            channel excluded from its own reference).
+        min_reref_size: Clusters with fewer channels than this stay identity.
+            Note this is distinct from
+            :attr:`~ezmsg.sigproc.affinetransform.AffineTransformSettings.min_cluster_size`,
+            which is a block-diagonal matmul merge threshold.
+        dtype: Result dtype; must be floating-point.
+
+    Returns:
+        Symmetric ``(n_channels, n_channels)`` numpy weight matrix.
+    """
+    A = np.eye(n_channels, dtype=dtype)
+    if clusters is None:
+        clusters = [list(range(n_channels))]
+    validate_channel_clusters(clusters, n_channels)
+    # Leave-one-out needs at least one *other* channel (k == 1 would divide by zero).
+    min_k = max(min_reref_size, 1 if include_current else 2)
+    for cluster in clusters:
+        idx = np.asarray(cluster, dtype=np.intp)
+        k = idx.size
+        if k < min_k:
+            continue
+        if include_current:
+            block = np.eye(k, dtype=dtype) - 1.0 / k
+        else:
+            block = (k / (k - 1.0)) * np.eye(k, dtype=dtype) - 1.0 / (k - 1.0)
+        A[np.ix_(idx, idx)] = block
+    return A
+
+
+def rereference_matrix(
+    kind: RereferenceKind | str,
+    n_channels: int,
+    *,
+    clusters: list[list[int]] | None = None,
+    include_current: bool = True,
+    min_reref_size: int = 1,
+    dtype: npt.DTypeLike = np.float64,
+) -> np.ndarray:
+    """Build the weight matrix for a :class:`RereferenceKind`.
+
+    Dispatches to :func:`car_matrix` for ``CAR``; the cluster/reference
+    arguments are ignored for ``IDENTITY``. Accepts the enum or its plain
+    string value.
+    """
+    kind = RereferenceKind(kind)
+    if kind == RereferenceKind.IDENTITY:
+        return np.eye(n_channels, dtype=dtype)
+    return car_matrix(
+        n_channels,
+        clusters=clusters,
+        include_current=include_current,
+        min_reref_size=min_reref_size,
+        dtype=dtype,
+    )

--- a/tests/unit/test_affine_transform.py
+++ b/tests/unit/test_affine_transform.py
@@ -611,7 +611,7 @@ def test_block_diagonal_invalid_clusters():
     n_chans = 64
     weights = np.eye(n_chans)
 
-    with pytest.raises(ValueError, match="out-of-range input indices"):
+    with pytest.raises(ValueError, match="out-of-range indices"):
         xformer = AffineTransformTransformer(
             AffineTransformSettings(
                 weights=weights,
@@ -622,7 +622,7 @@ def test_block_diagonal_invalid_clusters():
         msg_in = AxisArray(data=np.zeros((10, n_chans)), dims=["time", "ch"])
         xformer(msg_in)
 
-    with pytest.raises(ValueError, match="out-of-range input indices"):
+    with pytest.raises(ValueError, match="out-of-range indices"):
         xformer = AffineTransformTransformer(
             AffineTransformSettings(
                 weights=weights,

--- a/tests/unit/test_rereference.py
+++ b/tests/unit/test_rereference.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+from ezmsg.util.messages.axisarray import AxisArray
+
+from ezmsg.sigproc.affinetransform import AffineTransformSettings, AffineTransformTransformer
+from ezmsg.sigproc.util.rereference import RereferenceKind, car_matrix, rereference_matrix
+
+
+def _rng():
+    return np.random.default_rng(2718)
+
+
+class TestCarMatrix:
+    def test_single_cluster_car(self):
+        A = car_matrix(6)
+        X = _rng().normal(size=(20, 6))
+        expected = X - X.mean(axis=1, keepdims=True)
+        np.testing.assert_allclose(X @ A, expected, atol=1e-12)
+
+    def test_single_cluster_leave_one_out(self):
+        n = 6
+        A = car_matrix(n, include_current=False)
+        X = _rng().normal(size=(20, n))
+        loo = (X.sum(axis=1, keepdims=True) - X) / (n - 1)
+        np.testing.assert_allclose(X @ A, X - loo, atol=1e-12)
+
+    def test_per_cluster_independence(self):
+        clusters = [[0, 1, 2], [3, 4, 5, 6, 7]]
+        A = car_matrix(8, clusters=clusters, include_current=False)
+        X = _rng().normal(size=(20, 8))
+        expected = X.copy()
+        for cl in clusters:
+            block = X[:, cl]
+            loo = (block.sum(axis=1, keepdims=True) - block) / (len(cl) - 1)
+            expected[:, cl] = block - loo
+        np.testing.assert_allclose(X @ A, expected, atol=1e-12)
+        # No cross-cluster terms
+        assert np.all(A[np.ix_(clusters[0], clusters[1])] == 0)
+        assert np.all(A[np.ix_(clusters[1], clusters[0])] == 0)
+
+    def test_min_reref_size_leaves_small_clusters_identity(self):
+        clusters = [[0, 1], [2, 3, 4, 5]]
+        A = car_matrix(6, clusters=clusters, include_current=False, min_reref_size=3)
+        np.testing.assert_array_equal(A[np.ix_([0, 1], [0, 1])], np.eye(2))
+        assert A[2, 3] != 0
+
+    def test_unclustered_channels_stay_identity(self):
+        A = car_matrix(5, clusters=[[0, 1, 2]])
+        np.testing.assert_array_equal(A[3:, :], np.eye(5)[3:, :])
+        np.testing.assert_array_equal(A[:, 3:], np.eye(5)[:, 3:])
+
+    def test_leave_one_out_singleton_cluster_is_identity(self):
+        # k == 1 has no "other" channels; must not divide by zero.
+        A = car_matrix(4, clusters=[[0], [1, 2, 3]], include_current=False)
+        np.testing.assert_array_equal(A[0, :], np.eye(4)[0, :])
+
+    def test_leave_one_out_pair_is_bipolar(self):
+        A = car_matrix(2, include_current=False)
+        X = _rng().normal(size=(10, 2))
+        np.testing.assert_allclose((X @ A)[:, 0], X[:, 0] - X[:, 1], atol=1e-12)
+
+    def test_symmetric(self):
+        A = car_matrix(8, clusters=[[0, 1, 2], [3, 4, 5, 6, 7]], include_current=False)
+        np.testing.assert_array_equal(A, A.T)
+
+    def test_zero_channels(self):
+        assert car_matrix(0).shape == (0, 0)
+        assert car_matrix(0, clusters=[]).shape == (0, 0)
+
+    def test_out_of_range_indices_raise(self):
+        with pytest.raises(ValueError, match="out-of-range"):
+            car_matrix(4, clusters=[[0, 1, 4]])
+        with pytest.raises(ValueError, match="out-of-range"):
+            car_matrix(4, clusters=[[-1, 0, 1]])
+
+    def test_dtype(self):
+        assert car_matrix(4, dtype=np.float32).dtype == np.float32
+
+
+class TestRereferenceMatrix:
+    def test_identity(self):
+        np.testing.assert_array_equal(rereference_matrix(RereferenceKind.IDENTITY, 5), np.eye(5))
+
+    def test_car_dispatch(self):
+        expected = car_matrix(6, clusters=[[0, 1, 2]], include_current=False)
+        got = rereference_matrix(RereferenceKind.CAR, 6, clusters=[[0, 1, 2]], include_current=False)
+        np.testing.assert_array_equal(got, expected)
+
+    def test_accepts_plain_strings(self):
+        np.testing.assert_array_equal(rereference_matrix("identity", 3), np.eye(3))
+        np.testing.assert_array_equal(rereference_matrix("car", 4), car_matrix(4))
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError):
+            rereference_matrix("laplacian", 4)
+
+
+class TestAffineKindWeights:
+    """AffineTransformTransformer accepts a RereferenceKind (or its string value)
+    as ``weights`` and builds the matrix over ``channel_clusters`` at reset."""
+
+    def test_identity_kind(self):
+        X = _rng().normal(size=(10, 6))
+        xf = AffineTransformTransformer(AffineTransformSettings(weights=RereferenceKind.IDENTITY, axis="ch"))
+        out = xf(AxisArray(X, dims=["time", "ch"]))
+        np.testing.assert_allclose(out.data, X, atol=1e-12)
+
+    def test_car_kind_with_clusters(self):
+        clusters = [[0, 1, 2], [3, 4, 5]]
+        X = _rng().normal(size=(10, 6))
+        xf = AffineTransformTransformer(
+            AffineTransformSettings(weights=RereferenceKind.CAR, axis="ch", channel_clusters=clusters)
+        )
+        out = xf(AxisArray(X, dims=["time", "ch"]))
+        expected = X.copy()
+        for cl in clusters:
+            expected[:, cl] -= X[:, cl].mean(axis=1, keepdims=True)
+        np.testing.assert_allclose(out.data, expected, atol=1e-12)
+
+    def test_car_kind_as_plain_string(self):
+        X = _rng().normal(size=(10, 4))
+        xf = AffineTransformTransformer(AffineTransformSettings(weights="car", axis="ch"))
+        out = xf(AxisArray(X, dims=["time", "ch"]))
+        np.testing.assert_allclose(out.data, X - X.mean(axis=1, keepdims=True), atol=1e-12)
+
+    def test_kind_weights_rebuild_on_channel_count_change(self):
+        xf = AffineTransformTransformer(AffineTransformSettings(weights="car", axis="ch"))
+        for n_ch in (4, 8):
+            X = _rng().normal(size=(5, n_ch))
+            out = xf(AxisArray(X, dims=["time", "ch"], key="k"))
+            np.testing.assert_allclose(out.data, X - X.mean(axis=1, keepdims=True), atol=1e-12)

--- a/tests/unit/test_util_channels.py
+++ b/tests/unit/test_util_channels.py
@@ -1,7 +1,8 @@
 import numpy as np
+import pytest
 from ezmsg.util.messages.axisarray import AxisArray
 
-from ezmsg.sigproc.util.channels import channel_clusters_from_field
+from ezmsg.sigproc.util.channels import channel_clusters_from_field, validate_channel_clusters
 
 
 def _msg(banks: list[str], n_data: int | None = None, field: str = "bank") -> AxisArray:
@@ -79,3 +80,21 @@ def test_linear_axis_returns_none():
 def test_length_mismatch_returns_none():
     """Coord length != channel-dim size is treated as unusable metadata."""
     assert channel_clusters_from_field(_msg(["A", "A"], n_data=4), "ch", "bank") is None
+
+
+class TestValidateChannelClusters:
+    def test_valid_clusters_pass(self):
+        validate_channel_clusters([[0, 1], [2, 3]], 4)
+
+    def test_empty_spec_passes(self):
+        validate_channel_clusters([], 4)
+        validate_channel_clusters([[]], 4)
+        validate_channel_clusters([], 0)
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="out-of-range"):
+            validate_channel_clusters([[0, 1, 4]], 4)
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="out-of-range"):
+            validate_channel_clusters([[-1, 0]], 4)


### PR DESCRIPTION
## Summary

- New `ezmsg.sigproc.util.rereference` module:
  - `RereferenceKind` str-enum (`identity` | `car`) — round-trips through config as plain strings.
  - `car_matrix(n_channels, *, clusters=None, include_current=True, min_reref_size=1, dtype=float64)` — per-cluster common-average reference as a symmetric weight matrix, supporting standard and leave-one-out CAR; clusters below `min_reref_size` stay identity (named distinctly from `AffineTransformSettings.min_cluster_size`, the block-diagonal matmul merge threshold).
  - `rereference_matrix(kind, ...)` dispatcher.
  - Matrices are host-side numpy: `AffineTransformTransformer` already converts weights to the message's array namespace/dtype/device on first use, so this stays Array-API/GPU friendly without any device-side construction code.
- `AffineTransformSettings.weights` now also accepts a `RereferenceKind` or its string value (e.g. `weights: car` in config), built over `channel_clusters` at reset — the same cluster spec drives both matrix construction and the block-diagonal matmul optimization. `weights=None` remains the zero-cost passthrough.
  - Docstrings note that users who simply want streaming CAR are better served by `CommonRereference` in the same module (per-sample mean subtraction, `median` support); kind-based weights exist for discoverability of deterministic transforms and for workflows that start from such a matrix and later replace it via `set_weights()`.
- Extracted shared `validate_channel_clusters()` into `util.channels`, replacing duplicated cluster bounds checks (also to be consumed by ezmsg-learn's SSR module).

## Motivation

ezmsg-learn PR ezmsg-org/ezmsg-learn#19 adds a CAR cold-start default to LRR; this PR hoists the deterministic-rereference matrix construction into ezmsg-sigproc so LRR (and any affine-transform user) can share one implementation. Once released, the learn PR reduces to a single `rereference_matrix(...)` call.

## Notes

- Minor edge case: a weights file literally named `car` or `identity` (bare relative path, no extension) is now interpreted as a kind rather than a path — same precedent as the existing `"passthrough"` special value.
- Error message for out-of-range clusters is unified as "channel_clusters contains out-of-range indices…" (two test regexes updated accordingly).

## Testing

- New `tests/unit/test_rereference.py`: 19 tests covering both CAR flavors, per-cluster independence, small/singleton-cluster guards, bipolar pair case, symmetry, bounds validation, string dispatch, and kind-based weights through `AffineTransformTransformer` (incl. rebuild on channel-count change).
- New validator tests in `tests/unit/test_util_channels.py`.
- Full affected suites pass: 79 tests across rereference/affine/channels; ezmsg-learn's unit suite (308 tests) also passes against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)