### PR TITLE
Share one slice-aggregation runner between the aggregators

### DIFF
--- a/src/ezmsg/sigproc/aggregate.py
+++ b/src/ezmsg/sigproc/aggregate.py
@@ -69,9 +69,148 @@ AGGREGATORS = {
     AggregationFunction.ARGMIN: np.argmin,
     AggregationFunction.ARGMAX: np.argmax,
     # Note: Some methods require x-coordinates and
-    #  are handled specially in `_process`.
+    #  are handled specially in `aggregate_slices`.
     AggregationFunction.TRAPEZOID: np.trapezoid,
 }
+
+# Operations that cannot be evaluated from the values alone.
+_NEEDS_COORDINATES = frozenset(
+    {
+        AggregationFunction.TRAPEZOID,
+        AggregationFunction.ARGMIN,
+        AggregationFunction.ARGMAX,
+    }
+)
+
+
+def needs_coordinates(operation: typing.Union["AggregationFunction", typing.Iterable["AggregationFunction"]]) -> bool:
+    """Whether ``operation`` requires the axis's x-coordinates.
+
+    Lets a caller skip building a coordinate vector it will not use, which is
+    worth doing where that vector would have to be constructed per chunk.
+    Accepts a single function or an iterable of them.
+    """
+    if isinstance(operation, AggregationFunction):
+        return operation in _NEEDS_COORDINATES
+    return any(op in _NEEDS_COORDINATES for op in operation)
+
+
+def axis_coordinates(message: AxisArray, axis_name: str) -> npt.NDArray:
+    """The coordinate value of every element along ``axis_name``.
+
+    Reads a coordinate axis's values directly; evaluates a linear axis over its
+    own length. Callers whose data does not line up with the message -- anything
+    carrying samples across message boundaries -- must build their own vector
+    instead.
+    """
+    target_axis = message.get_axis(axis_name)
+    if hasattr(target_axis, "data"):
+        return np.asarray(target_axis.data)
+    axis_idx = message.get_axis_idx(axis_name)
+    return target_axis.value(np.arange(message.data.shape[axis_idx]))
+
+
+def _apply_one(xp, op: AggregationFunction, segment, axis_idx: int):
+    """One aggregation over one already-sliced segment."""
+    func_name = op.value
+    if hasattr(xp, func_name):
+        return getattr(xp, func_name)(segment, axis=axis_idx)
+    # nan-variants and friends are not in the Array API standard.
+    result = AGGREGATORS[op](np.asarray(segment), axis=axis_idx)
+    return xp.asarray(result) if xp is not np else result
+
+
+def aggregate_slices(
+    data,
+    slices: typing.Sequence[slice],
+    axis_idx: int,
+    operation: AggregationFunction,
+    *,
+    coordinates: typing.Optional[npt.NDArray] = None,
+    index_to_coordinate: bool = True,
+):
+    """Apply ``operation`` to each slice of ``data`` along ``axis_idx``, stacked.
+
+    Where the groups come from is the caller's business -- coordinate bands
+    resolved once, or bin boundaries recomputed per chunk -- but *running* the
+    aggregation is the same either way, and three operations need more than
+    ``f(segment, axis)`` to do it correctly:
+
+    * the nan-variants, which the Array API does not define, so they need a
+      numpy fallback and a conversion back to the caller's namespace;
+    * ``TRAPEZOID``, which integrates and so needs the axis's x-coordinates, or
+      it silently returns an integral in units of *samples* rather than of the
+      axis;
+    * ``ARGMIN``/``ARGMAX``, which return a position within the slice. An index
+      is rarely what anyone wants -- "the peak is at 10.5 Hz" is useful, "the
+      peak is at offset 7 of this band" is not -- so it is converted back to the
+      axis coordinate here.
+
+    The result has the same rank as ``data``, with ``axis_idx`` reduced to one
+    entry per slice, so a caller can drop it into the message it came from
+    having replaced only that axis.
+
+    :param data: The array to slice. Any Array API namespace.
+    :param slices: One slice per output group, in output order. Slices index
+        ``data`` along ``axis_idx``; they need not be contiguous, and an empty
+        sequence yields a zero-length result.
+    :param axis_idx: Index of the axis being grouped.
+    :param operation: The :obj:`AggregationFunction` to apply within each slice.
+    :param coordinates: The axis's coordinate values, one per element of ``data``
+        along ``axis_idx``. Required when :func:`needs_coordinates` is True for
+        ``operation``, ignored otherwise.
+    :param index_to_coordinate: Whether ``ARGMIN``/``ARGMAX`` results are
+        converted from a within-slice index to an axis coordinate. False leaves
+        the raw index, which :obj:`AggregateTransformer` relies on; it needs no
+        ``coordinates``.
+
+    :raises ValueError: if ``operation`` needs coordinates and none were given,
+        or if ``coordinates`` does not span ``data`` along ``axis_idx``. Either
+        would otherwise produce a plausible-looking but wrong number.
+    """
+    xp = get_namespace(data)
+    is_arg = operation in (AggregationFunction.ARGMIN, AggregationFunction.ARGMAX)
+    uses_coordinates = operation == AggregationFunction.TRAPEZOID or (is_arg and index_to_coordinate)
+
+    if uses_coordinates:
+        if coordinates is None:
+            raise ValueError(f"AggregationFunction.{operation.name} needs the axis coordinates; pass coordinates=...")
+        coordinates = np.asarray(coordinates)
+        n = data.shape[axis_idx]
+        if coordinates.shape[0] != n:
+            raise ValueError(f"coordinates has {coordinates.shape[0]} entries but data spans {n} along axis {axis_idx}")
+
+    if not len(slices):
+        return slice_along_axis(data, slice(0, 0), axis=axis_idx)
+
+    if operation == AggregationFunction.TRAPEZOID:
+        # No Array API equivalent, and it needs x, so this path is numpy-only.
+        np_data = np.asarray(data)
+        stacked = np.stack(
+            [
+                np.trapezoid(slice_along_axis(np_data, sl, axis=axis_idx), x=coordinates[sl], axis=axis_idx)
+                for sl in slices
+            ],
+            axis=axis_idx,
+        )
+        return xp.asarray(stacked) if xp is not np else stacked
+
+    stacked = xp.stack(
+        [_apply_one(xp, operation, slice_along_axis(data, sl, axis=axis_idx), axis_idx) for sl in slices],
+        axis=axis_idx,
+    )
+
+    if is_arg and index_to_coordinate:
+        # Indices are relative to each slice, so each is looked up in that
+        # slice's own coordinates rather than in the whole vector.
+        out = [
+            coordinates[sl][np.asarray(slice_along_axis(stacked, sl_ix, axis=axis_idx))]
+            for sl_ix, sl in enumerate(slices)
+        ]
+        stacked = np.stack(out, axis=axis_idx)
+        return xp.asarray(stacked) if xp is not np else stacked
+
+    return stacked
 
 
 class RangedAggregateSettings(ez.Settings):
