### PR TITLE
Bound MLX Metal chunk specializations

### DIFF
--- a/benchmarks/benchmark_mlx_metal_tail_specialization.py
+++ b/benchmarks/benchmark_mlx_metal_tail_specialization.py
@@ -1,0 +1,120 @@
+"""Measure MLX Metal compile cost for full chunks and variable-length tails.
+
+This is intentionally a single-shot benchmark rather than a pytest-benchmark
+test: compilation is cached after the first specialization, so repeated rounds
+would mostly measure the warm steady state and hide the startup compile storm.
+
+Run from the repository root, for example::
+
+    uv run python benchmarks/benchmark_mlx_metal_tail_specialization.py
+    uv run python benchmarks/benchmark_mlx_metal_tail_specialization.py --operation ewma
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from collections.abc import Callable
+
+import mlx.core as mx
+import numpy as np
+import scipy.signal
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--operation", choices=("sosfilt", "ewma"), default="sosfilt")
+    parser.add_argument("--channels", type=int, default=256)
+    chunk_group = parser.add_mutually_exclusive_group()
+    chunk_group.add_argument("--chunk-size", type=int, help="Benchmark one backward-compatible CS value")
+    chunk_group.add_argument("--chunk-sizes", type=int, nargs="+", help="Allowable adaptive CS specializations")
+    parser.add_argument("--base-chunks", type=int, default=2)
+    parser.add_argument("--tail-start", type=int, default=1)
+    parser.add_argument("--tail-count", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=187)
+    return parser
+
+
+def _build_runner(operation: str, channels: int, chunk_sizes: tuple[int, ...], seed: int) -> Callable[[int], float]:
+    rng = np.random.default_rng(seed)
+    inputs: dict[int, mx.array] = {}
+
+    if operation == "sosfilt":
+        from ezmsg.sigproc.util.sosfilt_mlx_metal import sosfilt_mlx_metal
+
+        sos = mx.array(
+            scipy.signal.butter(
+                4,
+                [10.0, 450.0],
+                btype="bandpass",
+                fs=30_000.0,
+                output="sos",
+            ).astype(np.float32)
+        )
+
+        def invoke(x: mx.array):
+            return sosfilt_mlx_metal(sos, x, chunk_sizes=chunk_sizes)
+
+    else:
+        from ezmsg.sigproc.util.ewma_mlx_metal import ewma_mlx_metal
+
+        zi = mx.zeros((channels, 1), dtype=mx.float32)
+
+        def invoke(x: mx.array):
+            return ewma_mlx_metal(x, alpha=0.1, zi=zi, chunk_sizes=chunk_sizes)
+
+    def run(n_samples: int) -> float:
+        if n_samples not in inputs:
+            inputs[n_samples] = mx.array(rng.standard_normal((channels, n_samples), dtype=np.float32))
+        started = time.perf_counter()
+        y, zf = invoke(inputs[n_samples])
+        mx.eval(y, zf)
+        return (time.perf_counter() - started) * 1e3
+
+    return run
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.chunk_sizes is not None:
+        chunk_sizes = tuple(args.chunk_sizes)
+    elif args.chunk_size is not None:
+        chunk_sizes = (args.chunk_size,)
+    else:
+        chunk_sizes = (512,) if args.operation == "sosfilt" else (32, 1024)
+    max_chunk_size = max(chunk_sizes)
+    if not 1 <= args.tail_start < max_chunk_size:
+        raise ValueError("tail-start must be in [1, max(chunk-sizes))")
+    if args.tail_count < 1 or args.tail_start + args.tail_count > max_chunk_size:
+        raise ValueError("tail-count must select tails smaller than max(chunk-sizes)")
+
+    run = _build_runner(args.operation, args.channels, chunk_sizes, args.seed)
+    full_samples = args.base_chunks * max_chunk_size
+
+    rows: list[tuple[str, int, int, float]] = []
+    rows.append(("first full", full_samples, 0, run(full_samples)))
+    rows.append(("repeat full", full_samples, 0, run(full_samples)))
+    for tail in range(args.tail_start, args.tail_start + args.tail_count):
+        n_samples = full_samples + tail
+        rows.append(("new tail", n_samples, tail, run(n_samples)))
+
+    repeat_tail = args.tail_start
+    repeat_samples = full_samples + repeat_tail
+    rows.append(("repeat tail", repeat_samples, repeat_tail, run(repeat_samples)))
+
+    print(
+        f"operation={args.operation} channels={args.channels} "
+        f"chunk_sizes={chunk_sizes} base_chunks={args.base_chunks}"
+    )
+    print(f"{'phase':<12} {'samples':>8} {'tail':>6} {'elapsed (ms)':>14}")
+    for phase, n_samples, tail, elapsed_ms in rows:
+        print(f"{phase:<12} {n_samples:>8} {tail:>6} {elapsed_ms:>14.2f}")
+
+    new_tail_times = [elapsed_ms for phase, _, _, elapsed_ms in rows if phase == "new tail"]
+    print(f"new-tail median: {statistics.median(new_tail_times):.2f} ms")
+    print(f"repeat-tail:     {rows[-1][3]:.2f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ezmsg/sigproc/butterworthzerophase.py
+++ b/src/ezmsg/sigproc/butterworthzerophase.py
@@ -277,7 +277,13 @@ class ButterworthBackwardFilterTransformer(FilterByDesignTransformer[Butterworth
         if use_mlx_metal:
             if self._sos_mx is None:
                 self._sos_mx = _mx.array(np.asarray(self._coefs_cache).astype(np.float32))
-            y_bwd_rev, _ = _sosfilt_mlx_metal_xp(self._sos_mx, combined_rev, buffer_ax_idx, backward_zi)
+            y_bwd_rev, _ = _sosfilt_mlx_metal_xp(
+                self._sos_mx,
+                combined_rev,
+                buffer_ax_idx,
+                backward_zi,
+                self.settings.mlx_metal_chunk_sizes,
+            )
         elif self.settings.coef_type == "ba":
             b, a = self._coefs_cache
             y_bwd_rev, _ = scipy.signal.lfilter(b, a, combined_rev, axis=buffer_ax_idx, zi=backward_zi)

--- a/src/ezmsg/sigproc/ewma.py
+++ b/src/ezmsg/sigproc/ewma.py
@@ -13,19 +13,18 @@ from ezmsg.util.messages.axisarray import AxisArray, slice_along_axis
 from ezmsg.util.messages.util import replace
 
 
-def _ewma_mlx_metal_xp(data, axis_idx: int, zi, alpha: float):
+def _ewma_mlx_metal_xp(data, axis_idx: int, zi, alpha: float, chunk_sizes: tuple[int, ...]):
     """Run EWMA through the MLX Metal helper while preserving scipy zi layout."""
     import mlx.core as mx
 
-    from .util.ewma_mlx_metal import MAX_CHUNK_SIZE, ewma_mlx_metal
+    from .util.ewma_mlx_metal import ewma_mlx_metal
 
     zi = mx.asarray(zi, dtype=data.dtype)
     last_data_axis = data.ndim - 1
     last_zi_axis = zi.ndim - 1
     x_mx = mx.moveaxis(data, axis_idx, last_data_axis) if axis_idx != last_data_axis else data
     zi_mx = mx.moveaxis(zi, axis_idx, last_zi_axis) if axis_idx != last_zi_axis else zi
-    cs = min(x_mx.shape[-1], MAX_CHUNK_SIZE)
-    y_mx, zf_mx = ewma_mlx_metal(x_mx, alpha, zi_mx, chunk_size=cs)
+    y_mx, zf_mx = ewma_mlx_metal(x_mx, alpha, zi_mx, chunk_sizes=chunk_sizes)
     y = mx.moveaxis(y_mx, last_data_axis, axis_idx) if axis_idx != last_data_axis else y_mx
     zf = mx.moveaxis(zf_mx, last_zi_axis, axis_idx) if axis_idx != last_zi_axis else zf_mx
     return y, zf
@@ -175,6 +174,12 @@ class EWMASettings(ez.Settings):
     baseline estimate -- passthrough leaves the data untouched. May be toggled
     at runtime without resetting the filter state."""
 
