### PR TITLE
BinnedAggregate: add a passthrough flag

### DIFF
--- a/src/ezmsg/sigproc/binned_aggregate.py
+++ b/src/ezmsg/sigproc/binned_aggregate.py
@@ -85,6 +85,19 @@ class BinnedAggregateSettings(ez.Settings):
     newaxis: str = "metric"
     """Name of the trailing axis added when ``operation`` is a tuple."""
 
+    passthrough: bool = False
+    """Forward messages untouched, as if this node were not in the graph.
+
+    A separate flag rather than a sentinel ``bin_duration`` so the bin rate
+    survives being switched off and on -- a consumer toggling this at runtime
+    (say, because the view zoomed to a range where binning would cost detail)
+    should not have to remember and restore the rate itself.
+
+    Note that toggling changes the *shape* of the output: a tuple ``operation``
+    adds a trailing axis, and turning it off takes that axis away again.
+    Everything downstream has to be able to absorb that -- a fixed-layout sink
+    will have to reallocate, and a plot will have to rebuild."""
+
     fractional: bool = True
     """If True (default), bins span a *fractional* ``bin_duration * fs`` samples
     with a carry accumulator across chunks; each bin spans exactly ``bin_duration``
@@ -133,9 +146,18 @@ class BinnedAggregateTransformer(
     """
 
     def _hash_message(self, message: AxisArray) -> int:
-        return hash((message.axes[self.settings.axis].gain, message.key))
+        # passthrough is in the hash so flipping it resets the schedule and the
+        # carry. Without that, switching back on would splice samples from
+        # before the gap onto the first bin after it.
+        return hash((message.axes[self.settings.axis].gain, message.key, self.settings.passthrough))
 
     def _reset_state(self, message: AxisArray) -> None:
