### PR TITLE
Aggregate: ARGMIN/ARGMAX return coordinates; fix RangedAggregate async passthrough

### DIFF
--- a/src/ezmsg/sigproc/aggregate.py
+++ b/src/ezmsg/sigproc/aggregate.py
@@ -161,8 +161,9 @@ def aggregate_slices(
         ``operation``, ignored otherwise.
     :param index_to_coordinate: Whether ``ARGMIN``/``ARGMAX`` results are
         converted from a within-slice index to an axis coordinate. False leaves
-        the raw index, which :obj:`AggregateTransformer` relies on; it needs no
-        ``coordinates``.
+        the raw index and needs no ``coordinates``. Every transformer in this
+        package leaves this True; it exists for a caller that means to index
+        back into the array it passed in.
 
     :raises ValueError: if ``operation`` needs coordinates and none were given,
         or if ``coordinates`` does not span ``data`` along ``axis_idx``. Either
@@ -244,8 +245,18 @@ class RangedAggregateTransformer(
     def __call__(self, message: AxisArray) -> AxisArray:
         # Override for shortcut passthrough mode.
         if self.settings.bands is None:
+            self._request_reset()
             return message
         return super().__call__(message)
+
+    async def __acall__(self, message: AxisArray) -> AxisArray:
+        # The async path is what a graph actually takes (`BaseTransformerUnit`
+        # awaits `__acall__`), so the shortcut has to be repeated here or
+        # `bands=None` reaches `_reset_state` and raises on iterating None.
+        if self.settings.bands is None:
+            self._request_reset()
+            return message
+        return await super().__acall__(message)
 
     def _hash_message(self, message: AxisArray) -> int:
         axis = self.settings.axis or message.dims[0]
@@ -341,7 +352,14 @@ class AggregateSettings(ez.Settings):
     """The name of the axis to aggregate over. This axis will be removed from the output."""
 
     operation: AggregationFunction = AggregationFunction.MEAN
-    """:obj:`AggregationFunction` to apply."""
+    """:obj:`AggregationFunction` to apply.
+
+    ``ARGMIN``/``ARGMAX`` return the *coordinate* of the extremum along ``axis``
+    -- "the peak is at 14 Hz" -- not its index, matching
+    :obj:`RangedAggregateTransformer` and :obj:`BinnedAggregateTransformer`. An
+    index would be unusable here anyway, since ``axis`` is removed from the
+    output. Where ``axis`` carries no axis metadata the coordinates are 0, 1,
+    2, ..., so the result is the index after all."""
 
 
 class AggregateTransformer(BaseTransformer[AggregateSettings, AxisArray, AxisArray]):
@@ -361,22 +379,17 @@ class AggregateTransformer(BaseTransformer[AggregateSettings, AxisArray, AxisArr
             raise ValueError("AggregationFunction.NONE is not supported for full-axis aggregation")
 
         # A whole-axis reduction is the one-slice case, so it shares the runner
-        # -- which is what gets TRAPEZOID its x-coordinates here.
-        #
-        # index_to_coordinate=False keeps ARGMIN/ARGMAX returning a raw index.
-        # Unlike the other two aggregators that is a *tested* contract here
-        # rather than an oversight, so it is left alone; converting would be more
-        # consistent (and arguably more useful, since this drops the axis the
-        # index refers to) but it is a separate decision.
-        needs_x = op == AggregationFunction.TRAPEZOID
-        coordinates = axis_coordinates(message, self.settings.axis) if needs_x else None
+        # -- which is what gets TRAPEZOID its x-coordinates, and ARGMIN/ARGMAX
+        # their index-to-coordinate conversion. The latter matters more here than
+        # in the other two aggregators: this one *removes* the axis, so a raw
+        # index would point into a dimension the output no longer describes.
+        coordinates = axis_coordinates(message, self.settings.axis) if needs_coordinates(op) else None
         agg_data = aggregate_slices(
             message.data,
             [slice(None)],
             axis_idx,
             op,
             coordinates=coordinates,
-            index_to_coordinate=False,
         )
         # One slice in, one entry out: drop the now-degenerate axis.
         agg_data = slice_along_axis(agg_data, 0, axis=axis_idx)

--- a/tests/unit/test_aggregate.py
+++ b/tests/unit/test_aggregate.py
@@ -300,10 +300,47 @@ def test_aggregate_transformer_argminmax(operation: AggregationFunction):
     assert msg_out.data.shape == (10, 5)
     assert "freq" not in msg_out.dims
 
-    # Verify data correctness (returns indices)
+    # Verify data correctness. The result is the *coordinate* of the extremum,
+    # not its index -- the index would refer to an axis this transformer just
+    # dropped. `freq` is gain=2.0, offset=1.0, so the two differ.
     np_func = getattr(np, operation.value)
-    expected = np_func(msg_in.data, axis=2)
-    assert np.array_equal(msg_out.data, expected)
+    expected = msg_in.axes["freq"].value(np_func(msg_in.data, axis=2))
+    assert np.allclose(msg_out.data, expected)
+
+
+@pytest.mark.parametrize("operation", [AggregationFunction.ARGMIN, AggregationFunction.ARGMAX])
+def test_aggregate_argminmax_matches_ranged(operation: AggregationFunction):
+    """Aggregate and RangedAggregate answer ARG* the same way.
+
+    The invariant behind the divergence reported in #192: a band spanning the
+    whole axis is the same question the full-axis reduction asks, so the two
+    must agree. Pinned across both transformers so a future change to either
+    cannot reintroduce the split.
+    """
+    msg_in = get_simple_msg()
+
+    full = AggregateTransformer(AggregateSettings(axis="freq", operation=operation))(msg_in)
+
+    freq = msg_in.axes["freq"].value(np.arange(msg_in.data.shape[2]))
+    ranged = RangedAggregateTransformer(
+        RangedAggregateSettings(axis="freq", bands=[(freq[0], freq[-1])], operation=operation)
+    )(msg_in)
+
+    # RangedAggregate keeps the axis with one entry per band; Aggregate drops it.
+    assert np.allclose(full.data, ranged.data[..., 0])
+
+
+@pytest.mark.parametrize("operation", [AggregationFunction.ARGMIN, AggregationFunction.ARGMAX])
+def test_aggregate_argminmax_bare_axis_is_index(operation: AggregationFunction):
+    """With no axis metadata the coordinates are 0, 1, 2, ... -- i.e. the index."""
+    data = np.arange(3 * 8, dtype=float).reshape(3, 8)
+    np.random.default_rng(0).shuffle(data, axis=1)
+    msg_in = AxisArray(data=data, dims=["ch", "freq"], axes=frozendict({}), key="bare")
+
+    msg_out = AggregateTransformer(AggregateSettings(axis="freq", operation=operation))(msg_in)
+
+    np_func = getattr(np, operation.value)
+    assert np.allclose(msg_out.data, np_func(data, axis=1))
 
 
 def test_aggregate_transformer_trapezoid():
@@ -406,6 +443,36 @@ def test_ranged_aggregate_empty_passthrough():
     empty = make_empty_msg()
     result = proc(empty)
     check_empty_result(result)
+
+
+async def test_ranged_aggregate_passthrough_async():
+    """`bands=None` passes through on the async path too.
+
+    `BaseTransformerUnit` awaits `__acall__`, so this -- not `__call__` -- is
+    the path a RangedAggregate takes inside a graph. It used to fall through to
+    `_reset_state` and raise on iterating `None`.
+    """
+    proc = RangedAggregateTransformer(RangedAggregateSettings(axis="freq", bands=None))
+    msg = get_simple_msg()
+    assert await proc.__acall__(msg) is msg
+
+
+async def test_ranged_aggregate_passthrough_resume_async():
+    """Resuming from passthrough on the async path rebuilds the slices."""
+    msg = get_simple_msg()
+    freq = msg.axes["freq"].value(np.arange(msg.data.shape[2]))
+
+    proc = RangedAggregateTransformer(RangedAggregateSettings(axis="freq", bands=[(freq[0], freq[3])]))
+    first = await proc.__acall__(msg)
+
+    proc.update_settings(RangedAggregateSettings(axis="freq", bands=None))
+    assert await proc.__acall__(msg) is msg
+
+    proc.update_settings(RangedAggregateSettings(axis="freq", bands=[(freq[4], freq[-1])]))
+    second = await proc.__acall__(msg)
+
+    # Different bands -> different means; the first band's slices are not reused.
+    assert not np.allclose(first.data, second.data)
 
 
 # ============== MLX Tests ==============


### PR DESCRIPTION
Closes #192.

## `AggregateTransformer` ARG\* returns coordinates

`AggregateTransformer` returned `ARGMIN`/`ARGMAX` as a raw index into the aggregated axis, while `RangedAggregateTransformer` and `BinnedAggregateTransformer` return the axis coordinate for the same enum member. It is worse here than for the other two, because this transformer *removes* the axis from the output — the consumer is handed an index into a dimension the message no longer describes, and cannot convert it without having kept the input around.

The machinery was already in place; `AggregateTransformer` was opting out of it. This drops `index_to_coordinate=False` and widens the coordinate condition from `op == TRAPEZOID` to the existing `needs_coordinates(op)`, which already covers both ARG\* members.

```python
d = np.zeros((1, 10)); d[0, 7] = 1.0     # peak at index 7 -> 14.0 Hz
msg = AxisArray(data=d, dims=["ch", "freq"],
                axes={"freq": AxisArray.LinearAxis(gain=2.0, offset=0.0, unit="Hz")}, key="k")

AggregateTransformer(AggregateSettings(axis="freq", operation=A.ARGMAX))(msg).data
# before: array([7])     <- index, and "freq" is gone from dims
# after:  array([14.])   <- Hz
```

**Breaking.** ARG\* output units change from index to axis coordinate. `TRAPEZOID` was already correct and is unaffected, and no in-repo caller uses ARG\* through either transformer (`fbcca.py` calls `numpy.argmin` directly). Where the axis carries no metadata, `get_axis` supplies a default `LinearAxis` (gain=1, offset=0), so the coordinates are 0, 1, 2, … and the result is the index after all — covered by a test.

`index_to_coordinate` stays on `aggregate_slices` for a caller that means to index back into the array it passed in; nothing in this package sets it False any more, and the docstring now says so instead of naming `AggregateTransformer`.

## Separate bug: `RangedAggregate(bands=None)` was broken in every graph

Found while reading. `RangedAggregateTransformer` overrode `__call__` for its `bands is None` passthrough but not `__acall__`. `BaseTransformerUnit.on_signal` awaits `__acall__`, so in a graph the shortcut was skipped entirely and `bands=None` fell through to `_reset_state`:

```
TypeError: 'NoneType' object is not iterable    # for start, stop in self.settings.bands
```

The shortcut only ever worked when the transformer was driven synchronously, which is why every existing test passed. `BinnedAggregateTransformer` overrides both.

Both branches now also call `_request_reset()`, matching `BinnedAggregate`, so toggling `bands` to `None` and back to a *different* list cannot resume on the first list's slices.

## Tests

- `test_aggregate_transformer_argminmax` updated to expect coordinates (`freq` is gain=2.0/offset=1.0, so index and coordinate genuinely differ).
- `test_aggregate_argminmax_matches_ranged` — new, pins the actual invariant: a band spanning the whole axis asks the same question as the full-axis reduction, so the two transformers must agree. Guards against a future re-split.
- `test_aggregate_argminmax_bare_axis_is_index` — new, the no-metadata fallback.
- `test_ranged_aggregate_passthrough_async` / `..._resume_async` — new, cover the `__acall__` path.

Full suite: 3699 passed, 5 skipped. Ruff clean.