+    mlx_metal_chunk_sizes: tuple[int, ...] = (32, 1024)
+    """Allowable compile-time chunk sizes for EWMA Metal kernels. The smallest
+    size that fits the remaining samples is selected on each launch; otherwise
+    the largest size is repeated. Specializations compile lazily on first use.
+    Values must be in ``[1, 1024]``."""
+
 
 @processor_state
 class EWMAState:
@@ -188,7 +193,7 @@ class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray
     # `accumulate` is read live in `_process` to gate state updates and
     # `passthrough` is read live in `__call__`/`__acall__`; other fields are
     # cached into state (alpha, zi) during `_reset_state`.
-    NONRESET_SETTINGS_FIELDS = frozenset({"accumulate", "passthrough"})
+    NONRESET_SETTINGS_FIELDS = frozenset({"accumulate", "passthrough", "mlx_metal_chunk_sizes"})
 
     def __call__(self, message: AxisArray) -> AxisArray:
         if self.settings.passthrough or np.prod(message.data.shape) == 0:
@@ -222,7 +227,13 @@ class EWMATransformer(BaseStatefulTransformer[EWMASettings, AxisArray, AxisArray
 
         xp = np if is_numpy_array(message.data) else get_namespace(message.data)
         if xp is not np and xp.__name__ == "mlx.core":
-            expected, zf = _ewma_mlx_metal_xp(message.data, axis_idx, self._state.zi, self._state.alpha)
+            expected, zf = _ewma_mlx_metal_xp(
+                message.data,
+                axis_idx,
+                self._state.zi,
+                self._state.alpha,
+                self.settings.mlx_metal_chunk_sizes,
+            )
             if self.settings.accumulate:
                 self._state.zi = zf
         elif self.settings.accumulate:

--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -33,6 +33,29 @@ except ImportError:
     _HAS_MLX_METAL = False
 
 
+_MISSING = object()
+
+
+def _changed_settings_fields(old_settings, new_settings) -> set[str]:
+    """Names of settings fields that differ between two settings instances.
+
+    Equivalent to ``ezmsg.baseproc``'s private helper, but tolerant of
+    array-valued fields (e.g. ``cutoff`` as a sequence of band edges), whose
+    ``!=`` yields an array rather than a bool.
+    """
+    changed = set()
+    for settings_field in dataclasses.fields(new_settings):
+        old_value = getattr(old_settings, settings_field.name, _MISSING)
+        new_value = getattr(new_settings, settings_field.name)
+        try:
+            differs = bool(old_value != new_value)
+        except (TypeError, ValueError):
+            differs = not np.array_equal(old_value, new_value)
+        if differs:
+            changed.add(settings_field.name)
+    return changed
+
+
 @dataclass
 class FilterCoefficients:
     b: np.ndarray = field(default_factory=lambda: np.array([1.0, 0.0]))
@@ -587,11 +610,7 @@ class FilterByDesignTransformer(
         else:
             self.settings = replace(self.settings, **kwargs)
 
-        changed = {
-            settings_field.name
-            for settings_field in dataclasses.fields(self.settings)
-            if getattr(old_settings, settings_field.name) != getattr(self.settings, settings_field.name)
-        }
+        changed = _changed_settings_fields(old_settings, self.settings)
 
         if self.state.filter is not None:
             if changed <= {"mlx_metal_chunk_sizes"}:

--- a/src/ezmsg/sigproc/filter.py
+++ b/src/ezmsg/sigproc/filter.py
@@ -1,5 +1,6 @@
 """Core IIR/FIR filtering infrastructure with BA and SOS coefficient support."""
 
+import dataclasses
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -24,7 +25,6 @@ from .util.array import array_device, xp_asarray, xp_create
 try:
     import mlx.core as _mx
 
-    from .util.sosfilt_mlx_metal import MAX_CHUNK_SIZE as _MLX_MAX_CHUNK_SIZE
     from .util.sosfilt_mlx_metal import sos_float32_stable as _sos_float32_stable
     from .util.sosfilt_mlx_metal import sosfilt_mlx_metal as _sosfilt_mlx_metal_fn
 
@@ -159,7 +159,7 @@ def _sosfilt_xp(sos, x, axis_idx, zi, xp):
     return x, zi_out
 
 
-def _sosfilt_mlx_metal_xp(sos_mx, data, axis_idx, zi):
+def _sosfilt_mlx_metal_xp(sos_mx, data, axis_idx, zi, chunk_sizes):
     """Apply SOS filtering via the on-device Metal kernel.
 
     The kernel requires time as the last axis of its input; ``zi`` is kept
@@ -170,8 +170,7 @@ def _sosfilt_mlx_metal_xp(sos_mx, data, axis_idx, zi):
     """
     x_mx = _mx.moveaxis(data, axis_idx, -1) if axis_idx != data.ndim - 1 else data
     zi_mx = _mx.moveaxis(zi, axis_idx + 1, -1) if axis_idx + 1 != zi.ndim - 1 else zi
-    cs = min(x_mx.shape[-1], _MLX_MAX_CHUNK_SIZE)
-    y_mx, zf_mx = _sosfilt_mlx_metal_fn(sos_mx, x_mx, zi=zi_mx, chunk_size=cs)
+    y_mx, zf_mx = _sosfilt_mlx_metal_fn(sos_mx, x_mx, zi=zi_mx, chunk_sizes=chunk_sizes)
     y = _mx.moveaxis(y_mx, -1, axis_idx) if axis_idx != data.ndim - 1 else y_mx
     zf = _mx.moveaxis(zf_mx, -1, axis_idx + 1) if axis_idx + 1 != zi.ndim - 1 else zf_mx
     return y, zf
@@ -288,6 +287,12 @@ class FilterBaseSettings(ez.Settings):
     through scipy. Set to False to fall back to the scipy path (bit-exact
     with numpy at the cost of CPU round-trips and ~5-8x slowdown)."""
 
+    mlx_metal_chunk_sizes: tuple[int, ...] = (512,)
+    """Allowable compile-time chunk sizes for SOS Metal kernels. The smallest
+    size that fits the remaining samples is selected on each launch; otherwise
+    the largest size is repeated. Specializations compile lazily on first use.
+    Values must be in ``[1, 512]``."""
+
 
 class FilterSettings(FilterBaseSettings):
     coefs: FilterCoefficients | None = None
@@ -310,6 +315,8 @@ class FilterTransformer(BaseStatefulTransformer[FilterSettings, AxisArray, AxisA
     """
     Filter data using the provided coefficients.
     """
+
+    NONRESET_SETTINGS_FIELDS = frozenset({"mlx_metal_chunk_sizes"})
 
     def __call__(self, message: AxisArray) -> AxisArray:
         if self.settings.coefs is None:
@@ -488,7 +495,13 @@ class FilterTransformer(BaseStatefulTransformer[FilterSettings, AxisArray, AxisA
                 if self.state.sos_mx is None:
                     _, coefs = _normalize_coefs(self.settings.coefs)
                     self.state.sos_mx = _mx.array(np.asarray(coefs[0]).astype(np.float32))
-                dat_out, self.state.zi = _sosfilt_mlx_metal_xp(self.state.sos_mx, message.data, axis_idx, self.state.zi)
+                dat_out, self.state.zi = _sosfilt_mlx_metal_xp(
+                    self.state.sos_mx,
+                    message.data,
+                    axis_idx,
+                    self.state.zi,
+                    self.settings.mlx_metal_chunk_sizes,
+                )
             elif self.state.sos_method == "scipy_numpy":
                 _, coefs = _normalize_coefs(self.settings.coefs)
                 filt_func = {"ba": scipy.signal.lfilter, "sos": scipy.signal.sosfilt}[self.settings.coef_type]
@@ -568,15 +581,26 @@ class FilterByDesignTransformer(
             new_settings: Complete new settings object to replace current settings
             **kwargs: Individual settings to update
         """
-        # Update settings
+        old_settings = self.settings
         if new_settings is not None:
             self.settings = new_settings
         else:
             self.settings = replace(self.settings, **kwargs)
 
-        # Set flag to trigger recalculation on next message
+        changed = {
+            settings_field.name
+            for settings_field in dataclasses.fields(self.settings)
+            if getattr(old_settings, settings_field.name) != getattr(self.settings, settings_field.name)
+        }
+
         if self.state.filter is not None:
-            self.state.needs_redesign = True
+            if changed <= {"mlx_metal_chunk_sizes"}:
+                self.state.filter.settings = replace(
+                    self.state.filter.settings,
+                    mlx_metal_chunk_sizes=self.settings.mlx_metal_chunk_sizes,
+                )
+            else:
+                self.state.needs_redesign = True
 
     def __call__(self, message: AxisArray) -> AxisArray:
         # Offer a shortcut when there is no design function or order is 0.
@@ -629,6 +653,7 @@ class FilterByDesignTransformer(
             coef_type=self.settings.coef_type,
             coefs=coefs,
             use_mlx_metal=self.settings.use_mlx_metal,
+            mlx_metal_chunk_sizes=self.settings.mlx_metal_chunk_sizes,
         )
         self.state.filter = FilterTransformer(settings=new_settings)
         self.state.needs_redesign = False

--- a/src/ezmsg/sigproc/util/ewma_mlx_metal.py
+++ b/src/ezmsg/sigproc/util/ewma_mlx_metal.py
@@ -2,12 +2,12 @@
 
 import mlx.core as mx
 
-from .mlx_metal_common import chunked_scan, flatten_batch, restore_batch, to_float32
+from .mlx_metal_common import chunked_scan, flatten_batch, normalize_chunk_sizes, restore_batch, to_float32
 
 MAX_CHUNK_SIZE = 1024
 
 
-def ewma_mlx_metal(x, alpha: float, zi, chunk_size: int = MAX_CHUNK_SIZE):
+def ewma_mlx_metal(x, alpha: float, zi, chunk_size: int = MAX_CHUNK_SIZE, *, chunk_sizes=None):
     """Apply ``y[n] = alpha*x[n] + (1-alpha)*y[n-1]`` on-device.
 
     Args:
@@ -15,15 +15,19 @@ def ewma_mlx_metal(x, alpha: float, zi, chunk_size: int = MAX_CHUNK_SIZE):
         alpha: EWMA update coefficient.
         zi: Initial scipy-style filter state, i.e. ``(1-alpha) * y[-1]``,
             shaped like ``x.shape[:-1] + (1,)``.
-        chunk_size: Maximum samples per Metal launch.
+        chunk_size: Maximum samples per Metal launch. Ignored when
+            ``chunk_sizes`` is provided. Retained for backward compatibility.
+        chunk_sizes: Allowable compile-time kernel sizes. The smallest size
+            that fits the remaining samples is selected for each launch, and
+            each specialization is compiled lazily and cached by MLX.
 
     Returns:
         ``(y, zf)`` where ``zf`` has the same shape/convention as ``zi``.
     """
-    if chunk_size > MAX_CHUNK_SIZE:
-        raise ValueError(f"chunk_size={chunk_size} exceeds MAX_CHUNK_SIZE={MAX_CHUNK_SIZE}")
-    if chunk_size < 1:
-        raise ValueError(f"chunk_size must be >= 1; got {chunk_size}")
+    allowed_chunk_sizes = normalize_chunk_sizes(
+        (chunk_size,) if chunk_sizes is None else chunk_sizes,
+        MAX_CHUNK_SIZE,
+    )
     if x.ndim < 1:
         raise ValueError(f"x must have at least 1 dimension; got {x.ndim}")
     if zi.shape != tuple(x.shape[:-1]) + (1,):
@@ -36,10 +40,10 @@ def ewma_mlx_metal(x, alpha: float, zi, chunk_size: int = MAX_CHUNK_SIZE):
     x_flat, batch_shape, n_channels, n_samples = flatten_batch(x_f32)
     zi_flat = zi_f32.reshape(n_channels)
 
-    def launch(x_chunk, state, cs):
-        return _launch_kernel(x_chunk, coef, state, n_channels, cs)
+    def launch(x_chunk, state, cs, valid_length):
+        return _launch_kernel(x_chunk, coef, state, n_channels, cs, valid_length)
 
-    y_combined, zi_flat = chunked_scan(x_flat, n_samples, chunk_size, zi_flat, launch)
+    y_combined, zi_flat = chunked_scan(x_flat, n_samples, allowed_chunk_sizes, zi_flat, launch)
 
     y_out = restore_batch(y_combined, batch_shape, n_samples)
     zf_out = zi_flat.reshape(*batch_shape, 1) if batch_shape else zi_flat.reshape(1)
@@ -49,6 +53,7 @@ def ewma_mlx_metal(x, alpha: float, zi, chunk_size: int = MAX_CHUNK_SIZE):
 _KERNEL_SOURCE = r"""
     uint t  = thread_position_in_threadgroup.x;
     uint ch = threadgroup_position_in_grid.x;
+    uint valid = valid_length[0];
 
     float alpha = coef[0];
     float beta  = coef[1];
@@ -96,9 +101,11 @@ _KERNEL_SOURCE = r"""
     }
 
     float z_prev = t == 0 ? zi : s_v[src * CS + t - 1];
-    y_out[ch * CS + t] = alpha * x_val + z_prev;
+    if (t < valid) {
+        y_out[ch * CS + t] = alpha * x_val + z_prev;
+    }
 
-    if (t == CS - 1) {
+    if (t == valid - 1) {
         zf_out[ch] = s_v[src * CS + t];
     }
 """
@@ -106,15 +113,15 @@ _KERNEL_SOURCE = r"""
 
 _kernel = mx.fast.metal_kernel(
     name="ewma_first_order",
-    input_names=["x_in", "coef", "zi_in"],
+    input_names=["x_in", "coef", "zi_in", "valid_length"],
     output_names=["y_out", "zf_out"],
     source=_KERNEL_SOURCE,
 )
 
 
-def _launch_kernel(x_chunk, coef, zi_flat, n_channels: int, cs: int):
+def _launch_kernel(x_chunk, coef, zi_flat, n_channels: int, cs: int, valid_length):
     y_chunk, zf = _kernel(
-        inputs=[x_chunk, coef, zi_flat],
+        inputs=[x_chunk, coef, zi_flat, valid_length],
         template=[
             ("CS", cs),
         ],

--- a/src/ezmsg/sigproc/util/mlx_metal_common.py
+++ b/src/ezmsg/sigproc/util/mlx_metal_common.py
@@ -7,7 +7,27 @@ the per-chunk state forward. Those pieces live here so the kernel modules can
 focus on their actual Metal source and per-op state layout.
 """
 
+import numbers
+
 import mlx.core as mx
+
+
+def normalize_chunk_sizes(chunk_sizes, max_chunk_size):
+    """Return sorted, unique, validated Metal kernel chunk sizes."""
+    try:
+        requested = tuple(chunk_sizes)
+    except TypeError as exc:
+        raise ValueError("chunk_sizes must be an iterable of integers") from exc
+    if not requested:
+        raise ValueError("chunk_sizes must contain at least one size")
+    if any(not isinstance(size, numbers.Integral) or isinstance(size, bool) for size in requested):
+        raise ValueError(f"chunk_sizes must contain only integers; got {requested!r}")
+    sizes = tuple(sorted({int(size) for size in requested}))
+    if sizes[0] < 1:
+        raise ValueError(f"chunk_sizes must contain only positive sizes; got {sizes!r}")
+    if sizes[-1] > max_chunk_size:
+        raise ValueError(f"chunk_sizes={sizes!r} exceeds MAX_CHUNK_SIZE={max_chunk_size}")
+    return sizes
 
 
 def to_float32(arr):
@@ -38,21 +58,36 @@ def restore_batch(y_combined, batch_shape, n_samples):
     return y_combined.reshape(n_samples)
 
 
-def chunked_scan(x_flat, n_samples, chunk_size, state, launch_fn):
+def chunked_scan(x_flat, n_samples, chunk_sizes, state, launch_fn):
     """Drive a chunked recurrence kernel over the time axis.
 
-    Calls ``launch_fn(x_chunk, state, cs) -> (y_chunk, new_state)`` once per
-    chunk of up to ``chunk_size`` samples, threading ``state`` through. The
-    caller closes over any extra kernel inputs (coefficients, sizes) inside
-    ``launch_fn``.
+    ``chunk_sizes`` is a sorted tuple of allowable compile-time kernel sizes.
+    Each launch uses the smallest allowable size that fits all remaining
+    samples, or the largest size when multiple launches are required. A short
+    chunk is zero-padded to the selected size and its runtime ``valid_length``
+    is passed as a one-item uint32 array. This bounds the set of Metal kernel
+    specializations while avoiding unnecessary launches.
+
+    The caller closes over any extra kernel inputs (coefficients, sizes) inside
+    ``launch_fn``. Kernels must emit their state at ``valid_length - 1`` rather
+    than after the padding.
 
     Returns ``(y_combined, final_state)``.
     """
     y_chunks = []
-    for start in range(0, n_samples, chunk_size):
-        end = min(start + chunk_size, n_samples)
-        cs = end - start
-        y_chunk, state = launch_fn(x_flat[:, start:end], state, cs)
-        y_chunks.append(y_chunk)
+    start = 0
+    max_chunk_size = chunk_sizes[-1]
+    while start < n_samples:
+        remaining = n_samples - start
+        chunk_size = next((size for size in chunk_sizes if size >= remaining), max_chunk_size)
+        valid = min(remaining, chunk_size)
+        end = start + valid
+        x_chunk = x_flat[:, start:end]
+        if valid < chunk_size:
+            x_chunk = mx.pad(x_chunk, [(0, 0), (0, chunk_size - valid)])
+        valid_length = mx.array([valid], dtype=mx.uint32)
+        y_chunk, state = launch_fn(x_chunk, state, chunk_size, valid_length)
+        y_chunks.append(y_chunk[:, :valid])
+        start = end
     y_combined = y_chunks[0] if len(y_chunks) == 1 else mx.concatenate(y_chunks, axis=-1)
     return y_combined, state

--- a/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
+++ b/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
@@ -697,7 +697,7 @@ def _sosfilt_mlx_metal_unfused(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE, *, ch
         sos_row = sos_f32[s]
         state = zi_per_section[s]
 
-        def launch(x_chunk, section_state, cs, valid_length):
+        def launch(x_chunk, section_state, cs, valid_length, sos_row=sos_row):
             return _launch_unfused_kernel(x_chunk, sos_row, section_state, cs, valid_length)
 
         y_current, state = chunked_scan(y_current, n_samples, allowed_chunk_sizes, state, launch)

--- a/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
+++ b/src/ezmsg/sigproc/util/sosfilt_mlx_metal.py
@@ -64,7 +64,7 @@ import weakref
 import mlx.core as mx
 import numpy as np
 
-from .mlx_metal_common import chunked_scan, flatten_batch, restore_batch, to_float32
+from .mlx_metal_common import chunked_scan, flatten_batch, normalize_chunk_sizes, restore_batch, to_float32
 
 # ---------------------------------------------------------------------------
 # Module constants
@@ -132,7 +132,7 @@ def _cached_sos_float32_max_pole_radius(sos) -> float:
 # ---------------------------------------------------------------------------
 
 
-def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
+def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE, *, chunk_sizes=None):
     """Apply an SOS biquad filter cascade on-device.
 
     One fused Metal kernel launch per chunk handles typical biquad sections
@@ -152,7 +152,13 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
             ``(n_sections, *batch, 2)``. ``None`` is equivalent to zeros.
         chunk_size: Maximum samples per kernel invocation. Longer signals
             are chunked automatically with state carried between chunks.
-            Must be in ``[1, MAX_CHUNK_SIZE]``.
+            Must be in ``[1, MAX_CHUNK_SIZE]``. Ignored when ``chunk_sizes``
+            is provided. Retained for backward compatibility.
+        chunk_sizes: Allowable compile-time kernel sizes. For each launch, the
+            smallest size that fits the remaining samples is selected. If no
+            size fits, the largest size is launched repeatedly. Each selected
+            specialization is compiled lazily and cached by MLX. Defaults to
+            ``(chunk_size,)``.
 
     Returns:
         Tuple ``(y, zf)``:
@@ -162,25 +168,21 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
           suitable to pass as ``zi`` for the next chunk in streaming use.
 
     Raises:
-        ValueError: if ``sos`` has the wrong shape, if ``chunk_size`` is out
-            of range, or if the float32 SOS denominator would be unstable.
+        ValueError: if ``sos`` has the wrong shape, if a chunk size is out of
+            range, or if the float32 SOS denominator would be unstable.
 
     Notes:
         The kernel is compiled once per distinct
-        ``(chunk_size, n_sections, n_channels)`` combination and cached
-        by MLX. The first call with any new combination pays a one-time
-        compile cost of ~60–150 ms.
+        ``(selected_chunk_size, n_sections, n_channels)`` combination and
+        cached by MLX. A short chunk uses the selected specialization with its
+        valid length supplied at runtime.
     """
     if sos.ndim != 2 or sos.shape[1] != 6:
         raise ValueError(f"sos must have shape (n_sections, 6); got {tuple(sos.shape)}")
-    if chunk_size > MAX_CHUNK_SIZE:
-        raise ValueError(
-            f"chunk_size={chunk_size} exceeds MAX_CHUNK_SIZE={MAX_CHUNK_SIZE}. "
-            f"Raising this requires verifying threadgroup memory fits on "
-            f"your hardware."
-        )
-    if chunk_size < 1:
-        raise ValueError(f"chunk_size must be >= 1; got {chunk_size}")
+    allowed_chunk_sizes = normalize_chunk_sizes(
+        (chunk_size,) if chunk_sizes is None else chunk_sizes,
+        MAX_CHUNK_SIZE,
+    )
     if x.ndim < 1:
         raise ValueError(f"x must have at least 1 dimension; got {x.ndim}")
 
@@ -214,10 +216,10 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
 
     launch_one = _launch_serial_kernel if use_serial_kernel else _launch_fused_kernel
 
-    def launch(x_chunk, state, cs):
-        return launch_one(x_chunk, sos_flat, state, n_channels, n_sections, cs)
+    def launch(x_chunk, state, cs, valid_length):
+        return launch_one(x_chunk, sos_flat, state, n_channels, n_sections, cs, valid_length)
 
-    y_combined, zi_flat = chunked_scan(x_flat, n_samples, chunk_size, zi_flat, launch)
+    y_combined, zi_flat = chunked_scan(x_flat, n_samples, allowed_chunk_sizes, zi_flat, launch)
 
     y_out = restore_batch(y_combined, batch_shape, n_samples)
     zf_out = zi_flat.reshape(n_sections, *batch_shape, 2) if batch_shape else zi_flat.reshape(n_sections, 2)
@@ -262,6 +264,7 @@ def sosfilt_mlx_metal(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
 _FUSED_KERNEL_SOURCE = r"""
     uint t  = thread_position_in_threadgroup.x;
     uint ch = threadgroup_position_in_grid.x;
+    uint valid = valid_length[0];
 
     // Ping-pong shared buffers for (M, v), plus an inter-section y stash.
     threadgroup float s_M00[2 * CS];
@@ -371,8 +374,8 @@ _FUSED_KERNEL_SOURCE = r"""
         }
         s_y[t] = y_val;
 
-        // Write this section's final state (last thread only).
-        if (t == CS - 1) {
+        // Write this section's final state at the valid tail boundary.
+        if (t == valid - 1) {
             zf_all[zi_base + 0] = s_v0[src * CS + t];
             zf_all[zi_base + 1] = s_v1[src * CS + t];
         }
@@ -391,26 +394,28 @@ _FUSED_KERNEL_SOURCE = r"""
     }
 
     // Final section's y for this thread.
-    y_out[ch * CS + t] = x_val;
+    if (t < valid) {
+        y_out[ch * CS + t] = x_val;
+    }
 """
 
 
 _fused_kernel = mx.fast.metal_kernel(
     name="sosfilt_biquad_fused",
-    input_names=["x_in", "sos_all", "zi_all"],
+    input_names=["x_in", "sos_all", "zi_all", "valid_length"],
     output_names=["y_out", "zf_all"],
     source=_FUSED_KERNEL_SOURCE,
 )
 
 
-def _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs):
+def _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs, valid_length):
     """One kernel dispatch covering all sections for one chunk.
 
     Returns ``(y_chunk, zf_flat)`` both as ``float32`` MLX arrays. The
     caller rebinds ``zi_flat = zf_flat`` between chunks for streaming.
     """
     y_chunk, zf_flat = _fused_kernel(
-        inputs=[x_chunk, sos_flat, zi_flat],
+        inputs=[x_chunk, sos_flat, zi_flat, valid_length],
         template=[
             ("T", mx.float32),
             ("CS", cs),
@@ -441,6 +446,7 @@ def _launch_fused_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs)
 
 _SERIAL_KERNEL_SOURCE = r"""
     uint ch = thread_position_in_grid.x;
+    uint valid = valid_length[0];
 
     float z0[N_SECTIONS];
     float z1[N_SECTIONS];
@@ -450,7 +456,7 @@ _SERIAL_KERNEL_SOURCE = r"""
         z1[sec] = zi_all[zi_base + 1];
     }
 
-    for (uint t = 0; t < CS; t++) {
+    for (uint t = 0; t < valid; t++) {
         float x_val = x_in[ch * CS + t];
 
         for (uint sec = 0; sec < N_SECTIONS; sec++) {
@@ -483,16 +489,16 @@ _SERIAL_KERNEL_SOURCE = r"""
 
 _serial_kernel = mx.fast.metal_kernel(
     name="sosfilt_biquad_serial",
-    input_names=["x_in", "sos_all", "zi_all"],
+    input_names=["x_in", "sos_all", "zi_all", "valid_length"],
     output_names=["y_out", "zf_all"],
     source=_SERIAL_KERNEL_SOURCE,
 )
 
 
-def _launch_serial_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs):
+def _launch_serial_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs, valid_length):
     """One serial DF-II-T kernel dispatch for numerically delicate SOS filters."""
     y_chunk, zf_flat = _serial_kernel(
-        inputs=[x_chunk, sos_flat, zi_flat],
+        inputs=[x_chunk, sos_flat, zi_flat, valid_length],
         template=[
             ("T", mx.float32),
             ("CS", cs),
@@ -523,6 +529,7 @@ def _launch_serial_kernel(x_chunk, sos_flat, zi_flat, n_channels, n_sections, cs
 _UNFUSED_KERNEL_SOURCE = r"""
     uint t  = thread_position_in_threadgroup.x;
     uint ch = threadgroup_position_in_grid.x;
+    uint valid = valid_length[0];
 
     // Unpack single-section SOS row and derive affine form.
     float b0 = sos_row[0];
@@ -610,9 +617,11 @@ _UNFUSED_KERNEL_SOURCE = r"""
     } else {
         y_val = c0 * x_val + s_v0[src * CS + t - 1];
     }
-    y_out[ch * CS + t] = y_val;
+    if (t < valid) {
+        y_out[ch * CS + t] = y_val;
+    }
 
-    if (t == CS - 1) {
+    if (t == valid - 1) {
         zf_out[ch * 2 + 0] = s_v0[src * CS + t];
         zf_out[ch * 2 + 1] = s_v1[src * CS + t];
     }
@@ -621,18 +630,18 @@ _UNFUSED_KERNEL_SOURCE = r"""
 
 _unfused_kernel = mx.fast.metal_kernel(
     name="sosfilt_biquad_unfused",
-    input_names=["x_in", "sos_row", "zi"],
+    input_names=["x_in", "sos_row", "zi", "valid_length"],
     output_names=["y_out", "zf_out"],
     source=_UNFUSED_KERNEL_SOURCE,
 )
 
 
-def _launch_unfused_kernel(x_chunk, sos_row, state):
+def _launch_unfused_kernel(x_chunk, sos_row, state, cs, valid_length):
     """Single-section kernel dispatch. Used by
     :func:`_sosfilt_mlx_metal_unfused`."""
-    n_channels, cs = x_chunk.shape
+    n_channels = x_chunk.shape[0]
     y_chunk, zf = _unfused_kernel(
-        inputs=[x_chunk, sos_row, state],
+        inputs=[x_chunk, sos_row, state, valid_length],
         template=[("T", mx.float32), ("CS", cs)],
         grid=(n_channels * cs, 1, 1),
         threadgroup=(cs, 1, 1),
@@ -642,7 +651,7 @@ def _launch_unfused_kernel(x_chunk, sos_row, state):
     return y_chunk, zf
 
 
-def _sosfilt_mlx_metal_unfused(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
+def _sosfilt_mlx_metal_unfused(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE, *, chunk_sizes=None):
     """Unfused variant: one kernel launch per (section, chunk).
 
     Identical public signature and output to :func:`sosfilt_mlx_metal`,
@@ -654,10 +663,10 @@ def _sosfilt_mlx_metal_unfused(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
     """
     if sos.ndim != 2 or sos.shape[1] != 6:
         raise ValueError(f"sos must have shape (n_sections, 6); got {tuple(sos.shape)}")
-    if chunk_size > MAX_CHUNK_SIZE:
-        raise ValueError(f"chunk_size={chunk_size} > MAX_CHUNK_SIZE")
-    if chunk_size < 1:
-        raise ValueError("chunk_size must be >= 1")
+    allowed_chunk_sizes = normalize_chunk_sizes(
+        (chunk_size,) if chunk_sizes is None else chunk_sizes,
+        MAX_CHUNK_SIZE,
+    )
 
     sos_f32 = sos.astype(mx.float32) if sos.dtype != mx.float32 else sos
     x_f32 = x.astype(mx.float32) if x.dtype != mx.float32 else x
@@ -687,13 +696,11 @@ def _sosfilt_mlx_metal_unfused(sos, x, zi=None, chunk_size=MAX_CHUNK_SIZE):
     for s in range(n_sections):
         sos_row = sos_f32[s]
         state = zi_per_section[s]
-        y_chunks = []
-        for start in range(0, n_samples, chunk_size):
-            end = min(start + chunk_size, n_samples)
-            x_chunk = y_current[:, start:end]
-            y_chunk, state = _launch_unfused_kernel(x_chunk, sos_row, state)
-            y_chunks.append(y_chunk)
-        y_current = y_chunks[0] if len(y_chunks) == 1 else mx.concatenate(y_chunks, axis=-1)
+
+        def launch(x_chunk, section_state, cs, valid_length):
+            return _launch_unfused_kernel(x_chunk, sos_row, section_state, cs, valid_length)
+
+        y_current, state = chunked_scan(y_current, n_samples, allowed_chunk_sizes, state, launch)
         zf_list.append(state)
 
     if batch_shape:

--- a/tests/unit/test_butter.py
+++ b/tests/unit/test_butter.py
@@ -260,6 +260,27 @@ def test_butterworth_update_settings():
     assert power4[1][1] / power0[1][1] < 0.1  # 40Hz should be attenuated
 
 
+def test_butterworth_chunk_size_update_preserves_filter_state():
+    proc = ButterworthFilterTransformer(
+        ButterworthFilterSettings(
+            axis="time",
+            order=4,
+            cutoff=30.0,
+            coef_type="sos",
+        )
+    )
+    _ = proc(make_msg())
+    inner_filter = proc.state.filter
+    zi_before = inner_filter.state.zi.copy()
+
+    proc.update_settings(mlx_metal_chunk_sizes=(32, 256))
+
+    assert proc.state.filter is inner_filter
+    assert not proc.state.needs_redesign
+    assert np.array_equal(inner_filter.state.zi, zi_before)
+    assert inner_filter.settings.mlx_metal_chunk_sizes == (32, 256)
+
+
 def test_butterworth_empty_after_init_ba():
     from ezmsg.sigproc.butterworthfilter import ButterworthFilterSettings, ButterworthFilterTransformer
 

--- a/tests/unit/test_ewma.py
+++ b/tests/unit/test_ewma.py
@@ -129,6 +129,41 @@ def test_ewma_mlx_accepts_numpy_initialized_state():
     np.testing.assert_allclose(np.asarray(actual.data), expected.data, rtol=1e-4, atol=1e-5)
 
 
+@requires_mlx
+def test_ewma_mlx_dispatches_component_chunk_sizes(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    import ezmsg.sigproc.util.ewma_mlx_metal as ewma_metal_module
+
+    fs = 30_000.0
+    time_constant = 0.25
+    rng = np.random.default_rng(3)
+    settings = EWMASettings(
+        time_constant=time_constant,
+        axis="time",
+        mlx_metal_chunk_sizes=(32, 128),
+    )
+    proc_np = EWMATransformer(settings=settings)
+    proc_mx = EWMATransformer(settings=settings)
+
+    launches = []
+    original_launch = ewma_metal_module._launch_kernel
+
+    def recording_launch(x_chunk, coef, state, n_channels, cs, valid_length):
+        launches.append((cs, int(valid_length.item())))
+        return original_launch(x_chunk, coef, state, n_channels, cs, valid_length)
+
+    monkeypatch.setattr(ewma_metal_module, "_launch_kernel", recording_launch)
+    for n_samples in (30, 300):
+        data = rng.normal(size=(n_samples, 8)).astype(np.float32)
+        msg_np = AxisArray(data=data, dims=["time", "ch"], axes={"time": AxisArray.TimeAxis(fs=fs)})
+        msg_mx = replace_axisarray_data(msg_np, mx.array(data))
+        expected = proc_np(msg_np)
+        actual = proc_mx(msg_mx)
+        np.testing.assert_allclose(np.asarray(actual.data), expected.data, rtol=1e-4, atol=1e-5)
+
+    assert launches == [(32, 30), (128, 128), (128, 128), (128, 44)]
+
+
 def replace_axisarray_data(message: AxisArray, data) -> AxisArray:
     return AxisArray(data=data, dims=message.dims, axes=message.axes, key=message.key)
 
@@ -237,6 +272,7 @@ def test_ewma_settings_default_accumulate():
     """Test that EWMASettings defaults to accumulate=True."""
     settings = EWMASettings(time_constant=1.0)
     assert settings.accumulate is True
+    assert settings.mlx_metal_chunk_sizes == (32, 1024)
 
 
 def test_ewma_settings_accumulate_false():
@@ -315,6 +351,17 @@ def test_ewma_passthrough_toggle_preserves_state():
 
 class TestEWMAUpdateSettings:
     """Live settings updates via BaseProcessor.update_settings."""
+
+    def test_mlx_chunk_size_update_preserves_state(self):
+        proc = EWMATransformer(settings=EWMASettings(time_constant=0.1))
+        _ = proc(_make_ewma_test_msg(np.ones((10, 2))))
+        zi_before = proc._state.zi.copy()
+
+        proc.update_settings(EWMASettings(time_constant=0.1, mlx_metal_chunk_sizes=(64, 512)))
+
+        assert proc._hash != -1
+        assert np.array_equal(proc._state.zi, zi_before)
+        assert proc.settings.mlx_metal_chunk_sizes == (64, 512)
 
     def test_accumulate_toggle_preserves_state(self):
         proc = EWMATransformer(settings=EWMASettings(time_constant=0.1, accumulate=True))

--- a/tests/unit/test_firfilter.py
+++ b/tests/unit/test_firfilter.py
@@ -292,6 +292,29 @@ def test_firfilter_kaiser_width():
     assert result.data.shape == in_dat.shape
 
 
+def test_firfilter_update_settings_with_array_cutoff():
+    """Live settings updates must tolerate array-valued settings fields."""
+    settings = FIRFilterSettings(
+        axis="time",
+        order=51,
+        cutoff=np.array([10.0, 40.0]),
+        pass_zero=False,
+        wn_hz=True,
+        coef_type="ba",
+    )
+    transformer = FIRFilterTransformer(settings=settings)
+    _ = transformer(make_msg())
+    assert transformer.state.filter is not None
+
+    transformer.update_settings(order=63)
+    assert transformer.state.needs_redesign
+
+    transformer.state.needs_redesign = False
+    transformer.update_settings(mlx_metal_chunk_sizes=(32, 256))
+    assert not transformer.state.needs_redesign
+    assert transformer.state.filter.settings.mlx_metal_chunk_sizes == (32, 256)
+
+
 def test_fir_empty_after_init():
     from ezmsg.sigproc.firfilter import FIRFilterSettings, FIRFilterTransformer
 

--- a/tests/unit/test_sosfilt_mlx_metal.py
+++ b/tests/unit/test_sosfilt_mlx_metal.py
@@ -7,6 +7,10 @@ from ezmsg.sigproc.butterworthfilter import ButterworthFilterSettings, Butterwor
 from tests.helpers.util import requires_mlx
 
 
+def test_sos_component_default_chunk_sizes():
+    assert ButterworthFilterSettings().mlx_metal_chunk_sizes == (512,)
+
+
 @requires_mlx
 def test_sosfilt_mlx_metal_low_highpass_matches_scipy_float32():
     import mlx.core as mx
@@ -16,7 +20,9 @@ def test_sosfilt_mlx_metal_low_highpass_matches_scipy_float32():
     fs = 30_000.0
     sos = scipy.signal.butter(4, 3.0, btype="highpass", fs=fs, output="sos").astype(np.float32)
     rng = np.random.default_rng(0)
-    data = rng.standard_normal((3, 4096)).astype(np.float32)
+    # One full MAX_CHUNK_SIZE span plus a one-sample tail exercises runtime
+    # valid-length state emission in the numerically delicate serial kernel.
+    data = rng.standard_normal((3, 4097)).astype(np.float32)
 
     zi = np.zeros((sos.shape[0], data.shape[0], 2), dtype=np.float32)
     expected, expected_zf = scipy.signal.sosfilt(sos, data, axis=-1, zi=zi)
@@ -28,6 +34,127 @@ def test_sosfilt_mlx_metal_low_highpass_matches_scipy_float32():
     assert np.isfinite(actual_np).all()
     assert np.allclose(actual_np, expected, rtol=1e-5, atol=2e-5)
     assert np.allclose(np.asarray(actual_zf), expected_zf, rtol=1e-5, atol=2e-5)
+
+
+@requires_mlx
+def test_sosfilt_mlx_metal_variable_tails_preserve_streaming_state():
+    import mlx.core as mx
+
+    from ezmsg.sigproc.util.sosfilt_mlx_metal import _sosfilt_mlx_metal_unfused, sosfilt_mlx_metal
+
+    fs = 1_000.0
+    chunk_size = 128
+    sos = scipy.signal.butter(4, [30.0, 100.0], btype="bandpass", fs=fs, output="sos").astype(np.float32)
+    rng = np.random.default_rng(187)
+    blocks = [
+        rng.standard_normal((3, 257)).astype(np.float32),  # tail 1
+        rng.standard_normal((3, 259)).astype(np.float32),  # tail 3
+    ]
+
+    expected_state = np.zeros((sos.shape[0], 3, 2), dtype=np.float32)
+    actual_state = None
+    for block in blocks:
+        expected, expected_state = scipy.signal.sosfilt(sos, block, axis=-1, zi=expected_state)
+        actual, actual_state = sosfilt_mlx_metal(
+            mx.array(sos),
+            mx.array(block),
+            zi=actual_state,
+            chunk_size=chunk_size,
+        )
+        mx.eval(actual, actual_state)
+        np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-5, atol=2e-5)
+        np.testing.assert_allclose(np.asarray(actual_state), expected_state, rtol=1e-5, atol=2e-5)
+
+    unfused, unfused_state = _sosfilt_mlx_metal_unfused(
+        mx.array(sos),
+        mx.array(blocks[-1]),
+        chunk_size=chunk_size,
+    )
+    fused, fused_state = sosfilt_mlx_metal(mx.array(sos), mx.array(blocks[-1]), chunk_size=chunk_size)
+    mx.eval(unfused, unfused_state, fused, fused_state)
+    np.testing.assert_array_equal(np.asarray(fused), np.asarray(unfused))
+    np.testing.assert_array_equal(np.asarray(fused_state), np.asarray(unfused_state))
+
+
+@requires_mlx
+def test_sosfilt_mlx_metal_dispatches_only_configured_chunk_sizes(monkeypatch):
+    import mlx.core as mx
+
+    import ezmsg.sigproc.util.sosfilt_mlx_metal as sosfilt_module
+
+    sos = scipy.signal.butter(4, [30.0, 100.0], btype="bandpass", fs=1_000.0, output="sos").astype(np.float32)
+    rng = np.random.default_rng(188)
+    data = rng.standard_normal((3, 1_054)).astype(np.float32)
+    expected = scipy.signal.sosfilt(sos, data, axis=-1)
+
+    launches = []
+    original_launch = sosfilt_module._launch_fused_kernel
+
+    def recording_launch(x_chunk, sos_flat, state, n_channels, n_sections, cs, valid_length):
+        launches.append((cs, int(valid_length.item())))
+        return original_launch(x_chunk, sos_flat, state, n_channels, n_sections, cs, valid_length)
+
+    monkeypatch.setattr(sosfilt_module, "_launch_fused_kernel", recording_launch)
+    actual, actual_state = sosfilt_module.sosfilt_mlx_metal(
+        mx.array(sos),
+        mx.array(data),
+        chunk_sizes=(512, 32, 32),
+    )
+    mx.eval(actual, actual_state)
+
+    assert launches == [(512, 512), (512, 512), (32, 30)]
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-5, atol=2e-5)
+
+
+@requires_mlx
+@pytest.mark.parametrize("chunk_sizes", [(), (0,), (513,), (32, 1.5)])
+def test_sosfilt_mlx_metal_rejects_invalid_chunk_sizes(chunk_sizes):
+    import mlx.core as mx
+
+    from ezmsg.sigproc.util.sosfilt_mlx_metal import sosfilt_mlx_metal
+
+    sos = mx.array(scipy.signal.butter(2, 100.0, fs=1_000.0, output="sos").astype(np.float32))
+    with pytest.raises(ValueError, match="chunk_sizes"):
+        sosfilt_mlx_metal(sos, mx.zeros((2, 30)), chunk_sizes=chunk_sizes)
+
+
+@requires_mlx
+def test_butterworth_mlx_dispatches_component_chunk_sizes(monkeypatch):
+    import mlx.core as mx
+
+    import ezmsg.sigproc.util.sosfilt_mlx_metal as sosfilt_module
+
+    fs = 1_000.0
+    rng = np.random.default_rng(189)
+    data = rng.standard_normal((300, 4)).astype(np.float32)
+    settings = ButterworthFilterSettings(
+        axis="time",
+        order=4,
+        cuton=30.0,
+        cutoff=100.0,
+        coef_type="sos",
+        mlx_metal_chunk_sizes=(32, 128),
+    )
+    msg_np = AxisArray(data, dims=["time", "ch"], axes={"time": AxisArray.TimeAxis(fs=fs)})
+    msg_mx = AxisArray(mx.array(data), dims=msg_np.dims, axes=msg_np.axes)
+    proc_np = ButterworthFilterTransformer(settings)
+    proc_mx = ButterworthFilterTransformer(settings)
+
+    launches = []
+    original_launch = sosfilt_module._launch_fused_kernel
+
+    def recording_launch(x_chunk, sos_flat, state, n_channels, n_sections, cs, valid_length):
+        launches.append((cs, int(valid_length.item())))
+        return original_launch(x_chunk, sos_flat, state, n_channels, n_sections, cs, valid_length)
+
+    monkeypatch.setattr(sosfilt_module, "_launch_fused_kernel", recording_launch)
+    expected = proc_np(msg_np)
+    actual = proc_mx(msg_mx)
+    mx.eval(actual.data)
+
+    assert proc_mx.state.filter.settings.mlx_metal_chunk_sizes == (32, 128)
+    assert launches == [(128, 128), (128, 128), (128, 44)]
+    np.testing.assert_allclose(np.asarray(actual.data), expected.data, rtol=1e-5, atol=2e-5)
 
 
 @requires_mlx


### PR DESCRIPTION
## Summary

- pad trailing chunks to a bounded set of compile-time `CS` values and pass their valid length to the Metal kernels at runtime
- expose allowable specializations as component settings, defaulting to `(512,)` for SOS filters and `(32, 1024)` for EWMA
- select the smallest fitting specialization for each launch and compile it lazily once the first message provides the channel count
- preserve the existing single-`chunk_size` utility API and filter state when only the specialization setting changes
- add an MLX benchmark for cold tail-specialization costs

This removes the variable-tail compile storm while retaining smaller EWMA kernels where they provide a measurable benefit.

## Correctness

Compared the implementation against the pre-change code over a stateful message sequence with chunk lengths `3`, `30`, `300`, and `1000`. Fused SOS, serial SOS, and EWMA all produced byte-identical concatenated output and final state (`np.array_equal`, maximum absolute difference `0`).

## Validation

- `uv run pytest tests --benchmark-skip -p no:terminal`
- focused filter/EWMA/Metal integration suite: 272 passed, 12 skipped
- Ruff and `git diff --check`

Closes #187