+        if self.settings.passthrough:
+            # No schedule to build, and nothing may be carried across the gap.
+            self._state.schedule = None
+            self._state.carry = None
+            self._state.metric_axis = None
+            return
         axis_info = message.get_axis(self.settings.axis)
         schedule = BinSchedule(
             bin_duration=self.settings.bin_duration,
@@ -219,6 +241,9 @@ class BinnedAggregateTransformer(
         )
 
     def _process(self, message: AxisArray) -> AxisArray:
+        if self.settings.passthrough:
+            return message
+
         axis = self.settings.axis
         axis_info = message.get_axis(axis)
         axis_idx = message.get_axis_idx(axis)

--- a/src/ezmsg/sigproc/binned_aggregate.py
+++ b/src/ezmsg/sigproc/binned_aggregate.py
@@ -93,6 +93,9 @@ class BinnedAggregateSettings(ez.Settings):
     (say, because the view zoomed to a range where binning would cost detail)
     should not have to remember and restore the rate itself.
 
+    Switching back off starts a fresh schedule and an empty carry: nothing from
+    before the gap is spliced onto the first bin after it.
+
     Note that toggling changes the *shape* of the output: a tuple ``operation``
     adds a trailing axis, and turning it off takes that axis away again.
     Everything downstream has to be able to absorb that -- a fixed-layout sink
@@ -145,19 +148,27 @@ class BinnedAggregateTransformer(
     guaranteed to describe the same bins.
     """
 
+    # `passthrough` is read live in `__call__`/`__acall__`, which short-circuit
+    # before the state is ever consulted; everything else is baked into the
+    # schedule and the metric axis during `_reset_state`.
+    NONRESET_SETTINGS_FIELDS = frozenset({"passthrough"})
+
+    def __call__(self, message: AxisArray) -> AxisArray:
+        if self.settings.passthrough:
+            self._request_reset()
+            return message
+        return super().__call__(message)
+
+    async def __acall__(self, message: AxisArray) -> AxisArray:
+        if self.settings.passthrough:
+            self._request_reset()
+            return message
+        return await super().__acall__(message)
+
     def _hash_message(self, message: AxisArray) -> int:
-        # passthrough is in the hash so flipping it resets the schedule and the
-        # carry. Without that, switching back on would splice samples from
-        # before the gap onto the first bin after it.
-        return hash((message.axes[self.settings.axis].gain, message.key, self.settings.passthrough))
+        return hash((message.axes[self.settings.axis].gain, message.key))
 
     def _reset_state(self, message: AxisArray) -> None:
-        if self.settings.passthrough:
-            # No schedule to build, and nothing may be carried across the gap.
-            self._state.schedule = None
-            self._state.carry = None
-            self._state.metric_axis = None
-            return
         axis_info = message.get_axis(self.settings.axis)
         schedule = BinSchedule(
             bin_duration=self.settings.bin_duration,
@@ -241,9 +252,6 @@ class BinnedAggregateTransformer(
         )
 
     def _process(self, message: AxisArray) -> AxisArray:
-        if self.settings.passthrough:
-            return message
-
         axis = self.settings.axis
         axis_info = message.get_axis(axis)
         axis_idx = message.get_axis_idx(axis)

--- a/tests/unit/test_binned_aggregate.py
+++ b/tests/unit/test_binned_aggregate.py
@@ -513,6 +513,16 @@ def test_passthrough_keeps_the_bin_rate_for_when_it_is_switched_back():
     assert proc.settings.bin_duration == pytest.approx(0.02)
 
 
+def test_passthrough_skips_the_state_entirely():
+    """The short-circuit happens before hashing, so a message that arrives in
+    passthrough neither builds a schedule nor grows the carry."""
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=MINMAX, passthrough=True)
+    for msg in _sig_msgs(np.zeros((100, 2)), 1000.0, 25):
+        assert proc(msg) is msg
+    assert proc._state.schedule is None
+    assert proc._state.carry is None
+
+
 def test_toggling_off_does_not_splice_stale_samples_into_the_first_bin():
     """The carry holds an open partial bin. If it survived a passthrough gap,
     the first bin after would mix samples from either side of it."""
@@ -521,11 +531,53 @@ def test_toggling_off_does_not_splice_stale_samples_into_the_first_bin():
 
     # 25 samples: bin 0 closes, 5 are carried.
     proc(_sig_msgs(np.full((25, 1), 99.0), fs, 25)[0])
+    assert proc._state.carry.shape[0] == 5
 
     # Pass through a stretch, then resume. The 99s must not reappear.
     proc.settings = replace_settings(proc.settings, passthrough=True)
     proc(_sig_msgs(np.zeros((25, 1)), fs, 25)[0])
+    # The stale carry is still in the state, but a reset is queued so it can
+    # never reach the next bin.
+    assert proc._hash == -1
     proc.settings = replace_settings(proc.settings, passthrough=False)
     out = proc(_sig_msgs(np.zeros((40, 1)), fs, 40)[0])
 
     assert out.data.max() == pytest.approx(0.0)
+    assert out.data.shape[0] == 2  # a fresh grid: 40 samples = exactly 2 bins
+
+
+def test_toggling_off_via_update_settings_also_resets():
+    """`passthrough` is in NONRESET_SETTINGS_FIELDS, so update_settings queues
+    no reset of its own -- the short-circuit in __call__ has to be what does."""
+    fs = 1000.0
+    settings = BinnedAggregateSettings(axis="time", bin_duration=0.02, operation=AggregationFunction.MAX)
+    proc = BinnedAggregateTransformer(settings=settings)
+
+    proc(_sig_msgs(np.full((25, 1), 99.0), fs, 25)[0])
+
+    proc.update_settings(replace_settings(settings, passthrough=True))
+    proc(_sig_msgs(np.zeros((25, 1)), fs, 25)[0])
+    proc.update_settings(settings)
+    out = proc(_sig_msgs(np.zeros((40, 1)), fs, 40)[0])
+
+    assert out.data.max() == pytest.approx(0.0)
+
+
+def test_toggling_restores_the_metric_axis():
+    """A tuple operation adds a trailing axis; the gap must not leave it behind."""
+    fs = 1000.0
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=MINMAX)
+
+    out = proc(_sig_msgs(np.zeros((40, 2)), fs, 40)[0])
+    assert out.data.shape == (2, 2, 2)
+    assert list(out.axes["metric"].data) == ["min", "max"]
+
+    proc.settings = replace_settings(proc.settings, passthrough=True)
+    msg = _sig_msgs(np.zeros((40, 2)), fs, 40)[0]
+    assert proc(msg) is msg
+    assert "metric" not in msg.axes
+
+    proc.settings = replace_settings(proc.settings, passthrough=False)
+    out = proc(_sig_msgs(np.zeros((40, 2)), fs, 40)[0])
+    assert out.data.shape == (2, 2, 2)
+    assert list(out.axes["metric"].data) == ["min", "max"]

--- a/tests/unit/test_binned_aggregate.py
+++ b/tests/unit/test_binned_aggregate.py
@@ -487,3 +487,45 @@ def test_tuple_may_mix_value_and_coordinate_operations():
     assert list(out.axes["metric"].data) == ["max", "argmax"]
     np.testing.assert_allclose(out.data[:, 0, 0], [3.0, 5.0])  # peak values
     np.testing.assert_allclose(out.data[:, 0, 1], [0.007, 0.025])  # peak times
+
+
+# ---- passthrough -----------------------------------------------------------
+
+
+def replace_settings(settings, **kw):
+    """Mimic a runtime settings push."""
+    import dataclasses
+
+    return dataclasses.replace(settings, **kw)
+
+
+def test_passthrough_forwards_untouched():
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=MINMAX, passthrough=True)
+    msg = _sig_msgs(np.arange(100, dtype=float).reshape(50, 2), 1000.0, 50)[0]
+    out = proc(msg)
+    assert out is msg
+
+
+def test_passthrough_keeps_the_bin_rate_for_when_it_is_switched_back():
+    """A sentinel bin_duration would have destroyed the rate; a separate flag
+    means a caller toggling at runtime need not remember and restore it."""
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=MINMAX, passthrough=True)
+    assert proc.settings.bin_duration == pytest.approx(0.02)
+
+
+def test_toggling_off_does_not_splice_stale_samples_into_the_first_bin():
+    """The carry holds an open partial bin. If it survived a passthrough gap,
+    the first bin after would mix samples from either side of it."""
+    fs = 1000.0
+    proc = BinnedAggregateTransformer(axis="time", bin_duration=0.02, operation=AggregationFunction.MAX)
+
+    # 25 samples: bin 0 closes, 5 are carried.
+    proc(_sig_msgs(np.full((25, 1), 99.0), fs, 25)[0])
+
+    # Pass through a stretch, then resume. The 99s must not reappear.
+    proc.settings = replace_settings(proc.settings, passthrough=True)
+    proc(_sig_msgs(np.zeros((25, 1)), fs, 25)[0])
+    proc.settings = replace_settings(proc.settings, passthrough=False)
+    out = proc(_sig_msgs(np.zeros((40, 1)), fs, 40)[0])
+
+    assert out.data.max() == pytest.approx(0.0)


### PR DESCRIPTION
## What

Adds a `passthrough` flag to `BinnedAggregateSettings`, so this node can be left in a graph but switched off at runtime.

There was no way to do that before. Every other conditioning stage has one — `CommonRereference` has `mode="passthrough"`, `Butterworth` has `order=0`, `SamplingDelayAlignment` has `filter_len=0`, `Slicer` has an empty selection — so a pipeline that wanted to compare with and without binning had to rewire itself instead.

A separate flag rather than a sentinel `bin_duration`, because the intended use is a runtime toggle: a consumer switching this off because the view zoomed to a range where binning would cost detail should not have to remember and restore the rate itself. A sentinel would have destroyed it.

## How

`__call__`/`__acall__` short-circuit before the state is ever consulted, matching `EWMATransformer` and `AdaptiveStandardScalerTransformer`:

```python
def __call__(self, message: AxisArray) -> AxisArray:
    if self.settings.passthrough:
        self._request_reset()
        return message
    return super().__call__(message)
```

The `_request_reset()` is the load-bearing part. `_state.carry` holds the raw samples of an open partial bin; if it survived a passthrough gap, the first bin after resuming would mix samples from either side of it. Short-circuiting alone would cause exactly that, because `_hash` keeps its pre-gap value when nothing hashes it. `_request_reset()` sets `_hash = -1` directly, so the next real message is guaranteed to take the reset path and start from a fresh schedule and an empty carry.

It lives in `__call__` rather than only in `update_settings` so the guard also holds when settings are pushed by assignment (`proc.settings = replace(...)`), which is the path a runtime consumer is most likely to take. `passthrough` is in `NONRESET_SETTINGS_FIELDS` to record that `update_settings` need not queue a reset of its own.

## Note for downstream

Toggling changes the *shape* of the output when `operation` is a tuple: the trailing metric axis appears and disappears with the flag. Anything downstream has to absorb a rank change — a fixed-layout sink reallocates, a plot rebuilds. ezmsg-tools' shmem bridge and sweep widget both do, but neither does it for free.

## Deliberately not doing

`EWMATransformer` and `AdaptiveStandardScalerTransformer` resume from pre-gap state after passthrough, which is the opposite of what this PR does. That is intentional there and pinned by tests. The difference is that their state is a converged estimate, while the carry is raw samples that get spliced into an output bin. Whether theirs is right is #195.

Related: #196, an unrelated stale-cache bug found in `RangedAggregateTransformer` while comparing passthrough implementations.

## Tests

Six tests in `tests/unit/test_binned_aggregate.py`:

- `test_passthrough_forwards_untouched` — output is the input object
- `test_passthrough_keeps_the_bin_rate_for_when_it_is_switched_back` — the flag-vs-sentinel argument
- `test_passthrough_skips_the_state_entirely` — no schedule built, no carry grown
- `test_toggling_off_does_not_splice_stale_samples_into_the_first_bin` — the one that fails without `_request_reset()`
- `test_toggling_off_via_update_settings_also_resets` — the other toggle path
- `test_toggling_restores_the_metric_axis` — the trailing axis comes back correctly

Full suite passes (3689 unit + 51 integration).