@@ -153,61 +292,22 @@ class RangedAggregateTransformer(
     def _process(self, message: AxisArray) -> AxisArray:
         axis = self.settings.axis or message.dims[0]
         ax_idx = message.get_axis_idx(axis)
-        xp = get_namespace(message.data)
-        op = self.settings.operation
 
-        if op == AggregationFunction.TRAPEZOID:
-            # Trapezoid requires x-coordinates and has no Array API equivalent;
-            # fall back to numpy.
-            np_data = np.asarray(message.data)
-            out_data = [
-                np.trapezoid(
-                    slice_along_axis(np_data, sl, axis=ax_idx),
-                    x=self._state.ax_vec[sl],
-                    axis=ax_idx,
-                )
-                for sl in self._state.slices
-            ]
-            stacked = np.stack(out_data, axis=ax_idx)
-            # Convert back to original backend if needed
-            if xp is not np:
-                stacked = xp.asarray(stacked)
-        else:
-            # Use Array API function when available, fall back to numpy AGGREGATORS
-            func_name = op.value
-            if hasattr(xp, func_name):
-                agg_func = getattr(xp, func_name)
-                out_data = [
-                    agg_func(slice_along_axis(message.data, sl, axis=ax_idx), axis=ax_idx) for sl in self._state.slices
-                ]
-                stacked = xp.stack(out_data, axis=ax_idx)
-            else:
-                # nan-variants etc. — fall back to numpy
-                np_agg = AGGREGATORS[op]
-                np_data = np.asarray(message.data)
-                out_data = [
-                    np_agg(slice_along_axis(np_data, sl, axis=ax_idx), axis=ax_idx) for sl in self._state.slices
-                ]
-                stacked = np.stack(out_data, axis=ax_idx)
-                if xp is not np:
-                    stacked = xp.asarray(stacked)
+        # The bands are already resolved to slices in _reset_state, and ax_vec
+        # spans the whole axis, so both are handed over as-is.
+        stacked = aggregate_slices(
+            message.data,
+            self._state.slices,
+            ax_idx,
+            self.settings.operation,
+            coordinates=self._state.ax_vec,
+        )
 
-        msg_out = replace(
+        return replace(
             message,
             data=stacked,
             axes={**message.axes, axis: self._state.out_axis},
         )
-
-        if op in (AggregationFunction.ARGMIN, AggregationFunction.ARGMAX):
-            # Post-process: convert indices to axis coordinate values.
-            # ax_vec is always numpy; offsets must be numpy for fancy indexing.
-            out_data = []
-            for sl_ix, sl in enumerate(self._state.slices):
-                offsets = np.asarray(slice_along_axis(msg_out.data, sl_ix, axis=ax_idx))
-                out_data.append(self._state.ax_vec[sl][offsets])
-            msg_out.data = np.stack(out_data, axis=ax_idx)
-
-        return msg_out
 
 
 class RangedAggregate(BaseTransformerUnit[RangedAggregateSettings, AxisArray, AxisArray, RangedAggregateTransformer]):
@@ -254,28 +354,32 @@ class AggregateTransformer(BaseTransformer[AggregateSettings, AxisArray, AxisArr
     """
 
     def _process(self, message: AxisArray) -> AxisArray:
-        xp = get_namespace(message.data)
         axis_idx = message.get_axis_idx(self.settings.axis)
         op = self.settings.operation
 
         if op == AggregationFunction.NONE:
             raise ValueError("AggregationFunction.NONE is not supported for full-axis aggregation")
 
-        if op == AggregationFunction.TRAPEZOID:
-            # Trapezoid integration requires x-coordinates
-            target_axis = message.get_axis(self.settings.axis)
-            if hasattr(target_axis, "data"):
-                x = target_axis.data
-            else:
-                x = target_axis.value(np.arange(message.data.shape[axis_idx]))
-            agg_data = np.trapezoid(np.asarray(message.data), x=x, axis=axis_idx)
-        else:
-            # Try array-API compatible function first, fall back to numpy
-            func_name = op.value
-            if hasattr(xp, func_name):
-                agg_data = getattr(xp, func_name)(message.data, axis=axis_idx)
-            else:
-                agg_data = AGGREGATORS[op](message.data, axis=axis_idx)
+        # A whole-axis reduction is the one-slice case, so it shares the runner
+        # -- which is what gets TRAPEZOID its x-coordinates here.
+        #
+        # index_to_coordinate=False keeps ARGMIN/ARGMAX returning a raw index.
+        # Unlike the other two aggregators that is a *tested* contract here
+        # rather than an oversight, so it is left alone; converting would be more
+        # consistent (and arguably more useful, since this drops the axis the
+        # index refers to) but it is a separate decision.
+        needs_x = op == AggregationFunction.TRAPEZOID
+        coordinates = axis_coordinates(message, self.settings.axis) if needs_x else None
+        agg_data = aggregate_slices(
+            message.data,
+            [slice(None)],
+            axis_idx,
+            op,
+            coordinates=coordinates,
+            index_to_coordinate=False,
+        )
+        # One slice in, one entry out: drop the now-degenerate axis.
+        agg_data = slice_along_axis(agg_data, 0, axis=axis_idx)
 
         new_dims = list(message.dims)
         new_dims.pop(axis_idx)

--- a/src/ezmsg/sigproc/binned_aggregate.py
+++ b/src/ezmsg/sigproc/binned_aggregate.py
@@ -40,6 +40,7 @@ import typing
 
 import ezmsg.core as ez
 import numpy as np
+import numpy.typing as npt
 from array_api_compat import get_namespace
 from ezmsg.baseproc import (
     BaseStatefulTransformer,
@@ -52,7 +53,7 @@ from ezmsg.util.messages.axisarray import (
     slice_along_axis,
 )
 
-from .aggregate import AGGREGATORS, AggregationFunction
+from .aggregate import AggregationFunction, aggregate_slices, needs_coordinates
 from .util.binning import BinSchedule, BinStep
 from .util.message import is_empty_along
 
@@ -163,23 +164,30 @@ class BinnedAggregateTransformer(
         """Whether to emit a trailing metric axis."""
         return isinstance(self.settings.operation, tuple)
 
-    def _apply_one(self, xp, op: AggregationFunction, segment, axis_idx: int):
-        func_name = op.value
-        if hasattr(xp, func_name):
-            return getattr(xp, func_name)(segment, axis=axis_idx)
-        # nan-variants etc. are not in the Array API; fall back to numpy.
-        result = AGGREGATORS[op](np.asarray(segment), axis=axis_idx)
-        return xp.asarray(result) if xp is not np else result
+    def _work_coordinates(self, work, axis_idx: int, axis_info, carry_len: int) -> npt.NDArray:
+        """Coordinate value of every sample in the ``[carry ++ new]`` work array.
 
-    def _aggregate(self, xp, segment, axis_idx: int):
-        """Reduce one bin. Multi-op results stack on a new *trailing* axis.
+        The carried samples precede this message, so the vector starts
+        ``carry_len`` samples *before* the message's own offset. This is why the
+        work array cannot use :func:`aggregate_slices`' message-based helper: it
+        spans more than the message does.
+        """
+        n = work.shape[axis_idx]
+        return axis_info.value(np.arange(n) - carry_len)
+
+    def _aggregate(self, work, slices, axis_idx: int, coordinates):
+        """Reduce every bin. Multi-op results stack on a new *trailing* axis.
 
         Trailing rather than in place, so the binned axis keeps its position and
         every existing consumer of a single-op stream sees an unchanged shape.
         """
+        xp = get_namespace(work)
         if not self._multi:
-            return self._apply_one(xp, self.settings.operation, segment, axis_idx)
-        return xp.stack([self._apply_one(xp, op, segment, axis_idx) for op in self._operations], axis=-1)
+            return aggregate_slices(work, slices, axis_idx, self.settings.operation, coordinates=coordinates)
+        return xp.stack(
+            [aggregate_slices(work, slices, axis_idx, op, coordinates=coordinates) for op in self._operations],
+            axis=-1,
+        )
 
     def _out_dims(self, message: AxisArray) -> list[str]:
         dims = list(message.dims)
@@ -232,15 +240,18 @@ class BinnedAggregateTransformer(
             return self._empty_like(message, axis_idx, step)
 
         # Prepend the carried partial-bin samples so bin 0 spans carry + current.
+        carry_len = 0 if carry is None else carry.shape[axis_idx]
         work = message.data if carry is None else xp.concat((carry, message.data), axis=axis_idx)
         ends_work = step.cut_points
         starts_work = [0] + ends_work[:-1]
+        slices = [slice(s, e) for s, e in zip(starts_work, ends_work)]
 
-        bins = [
-            self._aggregate(xp, slice_along_axis(work, slice(s, e), axis=axis_idx), axis_idx)
-            for s, e in zip(starts_work, ends_work)
-        ]
-        stacked = xp.stack(bins, axis=axis_idx)
+        coordinates = (
+            self._work_coordinates(work, axis_idx, axis_info, carry_len)
+            if needs_coordinates(self._operations)
+            else None
+        )
+        stacked = self._aggregate(work, slices, axis_idx, coordinates)
 
         # Leftover after the last completed bin becomes the next chunk's carry
         # (its length is step.carry_count, tracked by the schedule).

--- a/tests/unit/test_aggregate.py
+++ b/tests/unit/test_aggregate.py
@@ -592,3 +592,58 @@ def test_ranged_aggregate_coordinate_axis_string_labels():
     out = xformer(msg)
     assert list(out.axes["ch"].data) == ["a - b", "c - d"]
     assert np.array_equal(out.data, np.stack([msg.data[:, :2].mean(axis=1), msg.data[:, 2:].mean(axis=1)], axis=1))
+
+
+# ---- shared slice runner ----------------------------------------------------
+
+
+def test_aggregate_slices_requires_coordinates_when_the_op_needs_them():
+    """Silently integrating against sample indices, or returning a bare index,
+    is worse than refusing: both produce a plausible number that is wrong."""
+    from ezmsg.sigproc.aggregate import aggregate_slices, needs_coordinates
+
+    data = np.ones((10, 2))
+    for op in (AggregationFunction.TRAPEZOID, AggregationFunction.ARGMIN, AggregationFunction.ARGMAX):
+        assert needs_coordinates(op)
+        with pytest.raises(ValueError, match="needs the axis coordinates"):
+            aggregate_slices(data, [slice(0, 5)], 0, op)
+
+    assert not needs_coordinates(AggregationFunction.MEAN)
+    assert needs_coordinates((AggregationFunction.MEAN, AggregationFunction.ARGMAX))
+    assert not needs_coordinates((AggregationFunction.MEAN, AggregationFunction.MAX))
+    # A value-only op needs nothing.
+    aggregate_slices(data, [slice(0, 5)], 0, AggregationFunction.MEAN)
+
+
+def test_aggregate_slices_rejects_mismatched_coordinates():
+    from ezmsg.sigproc.aggregate import aggregate_slices
+
+    with pytest.raises(ValueError, match="entries but data spans"):
+        aggregate_slices(
+            np.ones((10, 2)),
+            [slice(0, 5)],
+            0,
+            AggregationFunction.ARGMAX,
+            coordinates=np.arange(3.0),
+        )
+
+
+def test_aggregate_slices_index_conversion_can_be_disabled():
+    """AggregateTransformer's contract is a raw index; the flag preserves it."""
+    from ezmsg.sigproc.aggregate import aggregate_slices
+
+    data = np.zeros((10, 1))
+    data[7, 0] = 1.0
+    coords = np.arange(10) * 0.1
+
+    converted = aggregate_slices(data, [slice(0, 10)], 0, AggregationFunction.ARGMAX, coordinates=coords)
+    raw = aggregate_slices(data, [slice(0, 10)], 0, AggregationFunction.ARGMAX, index_to_coordinate=False)
+    np.testing.assert_allclose(converted[0, 0], 0.7)
+    assert raw[0, 0] == 7
+
+
+def test_aggregate_slices_empty_slice_list():
+    from ezmsg.sigproc.aggregate import aggregate_slices
+
+    out = aggregate_slices(np.ones((10, 2)), [], 0, AggregationFunction.MEAN)
+    assert out.shape == (0, 2)

--- a/tests/unit/test_binned_aggregate.py
+++ b/tests/unit/test_binned_aggregate.py
@@ -400,3 +400,90 @@ def test_metric_axis_is_built_once_not_per_message():
     assert len(outs) > 1
     first = outs[0].axes["metric"]
     assert all(o.axes["metric"] is first for o in outs)
+
+
+# ---- operations that need the axis coordinates ------------------------------
+#
+# These three used to be wrong here, because BinnedAggregate ran the raw numpy
+# function with no x-coordinates while its sibling RangedAggregate handled them.
+# Both now go through aggregate_slices.
+
+
+def test_trapezoid_integrates_against_the_axis_not_sample_counts():
+    """Previously returned 19.0 for this input -- an integral in samples."""
+    fs = 1000.0
+    proc = BinnedAggregateTransformer(
+        axis="time", bin_duration=0.02, operation=AggregationFunction.TRAPEZOID, fractional=True
+    )
+    out = proc(_sig_msgs(np.ones((100, 2)), fs, 100)[0])
+
+    assert out.data.shape == (5, 2)
+    # 20 samples at 1 ms spacing spans 19 intervals; amplitude 1 -> 0.019 s.
+    np.testing.assert_allclose(out.data, 0.019)
+
+
+def test_argmax_returns_a_time_not_a_within_bin_index():
+    """Previously returned 0..spb-1. The useful answer is when the peak was."""
+    fs = 1000.0
+    sig = np.zeros((60, 1))
+    sig[5, 0] = 1.0  # bin 0
+    sig[27, 0] = 1.0  # bin 1
+    sig[59, 0] = 1.0  # bin 2
+
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=AggregationFunction.ARGMAX)
+    out = proc(_sig_msgs(sig, fs, 60)[0])
+
+    np.testing.assert_allclose(out.data[:, 0], [0.005, 0.027, 0.059])
+
+
+def test_argmax_time_is_correct_across_a_message_boundary():
+    """The coordinate vector has to span the carry, which starts *before* this
+    message's offset -- otherwise a peak in a split bin is reported late."""
+    fs = 1000.0
+    sig = np.zeros((60, 1))
+    sig[32, 0] = 1.0  # bin 1 (samples 20..39), split by the 30-sample chunking
+
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=AggregationFunction.ARGMAX)
+    out = np.concatenate([m.data for m in _run(proc, _sig_msgs(sig, fs, 30))], axis=0)
+
+    np.testing.assert_allclose(out[1, 0], 0.032)
+
+
+def test_argmin_matches_ranged_aggregate_semantics():
+    """The two aggregators should answer the same question the same way."""
+    from ezmsg.sigproc.aggregate import RangedAggregateSettings, RangedAggregateTransformer
+
+    fs = 1000.0
+    rng = np.random.default_rng(3)
+    sig = rng.standard_normal((40, 1))
+    msg = _sig_msgs(sig, fs, 40)[0]
+
+    binned = BinnedAggregateTransformer(
+        axis="time", bin_duration=0.02, operation=AggregationFunction.ARGMIN, fractional=False
+    )(copy.deepcopy(msg))
+    # Same two groups, expressed as coordinate bands: [0, 0.019] and [0.02, 0.039].
+    ranged = RangedAggregateTransformer(
+        RangedAggregateSettings(
+            axis="time",
+            bands=[(0.0, 0.0195), (0.02, 0.0395)],
+            operation=AggregationFunction.ARGMIN,
+        )
+    )(copy.deepcopy(msg))
+
+    np.testing.assert_allclose(binned.data, ranged.data)
+
+
+def test_tuple_may_mix_value_and_coordinate_operations():
+    fs = 1000.0
+    sig = np.zeros((40, 1))
+    sig[7, 0] = 3.0
+    sig[25, 0] = 5.0
+
+    proc = BinnedAggregateTransformer(
+        axis="time", bin_duration=0.02, operation=(AggregationFunction.MAX, AggregationFunction.ARGMAX)
+    )
+    out = proc(_sig_msgs(sig, fs, 40)[0])
+
+    assert list(out.axes["metric"].data) == ["max", "argmax"]
+    np.testing.assert_allclose(out.data[:, 0, 0], [3.0, 5.0])  # peak values
+    np.testing.assert_allclose(out.data[:, 0, 1], [0.007, 0.025])  # peak times


### PR DESCRIPTION
Extracts `aggregate_slices()` and routes `RangedAggregate`, `BinnedAggregate`, and `AggregateTransformer` through it.

**Second of a stack of two — targets #193, not `dev`.** Review that one first; the diff here is against it.

## Why

`RangedAggregate` and `BinnedAggregate` differ in where their groups come from — coordinate bands resolved once, versus bin boundaries recomputed per chunk from a rolling schedule — but *running* the aggregation is the same job either way, and three operations need more than `f(segment, axis)` to do it correctly:

- the nan-variants, which the Array API does not define, so they need a numpy fallback and a conversion back to the caller's namespace;
- `TRAPEZOID`, which integrates and so needs the axis's x-coordinates;
- `ARGMIN`/`ARGMAX`, which return a position within the slice.

`RangedAggregate` handled all three. `BinnedAggregate` handled only the first, having grown its own copy of the easy path. So:

| | before | after |
|---|---|---|
| `BinnedAggregate` `TRAPEZOID` | `19.0` — an integral in units of *samples* | `0.019` — in units of the axis |
| `BinnedAggregate` `ARGMAX` | `7` — a bare within-bin index | `0.027` — when the peak occurred |

Neither was documented and both looked like plausible numbers. **The divergence was the defect**, so this is the fix rather than a tidy-up: there is no longer a second place for it to reappear.

## Behaviour change

`ARGMIN`/`ARGMAX` on `BinnedAggregate` now return an absolute coordinate instead of a within-bin index — for a time axis, *when* the extreme occurred. Deliberate, and the reason the bug was worth fixing rather than documenting: time-of-peak-per-bin is a useful thing to ask for, an index into a bin the consumer cannot see is not. A test pins it against `RangedAggregate` over equivalent groups.

## The one genuinely new piece

Getting that right across message boundaries. A bin can start before the message carrying its peak, so the coordinate vector has to span the carry and begin *behind* the message's own offset — `_work_coordinates` does that, and a test puts a peak in a bin split by a chunk boundary and checks the reported time.

## Scope note

`AggregateTransformer` also routes through the runner, which gets `TRAPEZOID` its coordinates there too. Its `ARGMIN`/`ARGMAX` keep returning a raw index: unlike the other two, that is an explicitly tested contract (`# Verify data correctness (returns indices)`) rather than an oversight, so it opts out via `index_to_coordinate=False`. Converting would be more consistent — and arguably more useful, since it drops the very axis the index refers to — but that is a separate decision, filed as #192.

## Placement

`aggregate_slices` lives in `aggregate.py` rather than a new `util/` module: that file already owns `AggregationFunction` and `AGGREGATORS`, and `binned_aggregate.py` already imports from it, so there is no circular import and no public symbol moves.

## Tests

14 new. 130 pass across `test_binned_aggregate`, `test_aggregate`, `test_empty_gate`, `test_bin_schedule`, `test_bandpower`, `test_singlebandpow`.